### PR TITLE
Use fabric8 junit5 mock kube annotation

### DIFF
--- a/agent-api/src/test/java/org/bf2/resources/ManagedKafkaCrdTest.java
+++ b/agent-api/src/test/java/org/bf2/resources/ManagedKafkaCrdTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@EnableKubernetesMockClient(crud = true)
+@EnableKubernetesMockClient(https = false, crud = true)
 public class ManagedKafkaCrdTest {
     private final String ROOT_PATH = System.getProperty("user.dir");
 


### PR DESCRIPTION
Use fabric8 client mock in agent-api tests, we don't need to take care about calling before and after for mock because extension takes care about it