### PR TITLE
Bumped new dekorate version

### DIFF
--- a/agent-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/agent-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -1,5 +1,6 @@
 package org.bf2.operator.resources.v1alpha1;
 
+import io.dekorate.crd.annotation.Crd;
 import io.dekorate.crd.annotation.Status;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -8,7 +9,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 
 @Group("managedkafka.bf2.org")
 @Version("v1alpha1")
-@io.dekorate.crd.annotation.CustomResource(group = "managedkafka.bf2.org", version = "v1alpha1")
+@Crd(group = "managedkafka.bf2.org", version = "v1alpha1")
 public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaStatus> implements Namespaced {
 
     private ManagedKafkaSpec spec;

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus-plugin.version>1.11.0.Final</quarkus-plugin.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <dekorate.version>2.0.0.beta1</dekorate.version>
+        <dekorate.version>2.0.0.beta3</dekorate.version>
         <strimzi.version>0.22.0-SNAPSHOT</strimzi.version>
         <quarkus.operator.extension>1.7.0</quarkus.operator.extension>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>


### PR DESCRIPTION
This PR bumps the dekorate version with the fix about this issue I raised https://github.com/dekorateio/dekorate/issues/713
It also moves to the useg of the new `@Crd` annotation for custom resources.