### PR TITLE
various sync updates

### DIFF
--- a/kas-fleetshard-sync/pom.xml
+++ b/kas-fleetshard-sync/pom.xml
@@ -100,6 +100,21 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
             </plugin>
+            <!-- running the tests have an issue now with the KubernetesServer
+                 scoping - it's global, not per test.
+                 There is a new Quarkus resource being developed to address this
+                 or we need to put more logic in the test to control the before/after state
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            -->
         </plugins>
     </build>
 
@@ -124,8 +139,12 @@
                                 </goals>
                                 <configuration>
                                     <systemPropertyVariables>
-                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
-                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                        <native.image.path>
+                                            ${project.build.directory}/${project.build.finalName}-runner
+                                        </native.image.path>
+                                        <java.util.logging.manager>
+                                            org.jboss.logmanager.LogManager
+                                        </java.util.logging.manager>
                                         <maven.home>${maven.home}</maven.home>
                                     </systemPropertyVariables>
                                 </configuration>

--- a/kas-fleetshard-sync/src/main/java/org/bf2/sync/client/ManagedKafkaResourceClient.java
+++ b/kas-fleetshard-sync/src/main/java/org/bf2/sync/client/ManagedKafkaResourceClient.java
@@ -3,8 +3,8 @@ package org.bf2.sync.client;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
@@ -13,21 +13,23 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafkaList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.quarkus.runtime.StartupEvent;
 
 /**
  * Represents a wrapper around a Kubernetes client for handling operations on a
  * Managed Kafka custom resource
+ *
+ * TODO this should eventually use the common base class
  */
 @ApplicationScoped
 public class ManagedKafkaResourceClient {
 
     @Inject
-    private KubernetesClient kubernetesClient;
+    KubernetesClient kubernetesClient;
 
     private MixedOperation<ManagedKafka, ManagedKafkaList, Resource<ManagedKafka>> kafkaResourceClient;
 
-    void onStart(@Observes StartupEvent ev) {
+    @PostConstruct
+    void onStart() {
         kafkaResourceClient = kubernetesClient.customResources(ManagedKafka.class, ManagedKafkaList.class);
     }
 

--- a/kas-fleetshard-sync/src/main/java/org/bf2/sync/informer/CustomResourceEventHandler.java
+++ b/kas-fleetshard-sync/src/main/java/org/bf2/sync/informer/CustomResourceEventHandler.java
@@ -16,6 +16,10 @@ final class CustomResourceEventHandler<T extends CustomResource<?,?>> implements
         this.consumer = consumer;
     }
 
+    public static <T extends CustomResource<?,?>> CustomResourceEventHandler<T> of(BiConsumer<T, T> consumer) {
+        return new CustomResourceEventHandler<T>(consumer);
+    }
+
     @Override
     public void onAdd(T obj) {
         if (obj.getStatus() != null) {
@@ -25,7 +29,7 @@ final class CustomResourceEventHandler<T extends CustomResource<?,?>> implements
 
     @Override
     public void onDelete(T obj, boolean deletedFinalStateUnknown) {
-        // TODO: this will depend upon the delete strategy chosen
+        // this will depend upon the delete strategy chosen
         // currently there is nothing for sync to do on delete
     }
 

--- a/kas-fleetshard-sync/src/main/java/org/bf2/sync/informer/InformerManager.java
+++ b/kas-fleetshard-sync/src/main/java/org/bf2/sync/informer/InformerManager.java
@@ -42,16 +42,14 @@ public class InformerManager implements LocalLookup {
 
         managedKafkaInformer = sharedInformerFactory.sharedIndexInformerFor(ManagedKafka.class, ManagedKafkaList.class,
                 resync.toMillis());
-
-        managedKafkaInformer.addEventHandler(new CustomResourceEventHandler<ManagedKafka>(controlPlane::updateKafkaClusterStatus));
-
-        managedKafkaInformer.run();
+        managedKafkaInformer.addEventHandler(CustomResourceEventHandler.of(controlPlane::updateKafkaClusterStatus));
 
         // for the Agent
         managedAgentInformer = sharedInformerFactory.sharedIndexInformerFor(ManagedKafkaAgent.class, ManagedKafkaAgentList.class,
                 resync.toMillis());
-        managedAgentInformer.addEventHandler(new CustomResourceEventHandler<ManagedKafkaAgent>(controlPlane::updateStatus));
-        managedAgentInformer.run();
+        managedAgentInformer.addEventHandler(CustomResourceEventHandler.of(controlPlane::updateStatus));
+
+        sharedInformerFactory.startAllRegisteredInformers();
     }
 
     void onStop(@Observes ShutdownEvent ev) {

--- a/kas-fleetshard-sync/src/test/java/org/bf2/sync/PollerTest.java
+++ b/kas-fleetshard-sync/src/test/java/org/bf2/sync/PollerTest.java
@@ -13,9 +13,9 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
-import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpec;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatus;
-import org.bf2.operator.resources.v1alpha1.Versions;
 import org.bf2.sync.controlplane.ControlPlane;
 import org.bf2.sync.controlplane.ControlPlaneRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -35,8 +36,8 @@ import io.smallrye.mutiny.Uni;
 @TestProfile(MockSyncProfile.class)
 public class PollerTest {
 
-    private static final String PLACEMENT_ID = "pid";
-    private static final String CLUSTER_ID = "007";
+    static final String PLACEMENT_ID = "pid";
+    static final String CLUSTER_ID = "007";
 
     @Inject
     KubernetesClient client;
@@ -106,17 +107,21 @@ public class PollerTest {
         assertEquals(1, status.get(PLACEMENT_ID).getConditions().size());
     }
 
-    private ManagedKafka exampleManagedKafka() {
-        ManagedKafka managedKafka = new ManagedKafka();
-        managedKafka.setKind("ManagedKafka");
-        managedKafka.getMetadata().setName("name");
-        managedKafka.setId(PLACEMENT_ID);
-        ManagedKafkaSpec spec = new ManagedKafkaSpec();
-        Versions versions = new Versions();
-        versions.setKafka("2.2.2");
-        spec.setVersions(versions);
-        managedKafka.setSpec(spec);
-        return managedKafka;
+    static ManagedKafka exampleManagedKafka() {
+        ManagedKafka mk = new ManagedKafkaBuilder()
+                .withId(PLACEMENT_ID)
+                .withMetadata(
+                        new ObjectMetaBuilder()
+                                .withName("name")
+                                .build())
+                .withSpec(
+                        new ManagedKafkaSpecBuilder()
+                                .withNewVersions()
+                                .withKafka("2.6.0")
+                                .endVersions()
+                                .build())
+                .build();
+        return mk;
     }
 
 }

--- a/kas-fleetshard-sync/src/test/java/org/bf2/sync/UpdateTest.java
+++ b/kas-fleetshard-sync/src/test/java/org/bf2/sync/UpdateTest.java
@@ -1,0 +1,91 @@
+package org.bf2.sync;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatus;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatusBuilder;
+import org.bf2.sync.client.ManagedKafkaResourceClient;
+import org.bf2.sync.controlplane.ControlPlane;
+import org.bf2.sync.controlplane.ControlPlaneRestClient;
+import org.bf2.sync.informer.InformerManager;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.mockito.InjectMock;
+
+@QuarkusTestResource(KubernetesServerTestResource.class)
+@QuarkusTest
+@TestProfile(MockSyncProfile.class)
+public class UpdateTest {
+
+    @InjectMock
+    @RestClient
+    ControlPlaneRestClient controlPlaneRestClient;
+
+    @Inject
+    ControlPlane controlPlane;
+
+    @Inject
+    ManagedKafkaResourceClient managedKafkaClient;
+
+    @Inject
+    InformerManager informerManager;
+
+    @Test
+    public void testManagedKafkaInformer() throws InterruptedException {
+        ManagedKafka managedKafka = PollerTest.exampleManagedKafka();
+        managedKafka.setStatus(
+                new ManagedKafkaStatusBuilder().addNewCondition().withStatus("Installing").endCondition().build());
+
+        assertTrue(informerManager.getLocalManagedKafkas().isEmpty());
+
+        managedKafka.getMetadata().setNamespace("test");
+        managedKafkaClient.create(managedKafka);
+
+        assertNotNull(getUpdates().getValue().get(PollerTest.PLACEMENT_ID));
+
+        assertFalse(informerManager.getLocalManagedKafkas().isEmpty());
+    }
+
+    @Test
+    public void testControlPlanUpdates() {
+        ManagedKafka managedKafka = PollerTest.exampleManagedKafka();
+        managedKafka.setStatus(
+                new ManagedKafkaStatusBuilder().addNewCondition().withStatus("Installed").endCondition().build());
+
+        controlPlane.updateKafkaClusterStatus(null, managedKafka);
+        assertEquals("Installed", getUpdates().getValue().get(PollerTest.PLACEMENT_ID).getConditions().get(0).getStatus());
+
+        // simulate a resync
+        // for now we're just looking for equality
+        Mockito.clearInvocations(controlPlaneRestClient);
+        controlPlane.updateKafkaClusterStatus(managedKafka, managedKafka);
+        // should be batched
+        Mockito.verifyNoInteractions(controlPlaneRestClient);
+
+        // clear the batch
+        controlPlane.sendPendingStatusUpdates();
+        ArgumentCaptor<Map<String, ManagedKafkaStatus>> statusCaptor = getUpdates();
+        assertEquals("Installed", statusCaptor.getValue().get(PollerTest.PLACEMENT_ID).getConditions().get(0).getStatus());
+    }
+
+    private ArgumentCaptor<Map<String, ManagedKafkaStatus>> getUpdates() {
+        ArgumentCaptor<Map<String, ManagedKafkaStatus>> statusCaptor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(controlPlaneRestClient).updateKafkaClustersStatus(Mockito.eq(PollerTest.CLUSTER_ID), statusCaptor.capture());
+        return statusCaptor;
+    }
+
+}


### PR DESCRIPTION
adding an update test
commenting on why the tests are not explicitly enabled yet
expanding the logic in updateKafkaClusterStatus
aligning the resourceclient with main
adding polling exception handling and correcting executor injection