### PR TITLE
adding resource limits and making the mock configurable

### DIFF
--- a/sync/src/main/java/org/bf2/sync/ManagedKafkaAgentSync.java
+++ b/sync/src/main/java/org/bf2/sync/ManagedKafkaAgentSync.java
@@ -20,9 +20,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 
-/**
- * TODO: This is throw away code until the Control Plane API for ManagedkafkaAgent CR is defined.
- */
 @ApplicationScoped
 public class ManagedKafkaAgentSync {
 
@@ -47,8 +44,12 @@ public class ManagedKafkaAgentSync {
     @Inject
     ControlPlane controlPlane;
 
-    @Scheduled(every = "{poll.interval}")
+    @Scheduled(every = "{poll.interval}", delayed = "5s")
     void loop() {
+        if (!lookup.isReady()) {
+            log.debug("Not ready to poll, the lookup is not ready");
+            return;
+        }
         ManagedKafkaAgent managedKafkaAgent = null;
         try {
             managedKafkaAgent = controlPlane.getManagedKafkaAgent();

--- a/sync/src/main/resources/application.properties
+++ b/sync/src/main/resources/application.properties
@@ -20,12 +20,14 @@ secret.enabled=true
 %dev.secret.enabled=false
 %dev.quarkus.log.category."org.bf2".level=DEBUG
 %dev.quarkus.log.category."org.bf2".min-level=DEBUG
-%dev.sync.run-control-plane-simulation=true
+%dev.sync.mock-control-plane.simulate=true
+%dev.sync.mock-control-plane.max=3
+%dev.quarkus.kubernetes.env.vars."sync.mock-control-plane.max"=${sync.mock-control-plane.max}
 
 # test overrides
 %test.sso.enabled=false
 %test.secret.enabled=false
-%test.sync.run-control-plane-simulation=false
+%test.sync.mock-control-plane.simulate=false
 
 # control plane properties
 control-plane/mp-rest/url=${control-plane.url}
@@ -46,3 +48,7 @@ quarkus.kubernetes-config.enabled=false
 
 quarkus.kubernetes.env.vars."quarkus.profile"=${quarkus.profile:prod}
 quarkus.kubernetes.env.vars."quarkus.kubernetes-config.enabled"=${secret.enabled}
+quarkus.kubernetes.resources.requests.memory=128Mi
+quarkus.kubernetes.resources.requests.cpu=100m
+quarkus.kubernetes.resources.limits.memory=256Mi
+quarkus.kubernetes.resources.limits.cpu=500m


### PR DESCRIPTION
/cc @ppatierno 

may need more guidance on the cpu - performance seemed acceptable with these values. On the memory it fails to start with 64, and runs fine with 128MI and 2500 managedkafka instances (simulation ran for over an hour - polling, sending updates, etc.).