### PR TITLE
Using cache from informer for operator deleted

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/Operand.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Operand.java
@@ -46,7 +46,7 @@ public interface Operand<T extends CustomResource> {
     /**
      *
      * @param customResource custom resource
-     * @return if resource is deleted
+     * @return if the operand instance is deleted
      */
     boolean isDeleted(T customResource);
 }


### PR DESCRIPTION
This PR refactor the operand deleted part using the cache from informer and it adds logging the deletion state.
It also refactor the methods to get ConfigMap and Secret related to Kafka.