### PR TITLE
Added event source handling for Kafka resource related changes

### DIFF
--- a/agent-operator/pom.xml
+++ b/agent-operator/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>crd-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.sundr</groupId>
+            <artifactId>builder-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
         </dependency>

--- a/agent-operator/src/main/java/org/bf2/operator/KafkaEvent.java
+++ b/agent-operator/src/main/java/org/bf2/operator/KafkaEvent.java
@@ -1,0 +1,25 @@
+package org.bf2.operator;
+
+import io.fabric8.kubernetes.client.Watcher;
+import io.javaoperatorsdk.operator.processing.event.AbstractEvent;
+import io.strimzi.api.kafka.model.Kafka;
+
+public class KafkaEvent extends AbstractEvent {
+
+    private Watcher.Action action;
+    private Kafka kafka;
+
+    public KafkaEvent(Watcher.Action action, Kafka kafka, KafkaEventSource kafkaEventSource) {
+        super(kafka.getMetadata().getOwnerReferences().get(0).getUid(), kafkaEventSource);
+        this.action = action;
+        this.kafka = kafka;
+    }
+
+    public Kafka getKafka() {
+        return kafka;
+    }
+
+    public Watcher.Action getAction() {
+        return action;
+    }
+}

--- a/agent-operator/src/main/java/org/bf2/operator/KafkaEventSource.java
+++ b/agent-operator/src/main/java/org/bf2/operator/KafkaEventSource.java
@@ -1,0 +1,61 @@
+package org.bf2.operator;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
+import io.strimzi.api.kafka.KafkaList;
+import io.strimzi.api.kafka.model.DoneableKafka;
+import io.strimzi.api.kafka.model.Kafka;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.net.HttpURLConnection.HTTP_GONE;
+
+public class KafkaEventSource extends AbstractEventSource implements Watcher<Kafka> {
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaEventSource.class);
+
+    private MixedOperation<Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafkaClient;
+
+    private KafkaEventSource(MixedOperation<Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafkaClient) {
+        this.kafkaClient = kafkaClient;
+    }
+
+    public static KafkaEventSource createAndRegisterWatch(MixedOperation<Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafkaClient) {
+        KafkaEventSource kafkaEventSource = new KafkaEventSource(kafkaClient);
+        kafkaEventSource.registerWatch();
+        return kafkaEventSource;
+    }
+
+    private void registerWatch() {
+        kafkaClient
+                .inAnyNamespace()
+                .watch(this);
+    }
+
+    @Override
+    public void eventReceived(Action action, Kafka kafka) {
+        log.info("Kafka event received: action {} kafka {}/{}", action, kafka.getMetadata().getNamespace(), kafka.getMetadata().getName());
+        if (action == Action.ERROR) {
+            log.warn("Skipping Kafka event: action {} kafka {}/{}", action, kafka.getMetadata().getNamespace(), kafka.getMetadata().getName());
+            return;
+        }
+        eventHandler.handleEvent(new KafkaEvent(action, kafka, this));
+    }
+
+    @Override
+    public void onClose(KubernetesClientException e) {
+        if (e == null) {
+            return;
+        }
+        if (e.getCode() == HTTP_GONE) {
+            log.warn("Received error for watch, will try to reconnect.", e);
+            registerWatch();
+        } else {
+            log.error("Unexpected error happened with watch. Will exit.", e);
+            System.exit(1);
+        }
+    }
+}

--- a/agent-operator/src/main/java/org/bf2/operator/KafkaFactory.java
+++ b/agent-operator/src/main/java/org/bf2/operator/KafkaFactory.java
@@ -1,5 +1,7 @@
 package org.bf2.operator;
 
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListenersBuilder;
@@ -8,6 +10,7 @@ import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
 import io.strimzi.api.kafka.model.storage.EphemeralStorageBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,6 +54,16 @@ public class KafkaFactory {
                 .endZookeeper()
                 .endSpec()
                 .build();
+
+        // setting the ManagedKafka has owner of the Kafka resource is needed
+        // by the operator sdk to handle events on the Kafka resource properly
+        OwnerReference ownerReference = new OwnerReferenceBuilder()
+                .withApiVersion(managedKafka.getApiVersion())
+                .withKind(managedKafka.getKind())
+                .withName(managedKafka.getMetadata().getName())
+                .withUid(managedKafka.getMetadata().getUid())
+                .build();
+        kafka.getMetadata().setOwnerReferences(Collections.singletonList(ownerReference));
 
         return kafka;
     }

