### PR TITLE
MGDSTRM-1262: Adding liveness and readiness check for fleetshard operator

### DIFF
--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/InformerManager.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/InformerManager.java
@@ -1,5 +1,14 @@
 package org.bf2.operator;
 
+import java.util.Collections;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.bf2.operator.events.DeploymentEventSource;
+import org.bf2.operator.events.KafkaEventSource;
+
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -11,13 +20,6 @@ import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.Kafka;
-import org.bf2.operator.events.DeploymentEventSource;
-import org.bf2.operator.events.KafkaEventSource;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import java.util.Collections;
 
 @ApplicationScoped
 public class InformerManager {
@@ -67,5 +69,9 @@ public class InformerManager {
 
     public Deployment getLocalDeployment(String namespace, String name) {
         return deploymentSharedIndexInformer.getIndexer().getByKey(Cache.namespaceKeyFunc(namespace, name));
+    }
+
+    public boolean isReady() {
+        return kafkaSharedIndexInformer.hasSynced() && deploymentSharedIndexInformer.hasSynced();
     }
 }

--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/LivenessHealthCheck.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/LivenessHealthCheck.java
@@ -17,7 +17,7 @@ public class LivenessHealthCheck implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
-        if (this.kubernetesClient.getNamespace() != null) {
+        if (this.kubernetesClient.namespaces().list().getItems().size() > 1) {
             return HealthCheckResponse.up("alive");
         }
         return HealthCheckResponse.down("can't reach kube api, liveness check failed");

--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/ReadinessHealthCheck.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/ReadinessHealthCheck.java
@@ -1,6 +1,4 @@
 package org.bf2.operator;
-import java.util.List;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -8,55 +6,18 @@ import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 
-import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
-import io.fabric8.kubernetes.client.CustomResource;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.model.Kafka;
-
 @Readiness
 @ApplicationScoped
 public class ReadinessHealthCheck implements HealthCheck {
 
     @Inject
-    protected KubernetesClient kubernetesClient;
+    InformerManager informerManager;
 
     @Override
     public HealthCheckResponse call() {
-        if (isStrimziInstalled(this.kubernetesClient.getNamespace())) {
-            return HealthCheckResponse.up("Ready, Strimzi Operator found");
+        if (informerManager.isReady()) {
+            return HealthCheckResponse.up("Ready");
         }
-        return HealthCheckResponse.down("Not Ready, Strimzi Operator not found");
-    }
-
-    boolean isStrimziInstalled(String namespace) {
-        final String strimziCrdName = CustomResource.getCRDName(Kafka.class);
-        List<CustomResourceDefinition> crds = this.kubernetesClient.apiextensions().v1().customResourceDefinitions()
-                .withLabel("app", "strimzi").list().getItems();
-
-        boolean crdFound = false;
-        for (CustomResourceDefinition crd : crds) {
-            if (crd.getMetadata().getName().equals(strimziCrdName)) {
-                crdFound = true;
-                break;
-            }
-        }
-
-        if (crdFound) {
-            // strimi deployment starts with "strimzi-cluster-operator-v*"
-            List<Deployment> deployments = this.kubernetesClient.apps().deployments().inNamespace(namespace)
-                    .list().getItems();
-            for (Deployment deployment : deployments) {
-                if (deployment.getMetadata().getName().startsWith("strimzi-cluster-operator-v")) {
-                    for (DeploymentCondition condition : deployment.getStatus().getConditions()) {
-                        if (condition.getType().equals("Available") && condition.getStatus().equalsIgnoreCase("True")) {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        return false;
+        return HealthCheckResponse.down("Not Ready");
     }
 }


### PR DESCRIPTION
Adding liveness and readiness check for fleetshard operator. This PR assumes a couple of things

1) The `strimzi` operator is installed in the same namespace as the `kas-fleetshard` is installed 
2) checks deployments with a certain name signature to identify the strimzi deployment. 

These both assumptions can be averted if we can either, configure or provide based strimzi install configuration. One thing I am not sure about is if OpenShift allows installing the "cluster" scoped operator in any place other than `openshift-operators`, if not that can be hardcoded. 
