### PR TITLE
fix: add the CORS allow list back to the server

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -226,6 +226,7 @@ public class AdminServer extends AbstractAdminServer {
     private List<EnvVar> getEnvVar(ManagedKafka managedKafka) {
         List<EnvVar> envVars = new ArrayList<>(1);
         envVars.add(new EnvVarBuilder().withName("KAFKA_ADMIN_BOOTSTRAP_SERVERS").withValue(managedKafka.getMetadata().getName() + "-kafka-bootstrap:9095").build());
+        envVars.add(new EnvVarBuilder().withName("CORS_ALLOW_LIST_REGEX").withValue("(https?:\\/\\/localhost(:\\d*)?)|(https:\\/\\/(qaprodauth\\.)?cloud\\.redhat\\.com)|(https:\\/\\/(prod|qa|ci|stage)\\.foo\\.redhat\\.com:1337)").build());
         return envVars;
     }
 


### PR DESCRIPTION
It's MIA since the move to kas-fleetshard https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/main/pkg/services/syncsetresources/admin_server.go#L59-L61