### PR TITLE
Unit test fix  + use junit5 asserts

### DIFF
--- a/operator/src/test/java/org/bf2/operator/controllers/ManagedKafkaAgentControllerTest.java
+++ b/operator/src/test/java/org/bf2/operator/controllers/ManagedKafkaAgentControllerTest.java
@@ -1,17 +1,16 @@
 package org.bf2.operator.controllers;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import javax.inject.Inject;
-
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
 import org.bf2.common.AgentResourceClient;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaAgent;
 import org.bf2.test.mock.QuarkusKubeMockServer;
 import org.junit.jupiter.api.Test;
 
-import io.quarkus.test.common.QuarkusTestResource;
-import io.quarkus.test.junit.QuarkusTest;
+import javax.inject.Inject;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @QuarkusTestResource(QuarkusKubeMockServer.class)
 @QuarkusTest
@@ -37,6 +36,8 @@ public class ManagedKafkaAgentControllerTest {
         mkaController.statusUpdateLoop();
         ManagedKafkaAgent agent = agentClient.getByName(agentClient.getNamespace(), AgentResourceClient.RESOURCE_NAME);
         assertNotNull(agent.getStatus());
+
+        agentClient.delete(agentClient.getNamespace(), AgentResourceClient.RESOURCE_NAME);
     }
 
 }

--- a/operator/src/test/java/org/bf2/operator/operands/ObservabilityManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/ObservabilityManagerTest.java
@@ -1,16 +1,9 @@
 package org.bf2.operator.operands;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-
 import org.bf2.operator.resources.v1alpha1.ObservabilityConfiguration;
 import org.bf2.operator.resources.v1alpha1.ObservabilityConfigurationBuilder;
 import org.bf2.test.mock.QuarkusKubeMockServer;
@@ -18,6 +11,11 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTestResource(QuarkusKubeMockServer.class)
 @QuarkusTest
@@ -29,14 +27,11 @@ public class ObservabilityManagerTest {
     @Inject
     ObservabilityManager observabilityManager;
 
-    private Base64.Decoder decoder = Base64.getDecoder();
+    private final Base64.Decoder decoder = Base64.getDecoder();
 
     @Test
     public void testObservabilitySecret() {
         client.getConfiguration().setNamespace("test");
-
-        Secret secret = observabilityManager.observabilitySecretResource().get();
-        assertNull(secret);
 
         ObservabilityConfiguration config = new ObservabilityConfigurationBuilder()
                 .withAccessToken("test-token")
@@ -48,7 +43,7 @@ public class ObservabilityManagerTest {
         this.observabilityManager.createOrUpdateObservabilitySecret(config);
 
         // lets call event handler
-        secret = observabilityManager.observabilitySecretResource().get();
+        Secret secret = observabilityManager.observabilitySecretResource().get();
         assertNotNull(secret);
 
         // the mock informermanager should be immediately updated, but it should
@@ -64,12 +59,12 @@ public class ObservabilityManagerTest {
                 .build();
 
         // secret verification
-        assertTrue(config.equals(secretConfig));
+        assertEquals(secretConfig, config);
         assertEquals("observability-operator", secret.getMetadata().getLabels().get("configures"));
 
         // status verification, the Informers do not work in test framework thus direct verification
         secret = ObservabilityManager.createObservabilitySecretBuilder(client.getNamespace(), config).editMetadata()
-            .addToAnnotations(ObservabilityManager.OBSERVABILITY_OPERATOR_STATUS, ObservabilityManager.ACCEPTED).endMetadata().build();
+                .addToAnnotations(ObservabilityManager.OBSERVABILITY_OPERATOR_STATUS, ObservabilityManager.ACCEPTED).endMetadata().build();
         observabilityManager.observabilitySecretResource().createOrReplace(secret);
         assertTrue(ObservabilityManager.isObservabilityStatusAccepted(secret));
     }


### PR DESCRIPTION
1. Remove assert which causes issue because mock kube server is reused across all unit tests and previous test already created secret for observability.
2. Use right junit5 asserts instead of juni4