### PR TITLE
Increase admin server CPU resources

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -45,9 +45,9 @@ import java.util.Optional;
 public class AdminServer extends AbstractAdminServer {
 
     private static final Quantity CONTAINER_MEMORY_REQUEST = new Quantity("256Mi");
-    private static final Quantity CONTAINER_CPU_REQUEST = new Quantity("50m");
+    private static final Quantity CONTAINER_CPU_REQUEST = new Quantity("250m");
     private static final Quantity CONTAINER_MEMORY_LIMIT = new Quantity("512Mi");
-    private static final Quantity CONTAINER_CPU_LIMIT = new Quantity("100m");
+    private static final Quantity CONTAINER_CPU_LIMIT = new Quantity("500m");
 
     @Inject
     Logger log;


### PR DESCRIPTION
The CPU request was not enough for admin server on starting up that was printing the warning about the main Vert.x event loop to be blocked. I increased it and even changed the corresponding limit accordingly.