### PR TITLE
Removed the editable classes generation

### DIFF
--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -11,7 +11,11 @@ import io.sundr.builder.annotations.BuildableReference;
 /**
  * Represents a ManagedKafka instance declaration with corresponding specification and status
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = @BuildableReference(CustomResource.class))
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        refs = @BuildableReference(CustomResource.class),
+        editableEnabled = false
+)
 @Group("managedkafka.bf2.org")
 @Version("v1alpha1")
 @Crd(group = "managedkafka.bf2.org", version = "v1alpha1")

--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAuthenticationOAuth.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAuthenticationOAuth.java
@@ -5,7 +5,10 @@ import io.sundr.builder.annotations.Buildable;
 /**
  * Defines the configuration for the Kafka instance authentication against an OAuth server
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
 public class ManagedKafkaAuthenticationOAuth {
 
     private String clientId;

--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaCapacity.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaCapacity.java
@@ -6,7 +6,10 @@ import io.sundr.builder.annotations.Buildable;
 /**
  * Defines the capacity provided by a ManagedKafka instance in terms of throughput, connection, data retention and more
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
 public class ManagedKafkaCapacity {
 
     private Quantity ingressEgressThroughputPerSec;

--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaCondition.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaCondition.java
@@ -7,7 +7,10 @@ import io.sundr.builder.annotations.Buildable;
 /**
  * Defines a condition related to the ManagedKafka instance status
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
 public class ManagedKafkaCondition {
 
     public enum Type {

--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaEndpoint.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaEndpoint.java
@@ -5,7 +5,10 @@ import io.sundr.builder.annotations.Buildable;
 /**
  * Defines the endpoint related information used for reaching the ManagedKafka instance
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
 public class ManagedKafkaEndpoint {
 
     private String bootstrapAddress;

--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaSpec.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaSpec.java
@@ -5,7 +5,10 @@ import io.sundr.builder.annotations.Buildable;
 /**
  * Defines the specification of the ManagedKafka instance
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
 public class ManagedKafkaSpec {
 
     private ManagedKafkaCapacity capacity;

--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaStatus.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaStatus.java
@@ -8,7 +8,10 @@ import java.util.List;
 /**
  * Defines the current status with related conditions of a ManagedKafka instance
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
 public class ManagedKafkaStatus {
 
     private List<ManagedKafkaCondition> conditions;

--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/TlsKeyPair.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/TlsKeyPair.java
@@ -5,7 +5,10 @@ import io.sundr.builder.annotations.Buildable;
 /**
  * Represents a TLS keys pair, both public (signed certificate) and private
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
 public class TlsKeyPair {
 
     private String cert;

--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/Versions.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/Versions.java
@@ -5,7 +5,10 @@ import io.sundr.builder.annotations.Buildable;
 /**
  * Represents different versions supported by the ManagedKafka instance
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
 public class Versions {
 
     private String kafka;

--- a/kas-fleetshard-api/src/test/java/org/bf2/resources/ManagedKafkaCrdTest.java
+++ b/kas-fleetshard-api/src/test/java/org/bf2/resources/ManagedKafkaCrdTest.java
@@ -10,7 +10,6 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileInputStream;
@@ -52,7 +51,6 @@ public class ManagedKafkaCrdTest {
     }
 
     @Test
-    @Disabled("due to issue https://github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard/issues/60")
     void testCreateDeleteManagedKafkaResource() {
         ManagedKafka mk = new ManagedKafkaBuilder()
                 .withMetadata(


### PR DESCRIPTION
This PR fixes #60 disabling the Editable classes generation and re-enable the tests using the builders.