### PR TITLE
Moved from watcher to informers for Kafka resource

### DIFF
--- a/agent-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaCondition.java
+++ b/agent-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaCondition.java
@@ -1,5 +1,6 @@
 package org.bf2.operator.resources.v1alpha1;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
 
 @Buildable
@@ -19,6 +20,7 @@ public class ManagedKafkaCondition {
         this.type = type;
     }
 
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public String getReason() {
         return reason;
     }
@@ -27,6 +29,7 @@ public class ManagedKafkaCondition {
         this.reason = reason;
     }
 
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
     public String getMessage() {
         return message;
     }

--- a/agent-operator/src/main/java/org/bf2/operator/InformerManager.java
+++ b/agent-operator/src/main/java/org/bf2/operator/InformerManager.java
@@ -1,0 +1,40 @@
+package org.bf2.operator;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import io.strimzi.api.kafka.KafkaList;
+import io.strimzi.api.kafka.model.Kafka;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class InformerManager {
+
+    @Inject
+    private KubernetesClient client;
+
+    @Inject
+    private KafkaEventSource kafkaEventSource;
+
+    SharedInformerFactory sharedInformerFactory;
+
+    void onStart(@Observes StartupEvent ev) {
+        sharedInformerFactory = client.informers();
+
+        SharedIndexInformer<Kafka> kafkaSharedIndexInformer =
+                sharedInformerFactory.sharedIndexInformerFor(Kafka.class, KafkaList.class, 60 * 1000L);
+
+        kafkaSharedIndexInformer.addEventHandler(kafkaEventSource);
+
+        sharedInformerFactory.startAllRegisteredInformers();
+    }
+
+    void onStop(@Observes ShutdownEvent ev) {
+        sharedInformerFactory.stopAllRegisteredInformers();
+    }
+}

--- a/agent-operator/src/main/java/org/bf2/operator/KafkaEvent.java
+++ b/agent-operator/src/main/java/org/bf2/operator/KafkaEvent.java
@@ -6,20 +6,14 @@ import io.strimzi.api.kafka.model.Kafka;
 
 public class KafkaEvent extends AbstractEvent {
 
-    private Watcher.Action action;
     private Kafka kafka;
 
-    public KafkaEvent(Watcher.Action action, Kafka kafka, KafkaEventSource kafkaEventSource) {
+    public KafkaEvent(Kafka kafka, KafkaEventSource kafkaEventSource) {
         super(kafka.getMetadata().getOwnerReferences().get(0).getUid(), kafkaEventSource);
-        this.action = action;
         this.kafka = kafka;
     }
 
     public Kafka getKafka() {
         return kafka;
-    }
-
-    public Watcher.Action getAction() {
-        return action;
     }
 }

--- a/agent-operator/src/main/java/org/bf2/operator/KafkaEventSource.java
+++ b/agent-operator/src/main/java/org/bf2/operator/KafkaEventSource.java
@@ -4,55 +4,39 @@ import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.Kafka;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KafkaEventSource extends AbstractEventSource implements Watcher<Kafka> {
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class KafkaEventSource extends AbstractEventSource implements ResourceEventHandler<Kafka> {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaEventSource.class);
 
-    private MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaClient;
-
-    private KafkaEventSource(MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaClient) {
-        this.kafkaClient = kafkaClient;
-    }
-
-    public static KafkaEventSource createAndRegisterWatch(MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaClient) {
-        KafkaEventSource kafkaEventSource = new KafkaEventSource(kafkaClient);
-        kafkaEventSource.registerWatch();
-        return kafkaEventSource;
-    }
-
-    private void registerWatch() {
-        kafkaClient
-                .inAnyNamespace()
-                .watch(this);
+    @Override
+    public void onAdd(Kafka kafka) {
+        log.info("Add event receiving for Kafka {}/{}", kafka.getMetadata().getNamespace(), kafka.getMetadata().getName());
+        handleEvent(kafka);
     }
 
     @Override
-    public void eventReceived(Action action, Kafka kafka) {
-        log.info("Kafka event received: action {} kafka {}/{}", action, kafka.getMetadata().getNamespace(), kafka.getMetadata().getName());
-        if (action == Action.ERROR) {
-            log.warn("Skipping Kafka event: action {} kafka {}/{}", action, kafka.getMetadata().getNamespace(), kafka.getMetadata().getName());
-            return;
-        }
-        eventHandler.handleEvent(new KafkaEvent(action, kafka, this));
+    public void onUpdate(Kafka oldKafka, Kafka newKafka) {
+        log.info("Update event receiving for Kafka {}/{}", oldKafka.getMetadata().getNamespace(), oldKafka.getMetadata().getName());
+        handleEvent(newKafka);
     }
 
     @Override
-    public void onClose(WatcherException e) {
-        if (e == null) {
-            return;
-        }
-        if (e.isHttpGone()) {
-            log.warn("Received error for watch, will try to reconnect.", e);
-            registerWatch();
-        } else {
-            log.error("Unexpected error happened with watch. Will exit.", e);
-            System.exit(1);
-        }
+    public void onDelete(Kafka kafka, boolean deletedFinalStateUnknown) {
+        log.info("Delete event receiving for Kafka {}/{}", kafka.getMetadata().getNamespace(), kafka.getMetadata().getName());
+        handleEvent(kafka);
+    }
+
+    private void handleEvent(Kafka kafka) {
+        eventHandler.handleEvent(new KafkaEvent(kafka, this));
     }
 }

--- a/agent-operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/agent-operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -40,6 +40,7 @@ public class ManagedKafkaController implements ResourceController<ManagedKafka> 
 
     private MixedOperation<Kafka, KafkaList, Resource<Kafka>> kafkaClient;
 
+    @Inject
     private KafkaEventSource kafkaEventSource;
 
     @Override
@@ -124,7 +125,6 @@ public class ManagedKafkaController implements ResourceController<ManagedKafka> 
         log.info("init");
 
         kafkaClient = client.customResources(Kafka.class, KafkaList.class);
-        kafkaEventSource = KafkaEventSource.createAndRegisterWatch(kafkaClient);
         eventSourceManager.registerEventSource("kafka-event-source", kafkaEventSource);
     }
 


### PR DESCRIPTION
This PR moves from using watcher to informers for getting events for the `Kafka` resource.