### PR TITLE
Fixed missing Namespaced interface implementation

### DIFF
--- a/agent-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/agent-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -1,6 +1,7 @@
 package org.bf2.operator.resources.v1alpha1;
 
 import io.dekorate.crd.annotation.Status;
+import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
@@ -8,7 +9,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("managedkafka.bf2.org")
 @Version("v1alpha1")
 @io.dekorate.crd.annotation.CustomResource(group = "managedkafka.bf2.org", version = "v1alpha1")
-public class ManagedKafka extends CustomResource {
+public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaStatus> implements Namespaced {
 
     private ManagedKafkaSpec spec;
     @Status


### PR DESCRIPTION
This trivial PR fixes the `ManagedKafka` resource which has to implement `Namespaced` interface to be namespace scoped after latest upgrade to fabric8 5.0.0.