### PR TITLE
updating to the new proposal for name/id/placementId

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -1,7 +1,13 @@
 package org.bf2.operator.resources.v1alpha1;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.dekorate.crd.annotation.Crd;
 import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
@@ -21,17 +27,33 @@ import io.sundr.builder.annotations.BuildableReference;
 @Crd(group = "managedkafka.bf2.org", version = "v1alpha1")
 public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaStatus> implements Namespaced {
 
-    private String id;
+    public final static String ID = "id";
+    public final static String PLACEMENT_ID = "placementId";
 
-    /**
-     * The id of the ManagedKafka, aka the placement id
-     * @return
-     */
+    @JsonIgnore
     public String getId() {
-        return id;
+        return getOrCreateAnnotations().get(ID);
+    }
+
+    private Map<String, String> getOrCreateAnnotations() {
+        ObjectMeta metadata = getMetadata();
+        if (metadata.getAnnotations() == null) {
+            metadata.setAnnotations(new LinkedHashMap<>());
+        }
+        return metadata.getAnnotations();
     }
 
     public void setId(String id) {
-        this.id = id;
+        getOrCreateAnnotations().put(ID, id);
     }
+
+    @JsonIgnore
+    public String getPlacementId() {
+        return getOrCreateAnnotations().get(PLACEMENT_ID);
+    }
+
+    public void setPlacementId(String placementId) {
+        getOrCreateAnnotations().put(PLACEMENT_ID, placementId);
+    }
+
 }

--- a/operator/examples/my-managedkafka.yaml
+++ b/operator/examples/my-managedkafka.yaml
@@ -2,7 +2,6 @@ apiVersion: "managedkafka.bf2.org/v1alpha1"
 kind: ManagedKafka
 metadata:
   name: my-managedkafka
-id: id
 spec:
   capacity:
     ingressEgressThroughputPerSec: 4Mi

--- a/sync/src/main/java/org/bf2/sync/controlplane/ControlPlane.java
+++ b/sync/src/main/java/org/bf2/sync/controlplane/ControlPlane.java
@@ -51,15 +51,19 @@ public class ControlPlane {
     private ConcurrentHashMap<String, ManagedKafka> managedKafkas = new ConcurrentHashMap<>();
 
     void addManagedKafka(ManagedKafka remoteManagedKafka) {
-        managedKafkas.put(remoteManagedKafka.getId(), remoteManagedKafka);
+        managedKafkas.put(managedKafkaKey(remoteManagedKafka), remoteManagedKafka);
     }
 
     public void removeManagedKafka(ManagedKafka remoteManagedKafka) {
-        managedKafkas.remove(remoteManagedKafka.getId());
+        managedKafkas.remove(managedKafkaKey(remoteManagedKafka));
     }
 
     public ManagedKafka getManagedKafka(String id) {
         return managedKafkas.get(id);
+    }
+
+    public static String managedKafkaKey(ManagedKafka kafka) {
+        return kafka.getId() + "/" + kafka.getPlacementId();
     }
 
     /**

--- a/sync/src/main/java/org/bf2/sync/controlplane/MockControlPlane.java
+++ b/sync/src/main/java/org/bf2/sync/controlplane/MockControlPlane.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -83,6 +84,7 @@ public class MockControlPlane {
                 .endEndpoint()
                 .build());
         mk.setId(clusterName(id));
+        mk.setPlacementId(UUID.randomUUID().toString());
         mk.getMetadata().setName("kluster-"+clusterName(id));
         return mk;
     }

--- a/systemtest/src/main/java/org/bf2/systemtest/framework/resource/ManagedKafkaResourceType.java
+++ b/systemtest/src/main/java/org/bf2/systemtest/framework/resource/ManagedKafkaResourceType.java
@@ -99,7 +99,6 @@ public class ManagedKafkaResourceType implements ResourceType<ManagedKafka> {
      */
     public static ManagedKafka getDefault(String namespace, String appName) {
         return new ManagedKafkaBuilder()
-                .withId(namespace)
                 .withMetadata(
                         new ObjectMetaBuilder()
                                 .withNamespace(namespace)


### PR DESCRIPTION
This aligns the sync to the current state of discussion: name is from metadata.name, id/placementId are from annotations

Assumptions / Notes:
- the sync component will create a namespace for each ManagedKafka that is roughly name-placementId.  However since Wei indicated that placementId may be null and that it is not kube safe the logic accounts for that.  This approach means that when a particular placement is deleted, the entire namespace will be deleted - ensuring complete isolation/cleanup.  However this may represent too detailed knowledge on the part of sync - other resource strategies, such as multi-tenant, will likely not require separate namespaces.  Or it may be desirable to reuse the same namespace across placements.  @ppatierno what are your thoughts here?
- We're assuming that the control plane will not list more than a single placement at a time for a given id.  Since the PUT calls are by id, the control plane cannot distinguish between placements.  With this assumption, the namespace is the only explicit usage/tracking of the placementId that is used.  The ControlPlane class is simply tracking by id.  If needed we can check the placementIds in the ControlPlane class to enforce there is only a single placement at a time.
