### PR TITLE
Enabled Micrometer based metrics

### DIFF
--- a/kas-fleetshard-operator/pom.xml
+++ b/kas-fleetshard-operator/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>api</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
                 <version>${quarkus.platform.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+                <version>${quarkus.platform.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.dekorate</groupId>
                 <artifactId>crd-annotations</artifactId>
                 <version>${dekorate.version}</version>


### PR DESCRIPTION
This trivial PR enables the Micrometer based metrics exposed on the `/q/metrics` path and in Prometheus format.