### PR TITLE
Kafka resource created as the last one

### DIFF
--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -112,9 +112,6 @@ public class KafkaCluster implements Operand<ManagedKafka> {
 
     @Override
     public void createOrUpdate(ManagedKafka managedKafka) {
-        Kafka currentKafka = cachedDeployment(managedKafka);
-        Kafka kafka = kafkaFrom(managedKafka, currentKafka);
-        createOrUpdate(kafka);
 
         if (isKafkaExternalCertificateEnabled) {
             Secret currentTlsSecret = cachedSecret(managedKafka, kafkaTlsSecretName(managedKafka));
@@ -139,6 +136,10 @@ public class KafkaCluster implements Operand<ManagedKafka> {
         ConfigMap currentZooKeeperMetricsConfigMap = cachedConfigMap(managedKafka, zookeeperMetricsConfigMapName(managedKafka));
         ConfigMap zooKeeperMetricsConfigMap = configMapFrom(managedKafka, zookeeperMetricsConfigMapName(managedKafka), currentZooKeeperMetricsConfigMap);
         createOrUpdate(zooKeeperMetricsConfigMap);
+
+        Kafka currentKafka = cachedDeployment(managedKafka);
+        Kafka kafka = kafkaFrom(managedKafka, currentKafka);
+        createOrUpdate(kafka);
     }
 
     @Override


### PR DESCRIPTION
This PR creates the `Kafka` custom resource as the last one after all the others needed (Secrets and ConfigMaps) are already on the cluster otherwise the Strimzi operator reports an error condition and our ManagedKafka controller shows an error state and not installing.
Maybe it's a kind of bug in Strimzi operator because in the end, it's still installing the Kafka cluster.