### PR TITLE
Add additional connection count and rate metrics

### DIFF
--- a/operator/src/main/resources/kafka-metrics.yaml
+++ b/operator/src/main/resources/kafka-metrics.yaml
@@ -196,3 +196,18 @@ data:
           kafka.network<type=RequestMetrics, name=TotalTimeMs,
           (.+)=(.+)><>(\d+)thPercentile
         type: GAUGE
+      - pattern: kafka.server<type=socket-server-metrics, listener=(.+), networkProcessor=(.+)><>connection-count
+        name: kafka_server_socket_listener_connection_count
+        type: GAUGE
+        labels:
+          listener: "$1"
+          networkProcessor: "$2"
+      - pattern: kafka.server<type=socket-server-metrics, listener=(.+), networkProcessor=(.+)><>connection-creation-rate
+        name: kafka_server_socket_listener_connection_creation_rate
+        type: GAUGE
+        labels:
+          listener: "$1"
+          networkProcessor: "$2"
+      - pattern: kafka.server<type=socket-server-metrics><>broker-connection-accept-rate
+        name: kafka_server_socket_broker_connection_accept_rate
+        type: GAUGE


### PR DESCRIPTION
Maybe one of `kafka_server_socket_listener_connection_creation_rate` and
`kafka_server_socket_broker_connection_accept_rate` would be enough,
I'm not 100% sure of the distinction between them.