### PR TITLE
refining the test profile for ci/cd

### DIFF
--- a/sync/src/main/resources/application.properties
+++ b/sync/src/main/resources/application.properties
@@ -26,7 +26,7 @@ secret.enabled=true
 # test overrides
 %test.sso.enabled=false
 %test.secret.enabled=false
-%test.sync.run-control-plane-simulation=true
+%test.sync.run-control-plane-simulation=false
 
 # control plane properties
 control-plane/mp-rest/url=${control-plane.url}


### PR DESCRIPTION
if the image is built and run with the test profile, it will include the mock control plane, but not run the simulation.  This means you could test through the mock by posting/deleting managedkafkas.  A service is already being created for the sync.