--- a/agent-operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/agent-operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -5,18 +5,35 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
-import io.javaoperatorsdk.operator.api.*;
+import io.javaoperatorsdk.operator.api.Controller;
+import io.javaoperatorsdk.operator.api.Context;
+import io.javaoperatorsdk.operator.api.DeleteControl;
+import io.javaoperatorsdk.operator.api.ResourceController;
+import io.javaoperatorsdk.operator.api.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
+import io.javaoperatorsdk.operator.processing.event.internal.CustomResourceEvent;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.status.Condition;
+import org.bf2.operator.KafkaEvent;
+import org.bf2.operator.KafkaEventSource;
 import org.bf2.operator.KafkaFactory;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaConditionBuilder;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatus;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatusBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
 
 @Controller(crdName = "managedkafkas.managedkafka.bf2.org", name = "ManagedKafkaController")
 public class ManagedKafkaController implements ResourceController<ManagedKafka> {
@@ -27,6 +44,8 @@ public class ManagedKafkaController implements ResourceController<ManagedKafka> 
     private KubernetesClient client;
 
     private MixedOperation<Kafka, KafkaList, DoneableKafka, Resource<Kafka, DoneableKafka>> kafkaClient;
+
+    private KafkaEventSource kafkaEventSource;
 
     @Override
     public DeleteControl deleteResource(ManagedKafka managedKafka, Context<ManagedKafka> context) {
@@ -42,15 +61,66 @@ public class ManagedKafkaController implements ResourceController<ManagedKafka> 
 
     @Override
     public UpdateControl<ManagedKafka> createOrUpdateResource(ManagedKafka managedKafka, Context<ManagedKafka> context) {
-        log.info("Creating Kafka instance version {}", managedKafka.getSpec().getKafkaInstance().getVersion());
 
-        Kafka kafka = KafkaFactory.getKafka(managedKafka);
-        log.info("Creating Kafka = {}", kafka);
-        try {
-            kafkaClient.create(kafka);
-        } catch (Exception e) {
-            log.error("Error creating the Kafka instance", e);
+        Optional<CustomResourceEvent> latestManagedKafkaEvent =
+                context.getEvents().getLatestOfType(CustomResourceEvent.class);
+
+        if (latestManagedKafkaEvent.isPresent()) {
+            // Kafka resource doesn't exist, has to be created
+            if (kafkaClient.withName(managedKafka.getMetadata().getName()).get() == null) {
+                Kafka kafka = KafkaFactory.getKafka(managedKafka);
+                log.info("Creating Kafka instance {}/{}", kafka.getMetadata().getNamespace(), kafka.getMetadata().getName());
+                try {
+                    kafkaClient.create(kafka);
+                } catch (Exception e) {
+                    log.error("Error creating the Kafka instance", e);
+                    return UpdateControl.noUpdate();
+                }
+
+                // TODO: factoring out a better mapping of statuses
+                ManagedKafkaStatus status = managedKafka.getStatus();
+                if (status == null) {
+                    ManagedKafkaCondition condition = new ManagedKafkaConditionBuilder()
+                            .withReason("KafkaResourceCreated")
+                            .withMessage("Kafka resource created")
+                            .withType("Ready")
+                            .withStatus("True")
+                            .withLastTransitionTime(iso8601Now())
+                            .build();
+                    status = new ManagedKafkaStatusBuilder()
+                            .withConditions(condition)
+                            .build();
+                    managedKafka.setStatus(status);
+                }
+                return UpdateControl.updateCustomResourceAndStatus(managedKafka);
+            // Kafka resource already exists, has to be updated
+            } else {
+                log.info("Updating Kafka instance {}", managedKafka.getSpec().getKafkaInstance().getVersion());
+                // TODO: updating Kafka instance
+                return UpdateControl.noUpdate();
+            }
+
         }
+
+        Optional<KafkaEvent> latestKafkaEvent =
+                context.getEvents().getLatestOfType(KafkaEvent.class);
+        if (latestKafkaEvent.isPresent()) {
+            Kafka kafka = latestKafkaEvent.get().getKafka();
+            log.info("Kafka resource {}/{} is changed", kafka.getMetadata().getNamespace(), kafka.getMetadata().getName());
+            if (kafka.getStatus() != null) {
+                log.info("Kafka conditions = {}", kafka.getStatus().getConditions());
+                Condition kafkaCondition = kafka.getStatus().getConditions().get(0);
+                // TODO: doing a better mapping, right now it's just reflecting the Kafka resource status
+                ManagedKafkaCondition managedKafkaCondition = managedKafka.getStatus().getConditions().get(0);
+                managedKafkaCondition.setReason(kafkaCondition.getReason());
+                managedKafkaCondition.setMessage(kafkaCondition.getMessage());
+                managedKafkaCondition.setType(kafkaCondition.getType());
+                managedKafkaCondition.setStatus(kafkaCondition.getStatus());
+                managedKafkaCondition.setLastTransitionTime(iso8601Now());
+            }
+            return UpdateControl.updateCustomResourceAndStatus(managedKafka);
+        }
+
         return UpdateControl.noUpdate();
     }
 
@@ -61,5 +131,16 @@ public class ManagedKafkaController implements ResourceController<ManagedKafka> 
         CustomResourceDefinition kafkaCrd = Crds.kafka();
         CustomResourceDefinitionContext kafkaCrdContext = CustomResourceDefinitionContext.fromCrd(kafkaCrd);
         kafkaClient = client.customResources(kafkaCrdContext, Kafka.class, KafkaList.class, DoneableKafka.class);
+
+        kafkaEventSource = KafkaEventSource.createAndRegisterWatch(kafkaClient);
+        eventSourceManager.registerEventSource("kafka-event-source", kafkaEventSource);
+    }
+
+    /**
+     * Returns the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
+     * @return the current timestamp in ISO 8601 format, for example "2019-07-23T09:08:12.356Z".
+     */
+    public static String iso8601Now() {
+        return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
     }
 }

--- a/agent-operator/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/agent-operator/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -1,11 +1,14 @@
 package org.bf2.operator.resources.v1alpha1;
 
+import io.dekorate.crd.annotation.Status;
 import io.fabric8.kubernetes.client.CustomResource;
 
 @io.dekorate.crd.annotation.CustomResource(group = "managedkafka.bf2.org", version = "v1alpha1")
 public class ManagedKafka extends CustomResource {
 
     private ManagedKafkaSpec spec;
+    @Status
+    private ManagedKafkaStatus status;
 
     public ManagedKafkaSpec getSpec() {
         return spec;
@@ -13,5 +16,13 @@ public class ManagedKafka extends CustomResource {
 
     public void setSpec(ManagedKafkaSpec spec) {
         this.spec = spec;
+    }
+
+    public ManagedKafkaStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ManagedKafkaStatus status) {
+        this.status = status;
     }
 }

--- a/agent-operator/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaCondition.java
+++ b/agent-operator/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaCondition.java
@@ -1,0 +1,54 @@
+package org.bf2.operator.resources.v1alpha1;
+
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable
+public class ManagedKafkaCondition {
+
+    private String type;
+    private String reason;
+    private String message;
+    private String status;
+    private String lastTransitionTime;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getLastTransitionTime() {
+        return lastTransitionTime;
+    }
+
+    public void setLastTransitionTime(String lastTransitionTime) {
+        this.lastTransitionTime = lastTransitionTime;
+    }
+
+}

--- a/agent-operator/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaStatus.java
+++ b/agent-operator/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaStatus.java
@@ -1,0 +1,19 @@
+package org.bf2.operator.resources.v1alpha1;
+
+import io.sundr.builder.annotations.Buildable;
+
+import java.util.List;
+
+@Buildable
+public class ManagedKafkaStatus {
+
+    private List<ManagedKafkaCondition> conditions;
+
+    public List<ManagedKafkaCondition> getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(List<ManagedKafkaCondition> conditions) {
+        this.conditions = conditions;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <junit.platform.version>1.7.0</junit.platform.version>
         <log4j2.version>2.13.3</log4j2.version>
+        <sundrio.version>0.22.1</sundrio.version>
     </properties>
 
     <modules>
@@ -56,6 +57,11 @@
                 <groupId>io.dekorate</groupId>
                 <artifactId>crd-annotations</artifactId>
                 <version>${dekorate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.sundr</groupId>
+                <artifactId>builder-annotations</artifactId>
+                <version>${sundrio.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This PR adds the main infrastructure to watch and handle status changes on the `Kafka` resource (as a secondary resource) handled by the operator.
It updates the `ManagedKafka` resource status as well but with just one condition right now reflecting more or less the current `Kafka` status.
Adding more conditions will be done in a new PR eventually.