### PR TITLE
Enable minikube internal registry

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.3.0
         with:
-          minikube version: 'v1.16.0'
+          minikube version: 'v1.17.1'
           kubernetes version: 'latest'
           start args: '--insecure-registry "10.0.0.0/24" --insecure-registry "localhost:5000" --extra-config=kubeadm.ignore-preflight-errors=SystemVerification --extra-config=apiserver.authorization-mode=RBAC,Node'
 


### PR DESCRIPTION
Enable intternal minikube registry to push local build of agent in integration/systemtest scenario 