### PR TITLE
Added OpenShift related support for admin server

### DIFF
--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/events/RouteEvent.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/events/RouteEvent.java
@@ -1,0 +1,18 @@
+package org.bf2.operator.events;
+
+import io.fabric8.openshift.api.model.Route;
+import io.javaoperatorsdk.operator.processing.event.AbstractEvent;
+
+public class RouteEvent extends AbstractEvent {
+
+    private Route route;
+
+    public RouteEvent(Route route, RouteEventSource routeEventSource) {
+        super(route.getMetadata().getOwnerReferences().get(0).getUid(), routeEventSource);
+        this.route = route;
+    }
+
+    public Route getRoute() {
+        return route;
+    }
+}

--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/events/RouteEventSource.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/events/RouteEventSource.java
@@ -1,0 +1,37 @@
+package org.bf2.operator.events;
+
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.openshift.api.model.Route;
+import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class RouteEventSource extends AbstractEventSource implements ResourceEventHandler<Route> {
+
+    private static final Logger log = LoggerFactory.getLogger(RouteEventSource.class);
+
+    @Override
+    public void onAdd(Route route) {
+        log.info("Add event received for Route {}/{}", route.getMetadata().getNamespace(), route.getMetadata().getName());
+        handleEvent(route);
+    }
+
+    @Override
+    public void onUpdate(Route oldRoute, Route newRoute) {
+        log.info("Update event received for Route {}/{}", oldRoute.getMetadata().getNamespace(), oldRoute.getMetadata().getName());
+        handleEvent(newRoute);
+    }
+
+    @Override
+    public void onDelete(Route route, boolean deletedFinalStateUnknown) {
+        log.info("Delete event received for Route {}/{}", route.getMetadata().getNamespace(), route.getMetadata().getName());
+        handleEvent(route);
+    }
+
+    private void handleEvent(Route route) {
+        eventHandler.handleEvent(new RouteEvent(route, this));
+    }
+}

--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/events/ServiceEvent.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/events/ServiceEvent.java
@@ -1,0 +1,18 @@
+package org.bf2.operator.events;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.javaoperatorsdk.operator.processing.event.AbstractEvent;
+
+public class ServiceEvent extends AbstractEvent {
+
+    private Service service;
+
+    public ServiceEvent(Service service, ServiceEventSource serviceEventSource) {
+        super(service.getMetadata().getOwnerReferences().get(0).getUid(), serviceEventSource);
+        this.service = service;
+    }
+
+    public Service getService() {
+        return service;
+    }
+}

--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/events/ServiceEventSource.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/events/ServiceEventSource.java
@@ -1,0 +1,37 @@
+package org.bf2.operator.events;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ServiceEventSource extends AbstractEventSource implements ResourceEventHandler<Service> {
+
+    private static final Logger log = LoggerFactory.getLogger(ServiceEventSource.class);
+
+    @Override
+    public void onAdd(Service service) {
+        log.info("Add event received for Service {}/{}", service.getMetadata().getNamespace(), service.getMetadata().getName());
+        handleEvent(service);
+    }
+
+    @Override
+    public void onUpdate(Service oldService, Service newService) {
+        log.info("Update event received for Service {}/{}", oldService.getMetadata().getNamespace(), oldService.getMetadata().getName());
+        handleEvent(newService);
+    }
+
+    @Override
+    public void onDelete(Service service, boolean deletedFinalStateUnknown) {
+        log.info("Delete event received for Service {}/{}", service.getMetadata().getNamespace(), service.getMetadata().getName());
+        handleEvent(service);
+    }
+
+    private void handleEvent(Service service) {
+        eventHandler.handleEvent(new ServiceEvent(service, this));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <quarkus-plugin.version>1.11.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.11.3.Final</quarkus-plugin.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <dekorate.version>2.0.0.beta8</dekorate.version>
         <strimzi.version>0.22.0-SNAPSHOT</strimzi.version>


### PR DESCRIPTION
This PR adds the Route creation for the admin server when it's on OpenShift.
It also adds the reconcile (for deletion or change) for Service and Route in the admin server.