### PR TITLE
Excluded SLF4J from the Strimzi API

### DIFF
--- a/kas-fleetshard-operator/pom.xml
+++ b/kas-fleetshard-operator/pom.xml
@@ -55,6 +55,13 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>api</artifactId>
+            <exclusions>
+                <!-- Quarkus logging system requiring it for avoiding multiple bindings problem: https://quarkus.io/guides/logging#logging-adapters -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This PR fixes the issue about the operator not printing logging at all due to multiple SLF4J bindings.