### PR TITLE
DRAFT Agent sync merge

### DIFF
--- a/agent-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/agent-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -1,10 +1,5 @@
 package org.bf2.operator.resources.v1alpha1;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import io.dekorate.crd.annotation.Crd;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -16,23 +11,17 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Crd(group = "managedkafka.bf2.org", version = "v1alpha1")
 public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaStatus> implements Namespaced {
 
-    private static final String ID_ANNOTATION_KEY = "kas.redhat.com/kafka-id";
+    private String id;
 
-    @JsonIgnore
-    public String getKafkaClusterId() {
-        Map<String, String> annotations = this.getMetadata().getAnnotations();
-        if (annotations != null) {
-            return annotations.get(ID_ANNOTATION_KEY);
-        }
-        return null;
+    /**
+     * The id of the ManagedKafka, aka the placement id
+     * @return
+     */
+    public String getId() {
+        return id;
     }
 
-    public void setKafkaClusterId(String id) {
-        Map<String, String> annotations = this.getMetadata().getAnnotations();
-        if (annotations == null) {
-            annotations = new LinkedHashMap<>();
-            this.getMetadata().setAnnotations(annotations);
-        }
-        annotations.put(ID_ANNOTATION_KEY, id);
+    public void setId(String id) {
+        this.id = id;
     }
 }

--- a/agent-operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
+++ b/agent-operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
@@ -1,7 +1,6 @@
 package org.bf2.operator.controllers;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -59,22 +58,7 @@ public class ManagedKafkaAgentController implements ResourceController<ManagedKa
     @Override
     public UpdateControl<ManagedKafkaAgent> createOrUpdateResource(ManagedKafkaAgent resource,
             Context<ManagedKafkaAgent> context) {
-        Optional<CustomResourceEvent> latestEvent = context.getEvents().getLatestOfType(CustomResourceEvent.class);
-        if (latestEvent.isPresent()) {
-            if (resource.getStatus() == null) {
-                log.infof("Updating Kafka agent instance %s in namespace %s", resource.getMetadata().getName(),
-                        this.namespace);
-                // this does not manage any other resources, so nothing to create
-                // calculate the node metrics and update
-                resource.setStatus(buildStatus(resource));
-                return UpdateControl.updateCustomResourceAndStatus(resource);
-            } else {
-                log.infof("Updating Kafka agent Status %s in namespace %s", resource.getMetadata().getName(),
-                        this.namespace);
-                resource.setStatus(buildStatus(resource));
-                return UpdateControl.updateStatusSubResource(resource);
-            }
-        }
+        context.getEvents().getLatestOfType(CustomResourceEvent.class);
         return UpdateControl.noUpdate();
     }
 

--- a/agent-sync/pom.xml
+++ b/agent-sync/pom.xml
@@ -52,7 +52,11 @@
 		<dependency>
 		    <groupId>io.quarkus</groupId>
 		    <artifactId>quarkus-smallrye-health</artifactId>
-		</dependency>        
+		</dependency>
+		<dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-mutiny</artifactId>
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/agent-sync/src/main/java/org/bf2/sync/AgentSync.java
+++ b/agent-sync/src/main/java/org/bf2/sync/AgentSync.java
@@ -1,14 +1,16 @@
 package org.bf2.sync;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.inject.Inject;
+
+import org.jboss.logging.Logger;
 
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 
 public class AgentSync implements QuarkusApplication {
 
-    private static final Logger log = LoggerFactory.getLogger(AgentSync.class);
+    @Inject
+    Logger log;
 
     @Override
     public int run(String... args) throws Exception {

--- a/agent-sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
+++ b/agent-sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
@@ -1,28 +1,22 @@
 package org.bf2.sync;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
-import org.bf2.operator.resources.v1alpha1.ManagedKafkaList;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpec;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatus;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatusBuilder;
+import org.bf2.sync.client.ManagedKafkaResourceClient;
 import org.bf2.sync.controlplane.ControlPlane;
 import org.bf2.sync.informer.LocalLookup;
 import org.eclipse.microprofile.context.ManagedExecutor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
 import io.quarkus.scheduler.Scheduled;
 
@@ -38,10 +32,11 @@ import io.quarkus.scheduler.Scheduled;
 @ApplicationScoped
 public class ManagedKafkaSync {
 
-    private static final Logger log = LoggerFactory.getLogger(ManagedKafkaSync.class);
+    @Inject
+    Logger log;
 
     @Inject
-    KubernetesClient client;
+    ManagedKafkaResourceClient client;
 
     @Inject
     LocalLookup lookup;
@@ -52,44 +47,33 @@ public class ManagedKafkaSync {
     @javax.annotation.Resource
     ManagedExecutor pollExecutor;
 
-    private MixedOperation<ManagedKafka, ManagedKafkaList, Resource<ManagedKafka>> managedKafkaResources;
-
-    @PostConstruct
-    void init() {
-        CustomResourceDefinitionContext crdContext = CustomResourceDefinitionContext
-                .fromCustomResourceType(ManagedKafka.class);
-
-        managedKafkaResources = client.customResources(crdContext, ManagedKafka.class, ManagedKafkaList.class);
-    }
-
-    public void syncKafkaClusters(List<ManagedKafka> remoteManagedKafkas, Executor executor) {
+    /**
+     * Update the local state based upon the remote ManagedKafkas
+     * The strategy here is to take a pass over the list and find any deferred work
+     * Then execute that deferred work using the {@link ManagedExecutor} but with
+     * a refresh of the state to ensure we're still acting appropriately.
+     */
+    public void syncKafkaClusters(Executor executor) {
         Map<String, ManagedKafka> remotes = new HashMap<>();
 
-        for (ManagedKafka remoteManagedKafka : remoteManagedKafkas) {
-            remotes.put(remoteManagedKafka.getKafkaClusterId(), remoteManagedKafka);
+        for (ManagedKafka remoteManagedKafka : controlPlane.getKafkaClusters()) {
+            remotes.put(remoteManagedKafka.getId(), remoteManagedKafka);
             ManagedKafkaSpec remoteSpec = remoteManagedKafka.getSpec();
             assert remoteSpec != null;
 
-            // TODO: account for namespaces.
-            // eventually the remote metadata should be ignored - and we should assign /
-            // create a local namespace as needed
-            String namespace = remoteManagedKafka.getMetadata().getNamespace();
-
-            ManagedKafka existing = lookup.getLocalManagedKafka(remoteManagedKafka);
+            // TODO this requires the namespace is already set - this will change
+            // see also the create method
+            ManagedKafka existing = lookup.getLocalManagedKafka(Cache.metaNamespaceKeyFunc(remoteManagedKafka));
 
             // take action based upon differences
             // this is really just seeing if an instance needs created and the delete flag
             // there are no other fields to reconcile - but you could envision updating
             // component versions etc. later
+
             if (existing == null) {
                 if (!remoteSpec.isDeleted()) {
-                    controlPlane.addManagedKafka(remoteManagedKafka);
-
                     executor.execute(() -> {
-                        log.debug("Creating ManagedKafka {}", Cache.metaNamespaceKeyFunc(remoteManagedKafka));
-                        // TODO: create namespace when needed
-
-                        managedKafkaResources.create(remoteManagedKafka);
+                        reconcile(remoteManagedKafka.getId(), Cache.metaNamespaceKeyFunc(remoteManagedKafka));
                     });
                 } else {
                     // we've successfully removed locally, but control plane is not aware
@@ -98,27 +82,20 @@ public class ManagedKafkaSync {
                     // doesn't need to be async as the control plane call is async
                     ManagedKafkaStatusBuilder statusBuilder = new ManagedKafkaStatusBuilder();
                     statusBuilder.addNewCondition().withType("InstanceDeletionComplete").endCondition();
-                    controlPlane.updateKafkaClusterStatus(statusBuilder.build(), remoteManagedKafka.getKafkaClusterId());
+
+                    // fire and forget - if it fails, we'll retry on the next poll
+                    controlPlane.updateKafkaClusterStatus(statusBuilder.build(), remoteManagedKafka.getId());
                 }
-            } else if (remoteSpec.isDeleted() && !existing.getSpec().isDeleted()) {
-                controlPlane.removeManagedKafka(existing);
-                // mark the local as deleted
+            } else if (specChanged(remoteSpec, existing)) {
                 executor.execute(() -> {
-                    managedKafkaResources.inNamespace(existing.getMetadata().getNamespace())
-                            .withName(existing.getMetadata().getName()).edit(mk -> {
-                                mk.getSpec().setDeleted(true);
-                                return mk;
-                            });
-                    // the agent will handle the deletion from here
+                    reconcile(remoteManagedKafka.getId(), Cache.metaNamespaceKeyFunc(existing));
                 });
-            } else if (!remoteSpec.isDeleted() && existing.getSpec().isDeleted()) {
-                // TODO: seems like a problem / resurrection
             }
         }
 
         // process final removals
         for (ManagedKafka local : lookup.getLocalManagedKafkas()) {
-            if (remotes.get(local.getKafkaClusterId()) != null) {
+            if (remotes.get(local.getId()) != null) {
                 continue;
             }
 
@@ -128,18 +105,90 @@ public class ManagedKafkaSync {
                 // TODO: seems bad
             }
 
-            log.debug("Deleting ManagedKafka {}", Cache.metaNamespaceKeyFunc(local));
-            managedKafkaResources.inNamespace(local.getMetadata().getNamespace())
-                    .withName(local.getMetadata().getName()).delete();
+            executor.execute(() -> {
+                reconcile(null, Cache.metaNamespaceKeyFunc(local));
+            });
         }
+
+    }
+
+    /**
+     * TODO: delete is the only spec change we are currently tracking wrt modifications
+     * it's also not clear if there are any fields in the spec that we
+     * or the agent may fill out by default that should be retained,
+     *
+     * this will be generalized as needed
+     */
+    private boolean specChanged(ManagedKafkaSpec remoteSpec, ManagedKafka existing) {
+        if (!remoteSpec.isDeleted() && existing.getSpec().isDeleted()) {
+            // TODO: seems like a problem / resurrection - should not happen
+            log.warnf("Ignoring ManagedKafka %s %s that wants to come back to life", existing.getId(), Cache.metaNamespaceKeyFunc(existing));
+            return false;
+        }
+
+        return remoteSpec.isDeleted() && !existing.getSpec().isDeleted();
+    }
+
+    /**
+     * Final sync processing of the remote vs. local state
+     */
+    void reconcile(String remoteId, String localMetaNamespaceKey) {
+        ManagedKafka local = null;
+        if (localMetaNamespaceKey != null) {
+            //refresh the local
+            local = lookup.getLocalManagedKafka(localMetaNamespaceKey);
+        }
+
+        ManagedKafka remote = null;
+        if (remoteId != null) {
+            //refresh the remote
+            remote = controlPlane.getManagedKafka(remoteId);
+        }
+
+        if (local == null && remote == null) {
+            return; //nothing to do
+        }
+
+        if (local == null) {
+            if (!remote.getSpec().isDeleted()) {
+                create(remote);
+            }
+        } else if (remote == null) {
+            log.debugf("Deleting ManagedKafka %s %s", local.getId(), Cache.metaNamespaceKeyFunc(local));
+
+            client.delete(local.getMetadata().getNamespace(), local.getMetadata().getName());
+
+            controlPlane.removeManagedKafka(local);
+        } else if (specChanged(remote.getSpec(), local)) {
+            log.debugf("Initiating Delete of ManagedKafka %s %s", remote.getId(), Cache.metaNamespaceKeyFunc(remote));
+            // specChanged is only looking at delete currently, so mark the local as deleted
+            client.edit(local.getMetadata().getNamespace(), local.getMetadata().getName(), mk -> {
+                    mk.getSpec().setDeleted(true);
+                    return mk;
+                });
+            // the operator will handle the deletion from here
+        }
+    }
+
+    void create(ManagedKafka remote) {
+        // TODO: account for namespaces.
+        // eventually the remote metadata should be ignored (or unset) - and we should assign /
+        // create a local namespace as needed
+        // for now we're assuming remote.getMetadata().getNamespace() is set;
+
+        log.debugf("Creating ManagedKafka %s %s", remote.getId(), Cache.metaNamespaceKeyFunc(remote));
+
+        // TODO: there may be additional cleansing, setting of defaults, etc. on the remote instance before creation
+        client.create(remote);
     }
 
     @Scheduled(every = "{poll.interval}")
     void pollKafkaClusters() {
+        controlPlane.updateKafkaClusterStatus(new ManagedKafkaStatus(), "x");
         log.debug("Polling for control plane managed kafkas");
         // TODO: this is based upon a full poll - eventually this could be
         // based upon a delta revision / timestmap to get a smaller list
-        syncKafkaClusters(controlPlane.getKafkaClusters(), pollExecutor);
+        syncKafkaClusters(pollExecutor);
     }
 
 }

--- a/agent-sync/src/main/java/org/bf2/sync/client/ManagedKafkaResourceClient.java
+++ b/agent-sync/src/main/java/org/bf2/sync/client/ManagedKafkaResourceClient.java
@@ -1,0 +1,54 @@
+package org.bf2.sync.client;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaList;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.quarkus.runtime.StartupEvent;
+
+/**
+ * Represents a wrapper around a Kubernetes client for handling operations on a
+ * Managed Kafka custom resource
+ */
+@ApplicationScoped
+public class ManagedKafkaResourceClient {
+
+    @Inject
+    private KubernetesClient kubernetesClient;
+
+    private MixedOperation<ManagedKafka, ManagedKafkaList, Resource<ManagedKafka>> kafkaResourceClient;
+
+    void onStart(@Observes StartupEvent ev) {
+        kafkaResourceClient = kubernetesClient.customResources(ManagedKafka.class, ManagedKafkaList.class);
+    }
+
+    public void delete(String namespace, String name) {
+        kafkaResourceClient.inNamespace(namespace).withName(name).delete();
+    }
+
+    public ManagedKafka getByName(String namespace, String name) {
+        return kafkaResourceClient.inNamespace(namespace).withName(name).get();
+    }
+
+    public ManagedKafka create(ManagedKafka kafka) {
+        return kafkaResourceClient.inNamespace(kafka.getMetadata().getNamespace()).createOrReplace(kafka);
+    }
+
+    public ManagedKafka edit(String namespace, String name, UnaryOperator<ManagedKafka> function) {
+        return kafkaResourceClient.inNamespace(namespace).withName(name).edit(function);
+    }
+
+    public List<ManagedKafka> list() {
+        return kafkaResourceClient.list().getItems();
+    }
+
+}

--- a/agent-sync/src/main/java/org/bf2/sync/controlplane/ControlPlaneRestClient.java
+++ b/agent-sync/src/main/java/org/bf2/sync/controlplane/ControlPlaneRestClient.java
@@ -2,7 +2,6 @@ package org.bf2.sync.controlplane;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Consumes;
@@ -18,6 +17,8 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafkaAgentStatus;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatus;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import io.smallrye.mutiny.Uni;
+
 @ApplicationScoped
 @Path("/api/managed-services-api/v1/agent-clusters/")
 @RegisterRestClient
@@ -26,16 +27,16 @@ public interface ControlPlaneRestClient {
     @PUT
     @Path("/{id}/status")
     @Consumes(MediaType.APPLICATION_JSON)
-    CompletableFuture<Void> updateStatus(@PathParam("id") String id, ManagedKafkaAgentStatus status);
+    Uni<Void> updateStatus(@PathParam("id") String id, ManagedKafkaAgentStatus status);
 
     @GET
     @Path("/{id}/kafkas")
     @Produces(MediaType.APPLICATION_JSON)
-    List<ManagedKafka> getKafkaClusters(@PathParam("id") String id);
+    Uni<List<ManagedKafka>> getKafkaClusters(@PathParam("id") String id);
 
     @PUT
     @Path("/{id}/kafkas/status")
     @Consumes(MediaType.APPLICATION_JSON)
-    CompletableFuture<Void> updateKafkaClustersStatus(@PathParam("id") String id, Map<String, ManagedKafkaStatus> status);
+    Uni<Void> updateKafkaClustersStatus(@PathParam("id") String id, Map<String, ManagedKafkaStatus> status);
 
 }

--- a/agent-sync/src/main/java/org/bf2/sync/informer/CustomResourceEventHandler.java
+++ b/agent-sync/src/main/java/org/bf2/sync/informer/CustomResourceEventHandler.java
@@ -1,25 +1,25 @@
 package org.bf2.sync.informer;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 
 /**
- * Simple generic handler.  The consumer should be async.
+ * Simple generic handler.  The consumer should be non-blocking.
  */
 final class CustomResourceEventHandler<T extends CustomResource<?,?>> implements ResourceEventHandler<T> {
 
-    private Consumer<T> consumer;
+    private BiConsumer<T, T> consumer;
 
-    public CustomResourceEventHandler(Consumer<T> consumer) {
+    public CustomResourceEventHandler(BiConsumer<T, T> consumer) {
         this.consumer = consumer;
     }
 
     @Override
     public void onAdd(T obj) {
         if (obj.getStatus() != null) {
-            consumer.accept(obj);
+            consumer.accept(null, obj);
         }
     }
 
@@ -35,7 +35,7 @@ final class CustomResourceEventHandler<T extends CustomResource<?,?>> implements
         // which is a way to ensure the consumer has an up-to-date state
         // even if something is missed
         if (newObj.getStatus() != null) {
-            consumer.accept(newObj);
+            consumer.accept(oldObj, newObj);
         }
     }
 

--- a/agent-sync/src/main/java/org/bf2/sync/informer/InformerManager.java
+++ b/agent-sync/src/main/java/org/bf2/sync/informer/InformerManager.java
@@ -17,7 +17,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 import io.fabric8.kubernetes.client.informers.SharedInformerFactory;
-import io.fabric8.kubernetes.client.informers.cache.Cache;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 
@@ -60,8 +59,8 @@ public class InformerManager implements LocalLookup {
     }
 
     @Override
-    public ManagedKafka getLocalManagedKafka(ManagedKafka remote) {
-        return managedKafkaInformer.getIndexer().getByKey(Cache.metaNamespaceKeyFunc(remote));
+    public ManagedKafka getLocalManagedKafka(String metaNamespaceKey) {
+        return managedKafkaInformer.getIndexer().getByKey(metaNamespaceKey);
     }
 
     @Override

--- a/agent-sync/src/main/java/org/bf2/sync/informer/LocalLookup.java
+++ b/agent-sync/src/main/java/org/bf2/sync/informer/LocalLookup.java
@@ -4,12 +4,17 @@ import java.util.List;
 
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 
+import io.fabric8.kubernetes.client.informers.cache.Cache;
+
 /**
  * Provides an interface to lookup the local (informer) state
  */
 public interface LocalLookup {
 
-    ManagedKafka getLocalManagedKafka(ManagedKafka remote);
+    /**
+     * @see Cache#metaNamespaceKeyFunc(Object) for the key
+     */
+    ManagedKafka getLocalManagedKafka(String metaNamespaceKey);
 
     List<ManagedKafka> getLocalManagedKafkas();
 

--- a/agent-sync/src/main/resources/application.properties
+++ b/agent-sync/src/main/resources/application.properties
@@ -1,7 +1,8 @@
 org.bf2.sync.controlplane.ControlPlaneRestClient/mp-rest/url=https://control-plane.srv
 cluster.id=007
-poll.interval=10s
+poll.interval=15s
 resync.interval=60s
+update.delayed=15s
 
 quarkus.http.port=9090
 quarkus.jib.ports=9090

--- a/agent-sync/src/test/java/org/bf2/sync/DirectLocalLookup.java
+++ b/agent-sync/src/test/java/org/bf2/sync/DirectLocalLookup.java
@@ -1,0 +1,36 @@
+package org.bf2.sync;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.sync.client.ManagedKafkaResourceClient;
+import org.bf2.sync.informer.LocalLookup;
+
+import io.quarkus.test.Mock;
+
+/**
+ * To bypass the informer async update, we can lookup directly
+ * against the (Mock) server
+ */
+@Mock
+@ApplicationScoped
+public class DirectLocalLookup implements LocalLookup {
+
+    @Inject
+    ManagedKafkaResourceClient client;
+
+    @Override
+    public ManagedKafka getLocalManagedKafka(String metaNamespaceKey) {
+        String[] parts = metaNamespaceKey.split("/");
+        return client.getByName(parts[0], parts[1]);
+    }
+
+    @Override
+    public List<ManagedKafka> getLocalManagedKafkas() {
+        return client.list();
+    }
+
+}

--- a/agent-sync/src/test/java/org/bf2/sync/KubernetesServerTestResource.java
+++ b/agent-sync/src/test/java/org/bf2/sync/KubernetesServerTestResource.java
@@ -52,7 +52,7 @@ public class KubernetesServerTestResource implements QuarkusTestResourceLifecycl
     public void configureServer(KubernetesServer mockServer) {
         // initialize with the crd
         try (NamespacedKubernetesClient client = server.getClient()) {
-            client.load(PollerTest.class.getResourceAsStream("/META-INF/dekorate/kubernetes.yml")).get().forEach(crd -> {
+            client.load(KubernetesServerTestResource.class.getResourceAsStream("/META-INF/dekorate/kubernetes.yml")).get().forEach(crd -> {
                 client.apiextensions().v1beta1().customResourceDefinitions()
                         .createOrReplace((CustomResourceDefinition) crd);
             });


### PR DESCRIPTION
updates to the last round of review comments and added update batching / support for a control plane that does not send status.  I had initially thought that would diverge more, but it's a pretty minor change.  This can be a draft and/or all of the common changes could be committed until we know the actual direction.

@rareddy do the comments in ManagedKafkaSync make things more clear now?  