### PR TITLE
Adding main method to run from inside IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # mk-agent
+
+## Running
+
+> **WARNING** : currently the agent operator needs a Strimzi operator already running on your Kubernetes/OpenShift cluster.
+
+The first step is to package the operator allowing the `dekorate` plugin to generate the `ManagedKafka` CRD.
+
+```shell
+mvn package
+```
+
+After that, apply the generated CRD to the Kubernetes/OpenShift cluster by running the following command.
+
+```shell
+kubectl apply -f target/classes/META-INF/dekorate/kubernetes.yml
+```
+
+Finally, you can start the operator from your IDE running the `Main` application (for a step by step debugging purposes), 
+or you can run it from the command line by running the following command (with Quarkus in "dev" mode).
+
+```shell
+./mvnw quarkus:dev
+```
+
+> NOTE: Quarkus will start debugger listener on port 5005 to which you can attach from your IDE.

--- a/src/main/java/org/bf2/operator/AgentOperator.java
+++ b/src/main/java/org/bf2/operator/AgentOperator.java
@@ -6,12 +6,10 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
-import io.quarkus.runtime.annotations.QuarkusMain;
 import org.bf2.operator.controllers.ManagedKafkaController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@QuarkusMain
 public class AgentOperator implements QuarkusApplication {
 
     private static final Logger log = LoggerFactory.getLogger(AgentOperator.class);

--- a/src/main/java/org/bf2/operator/Main.java
+++ b/src/main/java/org/bf2/operator/Main.java
@@ -1,0 +1,12 @@
+package org.bf2.operator;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class Main {
+
+    public static void main(String... args) {
+        Quarkus.run(AgentOperator.class, args);
+    }
+}


### PR DESCRIPTION
This PR adds a `main` method to run the operator from inside IDE easily and it also adds a description on how to run the application (in the landing page).