### PR TITLE
Refactoring to bootstrap server host field

### DIFF
--- a/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaEndpoint.java
+++ b/kas-fleetshard-api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaEndpoint.java
@@ -11,15 +11,15 @@ import io.sundr.builder.annotations.Buildable;
 )
 public class ManagedKafkaEndpoint {
 
-    private String bootstrapAddress;
+    private String bootstrapServerHost;
     private TlsKeyPair tls;
 
-    public String getBootstrapAddress() {
-        return bootstrapAddress;
+    public String getBootstrapServerHost() {
+        return bootstrapServerHost;
     }
 
-    public void setBootstrapAddress(String bootstrapAddress) {
-        this.bootstrapAddress = bootstrapAddress;
+    public void setBootstrapServerHost(String bootstrapServerHost) {
+        this.bootstrapServerHost = bootstrapServerHost;
     }
 
     public TlsKeyPair getTls() {

--- a/kas-fleetshard-api/src/test/java/org/bf2/resources/ManagedKafkaCrdTest.java
+++ b/kas-fleetshard-api/src/test/java/org/bf2/resources/ManagedKafkaCrdTest.java
@@ -71,7 +71,7 @@ public class ManagedKafkaCrdTest {
                                     .withMaxPartitions(100)
                                 .endCapacity()
                                 .withNewEndpoint()
-                                    .withNewBootstrapAddress("")
+                                    .withNewBootstrapServerHost("")
                                     .withNewTls()
                                         .withNewCert("cert")
                                         .withNewKey("key")

--- a/kas-fleetshard-operator/examples/my-managedkafka.yaml
+++ b/kas-fleetshard-operator/examples/my-managedkafka.yaml
@@ -32,7 +32,7 @@ spec:
       l4wOuDwKQa+upc8GftXE2C//4mKANBC6It01gUaTIpo=
       -----END CERTIFICATE-----
   endpoint:
-    bootstrapAddress: xyz.yyy.com
+    bootstrapServerHost: xyz.yyy.com
     tls:
       cert: |-
         -----BEGIN CERTIFICATE-----

--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -227,7 +227,7 @@ public class AdminServer implements Operand<ManagedKafka> {
                     .withNewPort()
                         .withTargetPort(new IntOrString("http"))
                     .endPort()
-                    .withHost("admin-server-" + managedKafka.getSpec().getEndpoint().getBootstrapAddress())
+                    .withHost("admin-server-" + managedKafka.getSpec().getEndpoint().getBootstrapServerHost())
                     .withNewTls()
                         .withTermination("edge")
                     .endTls()

--- a/systemtest/src/test/java/org/bf2/systemtest/ManagedKafkaST.java
+++ b/systemtest/src/test/java/org/bf2/systemtest/ManagedKafkaST.java
@@ -68,7 +68,7 @@ public class ManagedKafkaST extends AbstractST {
                                     .withMaxPartitions(100)
                                 .endCapacity()
                                 .withNewEndpoint()
-                                    .withNewBootstrapAddress("")
+                                    .withNewBootstrapServerHost("")
                                     .withNewTls()
                                         .withNewCert("cert")
                                         .withNewKey("key")


### PR DESCRIPTION
This trivial PR just does a refactoring to use as the current managed service API, a boostrap server host field.