### PR TITLE
Enabled TLSv1.3 only on the Kafka cluster

### DIFF
--- a/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/kas-fleetshard-operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -457,6 +457,8 @@ public class KafkaCluster implements Operand<ManagedKafka> {
         config.put("default.replication.factor", 3);
         config.put("log.message.format.version", managedKafka.getSpec().getVersions().getKafka());
         config.put("inter.broker.protocol.version", managedKafka.getSpec().getVersions().getKafka());
+        config.put("ssl.enabled.protocols", "TLSv1.3");
+        config.put("ssl.protocol", "TLSv1.3");
 
         config.put("client.quota.callback.class", "org.apache.kafka.server.quota.StaticQuotaCallback");
         // Throttle at 4 MB/sec


### PR DESCRIPTION
This PR is about disabling old TLS versions with the Kafka cluster supporting 1.3 only.