### PR TITLE
Added HTTP port, liveness probe and Quarkus profile env var to operator deployment

### DIFF
--- a/operator/src/main/kubernetes/deployment.yaml
+++ b/operator/src/main/kubernetes/deployment.yaml
@@ -16,6 +16,23 @@ spec:
       containers:
         - name: kas-fleetshard-operator
           image: ##IMAGE##
+          env:
+            - name: QUARKUS_PROFILE
+              value: prod
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
   selector:
     matchLabels:
       app: kas-fleetshard-operator


### PR DESCRIPTION
This trivial PR adds some missing stuff on the operator deployment:
- the exposed 8080 port from the container
- the liveness probe
- the env var to define the Quarkus profile