### PR TITLE
Fixed on admin server

### DIFF
--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -197,8 +197,7 @@ public class AdminServer implements Operand<ManagedKafka> {
                 .editOrNewMetadata()
                     .withNamespace(adminServerNamespace(managedKafka))
                     .withName(adminServerName(managedKafka))
-                    // TODO: adding labels for shared Ingress controller
-                    .withLabels(getLabels(adminServerName))
+                    .withLabels(getRouteLabels())
                 .endMetadata()
                 .editOrNewSpec()
                     .withNewTo()
@@ -242,10 +241,16 @@ public class AdminServer implements Operand<ManagedKafka> {
         return labels;
     }
 
+    private Map<String, String> getRouteLabels() {
+        Map<String, String> labels = new HashMap<>(2);
+        labels.put("ingressType", "sharded");
+        labels.put("app.kubernetes.io/managed-by", "kas-fleetshard-operator");
+        return labels;
+    }
+
     private List<EnvVar> getEnvVar(ManagedKafka managedKafka) {
-        List<EnvVar> envVars = new ArrayList<>(2);
-        // TODO: move to port 9095 that should be OAuth enabled in the Kafka resource
-        envVars.add(new EnvVarBuilder().withName("KAFKA_ADMIN_BOOTSTRAP_SERVERS").withValue(managedKafka.getMetadata().getName() + "-kafka-bootstrap:9092").build());
+        List<EnvVar> envVars = new ArrayList<>(1);
+        envVars.add(new EnvVarBuilder().withName("KAFKA_ADMIN_BOOTSTRAP_SERVERS").withValue(managedKafka.getMetadata().getName() + "-kafka-bootstrap:9095").build());
         return envVars;
     }
 

--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -582,7 +582,7 @@ public class KafkaCluster implements Operand<ManagedKafka> {
     }
 
     private Map<String, String> getKafkaLabels() {
-        Map<String, String> labels = new HashMap<>(1);
+        Map<String, String> labels = new HashMap<>(2);
         labels.put("ingressType", "sharded");
         labels.put("app.kubernetes.io/managed-by", "kas-fleetshard-operator");
         return labels;


### PR DESCRIPTION
This PR sets the right bootstrap server for the admin server with the OAuth enabled and set the ingress controller label on the corresponding Route.