### PR TITLE
Make systemtest module visible in root pom

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,4 @@ jobs:
       with:
         java-version: 11
     - name: Build and run Unit tests
-      run: mvn package --file pom.xml -Psystemtest --no-transfer-progress
+      run: mvn package --file pom.xml --no-transfer-progress

--- a/pom.xml
+++ b/pom.xml
@@ -36,17 +36,9 @@
         <module>common</module>
         <module>operator</module>
         <module>sync</module>
+        <module>systemtest</module>
         <module>test</module>
     </modules>
-    
-    <profiles>
-	    <profile>
-	        <id>systemtest</id>
-	        <modules>
-	            <module>systemtest</module>
-	        </modules>
-	    </profile>   
-    </profiles>
 
     <dependencyManagement>
         <dependencies>

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -11,6 +11,10 @@
     </parent>
     <artifactId>systemtest</artifactId>
 
+    <properties>
+        <it.skip>true</it.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.bf2</groupId>
@@ -69,6 +73,15 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>systemtest</id>
+            <properties>
+                <it.skip>false</it.skip>
+            </properties>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -88,43 +101,44 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>integration-test</goal>
                             <goal>verify</goal>
+                            <goal>integration-test</goal>
                         </goals>
-                        <configuration>
-                            <forkCount>0</forkCount>
-                            <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
-                            <includes>
-                                <include>**/IT*.java</include>
-                                <include>**/*IT.java</include>
-                                <include>**/ST*.java</include>
-                                <include>**/*ST.java</include>
-                            </includes>
-                            <statelessTestsetReporter
-                                    implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
-                                <disable>false</disable>
-                                <version>3.0</version>
-                                <usePhrasedFileName>false</usePhrasedFileName>
-                                <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
-                                <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
-                                <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
-                            </statelessTestsetReporter>
-                            <consoleOutputReporter
-                                    implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
-                                <disable>false</disable>
-                                <encoding>UTF-8</encoding>
-                                <usePhrasedFileName>true</usePhrasedFileName>
-                            </consoleOutputReporter>
-                            <statelessTestsetInfoReporter
-                                    implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
-                                <disable>false</disable>
-                                <usePhrasedFileName>false</usePhrasedFileName>
-                                <usePhrasedClassNameInRunning>false</usePhrasedClassNameInRunning>
-                                <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
-                            </statelessTestsetInfoReporter>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <forkCount>0</forkCount>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                    <includes>
+                        <include>**/IT*.java</include>
+                        <include>**/*IT.java</include>
+                        <include>**/ST*.java</include>
+                        <include>**/*ST.java</include>
+                    </includes>
+                    <skipTests>${it.skip}</skipTests>
+                    <statelessTestsetReporter
+                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                        <disable>false</disable>
+                        <version>3.0</version>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                        <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                        <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                        <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                    </statelessTestsetReporter>
+                    <consoleOutputReporter
+                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+                        <disable>false</disable>
+                        <encoding>UTF-8</encoding>
+                        <usePhrasedFileName>true</usePhrasedFileName>
+                    </consoleOutputReporter>
+                    <statelessTestsetInfoReporter
+                            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+                        <disable>false</disable>
+                        <usePhrasedFileName>false</usePhrasedFileName>
+                        <usePhrasedClassNameInRunning>false</usePhrasedClassNameInRunning>
+                        <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+                    </statelessTestsetInfoReporter>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
1. Make systemtest module visible in root pom and visible in IDEs
2. Skip systemtests integration tests by default when `mvn install` is called and run only systemtest unit tests
3. Use systemtest profile to enable systemtests run