### PR TITLE
Fix #38: Ignore deployment events from deployments without recognised owner refs

### DIFF
--- a/agent-operator/src/main/java/org/bf2/operator/events/DeploymentEvent.java
+++ b/agent-operator/src/main/java/org/bf2/operator/events/DeploymentEvent.java
@@ -8,11 +8,15 @@ public class DeploymentEvent extends AbstractEvent {
     private Deployment deployment;
 
     public DeploymentEvent(Deployment deployment, DeploymentEventSource deploymentEventSource) {
-        super(deployment.getMetadata().getOwnerReferences().get(0).getUid(), deploymentEventSource);
+        super(getOwnerUidOrNull(deployment), deploymentEventSource);
         this.deployment = deployment;
     }
 
     public Deployment getDeployment() {
         return deployment;
+    }
+
+    private static String getOwnerUidOrNull(Deployment deployment) {
+        return deployment.getMetadata().getOwnerReferences() == null && deployment.getMetadata().getOwnerReferences().isEmpty() ? deployment.getMetadata().getOwnerReferences().get(0).getUid() : null;
     }
 }

--- a/agent-operator/src/main/java/org/bf2/operator/events/DeploymentEventSource.java
+++ b/agent-operator/src/main/java/org/bf2/operator/events/DeploymentEventSource.java
@@ -32,6 +32,9 @@ public class DeploymentEventSource extends AbstractEventSource implements Resour
     }
 
     private void handleEvent(Deployment deployment) {
+        if (eventHandler == null) {
+            return;
+        }
         eventHandler.handleEvent(new DeploymentEvent(deployment, this));
     }
 }


### PR DESCRIPTION
Probably a naive fix - would be better to be selective and avoid listening to all Deployments.   Can we add a label selector?