### PR TITLE
Added check that Kafka instance is not deleted yet

### DIFF
--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -67,11 +67,8 @@ public class ManagedKafkaController implements ResourceController<ManagedKafka> 
 
     @Override
     public DeleteControl deleteResource(ManagedKafka managedKafka, Context<ManagedKafka> context) {
-        // ignore the delete event on ManagedKafka resource, just logging a warning is the Kafka instance is erroneously still in place
-        if (!kafkaInstance.isDeleted(managedKafka)) {
-            log.warn("Received a delete event on {}/{} but the Kafka instance is still in place",
-                    managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName());
-        }
+        log.info("Deleting Kafka instance {}/{}", managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName());
+        kafkaInstance.delete(managedKafka, context);
         return DeleteControl.DEFAULT_DELETE;
     }
 


### PR DESCRIPTION
This PR does two main things:

* in the `handleUpdate` of the MK controller, if the MK is marked as `spec.deleted: true`, it checks that the Kafka instance is really not deleted yet before calling deletion of all operands. I added this check because there could be a time window where the deleted flag is true, the Deleted condition is there (so actually the Kafka instance related resources are gone) but the ManagedKafka resource is still in place (because the sync haven't got from the control plane a new list with the Kafka cluster missing yet). If for any reason, the ManagedKafka resource is touched (it shouldn't happen), it triggers an event and the controller tries to delete things again. It should not hurt but they are useless Kube API calls.
* in the `deleteResource`, it removes the call to delete the Kafka instance because now the deletion happen based on a specific protocol (deleted flag + Deleted condition) and not when the ManagedKafka resource is deleted (when it happens, the Kafka instance is already gone but this PR adds a warning if it's not the case).