### PR TITLE
Fix mock control plane with valid Kafka version

### DIFF
--- a/sync/src/main/java/org/bf2/sync/controlplane/MockControlPlane.java
+++ b/sync/src/main/java/org/bf2/sync/controlplane/MockControlPlane.java
@@ -70,7 +70,7 @@ public class MockControlPlane implements ControlPlaneApi {
     private ManagedKafka createManagedKafka(int id) {
         ManagedKafka mk = new ManagedKafka();
         mk.setSpec(new ManagedKafkaSpecBuilder()
-                .withVersions(new VersionsBuilder().withKafka("2.2.6").withStrimzi("0.21.1").build())
+                .withVersions(new VersionsBuilder().withKafka("2.6.0").withStrimzi("0.21.1").build())
                 .withNewCapacity()
                     .withIngressEgressThroughputPerSec(Quantity.parse("2Mi"))
                     .withTotalMaxConnections(100)


### PR DESCRIPTION
In order to use the mocked control plane with latest Strimzi operator we need a valid Kafka version for simulation.