### PR TITLE
Fix the informers to watch all namespaces

### DIFF
--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/InformerManager.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/InformerManager.java
@@ -40,7 +40,9 @@ public class InformerManager {
         sharedInformerFactory = client.informers();
 
         OperationContext operationContext =
-                new OperationContext().withLabels(Collections.singletonMap("app.kubernetes.io/managed-by", "kas-fleetshard-operator"));
+                new OperationContext()
+                        .withLabels(Collections.singletonMap("app.kubernetes.io/managed-by", "kas-fleetshard-operator"))
+                        .withIsNamespaceConfiguredFromGlobalConfig(true);
 
         // TODO: should we make the resync time configurable?
         kafkaSharedIndexInformer =

--- a/kas-fleetshard-operator/src/main/kubernetes/clusterrole.yaml
+++ b/kas-fleetshard-operator/src/main/kubernetes/clusterrole.yaml
@@ -76,3 +76,15 @@ rules:
       - delete
       - patch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update


### PR DESCRIPTION
This PR fixes #74 enabling the informers to watch for `Kafka`(s) and `Deployment`(s) in all namespaces.
It also adds permissions in the cluster role for handling `Service` due to the admin server addition.