### PR TITLE
adding handling for properties from secret

### DIFF
--- a/kas-fleetshard-sync/README.md
+++ b/kas-fleetshard-sync/README.md
@@ -48,6 +48,8 @@ eval $(minikube docker-env)
 mvn package -DskipTests -Dquarkus.kubernetes.deploy=true -Dquarkus.container-image.build=true -Dquarkus.kubernetes.image-pull-policy=IfNotPresent -Dquarkus.kubernetes.namespace=kas-fleetshard
 ```
 
+Be default the image will run in prod mode.  Add -Dquarkus.profile=dev to run in dev mode - which does not expect sso nor the addon secret
+
 ### In OpenShift (Code Ready Container)
 
 To get access to the OpenShift image registry run below commands

--- a/kas-fleetshard-sync/pom.xml
+++ b/kas-fleetshard-sync/pom.xml
@@ -61,6 +61,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-oidc-client-filter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes-config</artifactId>
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/kas-fleetshard-sync/src/main/java/org/bf2/sync/ExecutorServiceProvider.java
+++ b/kas-fleetshard-sync/src/main/java/org/bf2/sync/ExecutorServiceProvider.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -30,6 +31,12 @@ public class ExecutorServiceProvider {
     @Produces
     public ExecutorService executorService() {
         return executor;
+    }
+
+    @PreDestroy
+    void shutdown() {
+        // we don't need to be more graceful than this as any action will be retried
+        executor.shutdownNow();
     }
 
 }

--- a/kas-fleetshard-sync/src/main/java/org/bf2/sync/informer/SecretRestartHandler.java
+++ b/kas-fleetshard-sync/src/main/java/org/bf2/sync/informer/SecretRestartHandler.java
@@ -1,0 +1,49 @@
+package org.bf2.sync.informer;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.scheduler.Scheduled;
+
+@ApplicationScoped
+public class SecretRestartHandler {
+    @Inject
+    Logger log;
+
+    @ConfigProperty(name="secret.name")
+    String secretName;
+
+    @Inject
+    KubernetesClient client;
+
+    private volatile String resourceVersion;
+    /*
+     * track the uid to detect delete/add (there unfortunately doesn't seem
+     * to be a hard guarantee about resourceVersions across uids)
+     */
+    private volatile String uid;
+
+    @Scheduled(every = "60s")
+    public void checkSecret() {
+        Secret secret = client.secrets().inNamespace(client.getNamespace()).withName(secretName).get();
+        if (secret == null) {
+            return;
+        }
+        if (resourceVersion == null) {
+            // capture the initial version being used
+            // will be replaced by https://github.com/quarkusio/quarkus/issues/15247
+            resourceVersion = secret.getMetadata().getResourceVersion();
+            uid = secret.getMetadata().getUid();
+        } else if (!resourceVersion.equals(secret.getMetadata().getResourceVersion())
+                    || !uid.equals(secret.getMetadata().getUid())) {
+            log.info(secretName + " changed, requires a restart to pickup new configuration");
+            Quarkus.asyncExit();
+        }
+    }
+}

--- a/kas-fleetshard-sync/src/main/resources/application.properties
+++ b/kas-fleetshard-sync/src/main/resources/application.properties
@@ -1,19 +1,44 @@
-# control plane properties
-control-plane/mp-rest/url=http://localhost:8080
-control-plane/mp-rest/connectTimeout=5000
-control-plane/mp-rest/readTimeout=10000
-## authentication properties, client-enabled and register-filter should be true to enable
-quarkus.oidc-client.client-enabled=false
-quarkus.oidc-client-filter.register-filter=false
-quarkus.oidc-client.auth-server-url=https://localhost/auth/realms/realm
-quarkus.oidc-client.client-id=client-id
-quarkus.oidc-client.credentials.secret=secret
-
-quarkus.log.category."org.bf2".level=DEBUG
-quarkus.log.category."org.bf2".min-level=DEBUG
-
+# property defaults for what is expected from the secret
+control-plane.url=http://localhost:8080
+sso.client-id=client-id
+sso.secret=secret
+sso.auth-server-url=https://localhost/auth/realms/realm
 cluster.id=007
 poll.interval=15s
 resync.interval=60s
 
-sync.run-control-plane-simulation=false
+# prod defaults (not expected to change)
+secret.name=addon-kas-fleetshard-operator-parameters
+sso.enabled=true
+secret.enabled=true
+
+# dev overrides
+%dev.sso.enabled=false
+%dev.secret.enabled=false
+%dev.quarkus.log.category."org.bf2".level=DEBUG
+%dev.quarkus.log.category."org.bf2".min-level=DEBUG
+%dev.sync.run-control-plane-simulation=true
+
+# test overrides
+%test.sso.enabled=false
+%test.secret.enabled=false
+
+# control plane properties
+control-plane/mp-rest/url=${control-plane.url}
+control-plane/mp-rest/connectTimeout=5000
+control-plane/mp-rest/readTimeout=10000
+## authentication properties, client-enabled and register-filter should be true to enable
+quarkus.oidc-client.client-enabled=${sso.enabled}
+quarkus.oidc-client-filter.register-filter=${sso.enabled}
+quarkus.oidc-client.auth-server-url=${sso.auth-server-url}
+quarkus.oidc-client.client-id=${sso.client-id}
+quarkus.oidc-client.credentials.secret=${sso.secret}
+
+# properties for secret handling
+quarkus.kubernetes-config.secrets.enabled=true
+quarkus.kubernetes-config.secrets=${secret.name}
+## must be disabled by default for dev/test - cannot use indirection; set in container via env
+quarkus.kubernetes-config.enabled=false
+
+quarkus.kubernetes.env.vars."quarkus.profile"=${quarkus.profile:prod}
+quarkus.kubernetes.env.vars."quarkus.kubernetes-config.enabled"=${secret.enabled}


### PR DESCRIPTION
adding a container restart to deal with a changing secret
adding a set of simple properties for use from the addon secret
using quarkus-kubernetes-config which will eventually give us the exact
initial secret used and the ability to make the secret optional