### PR TITLE
Add pod labels for observability purposes

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -219,6 +219,7 @@ public class AdminServer extends AbstractAdminServer {
     private Map<String, String> getLabels(String adminServerName) {
         Map<String, String> labels = OperandUtils.getDefaultLabels();
         labels.put("app", adminServerName);
+        labels.put("app.kubernetes.io/component", "adminserver");
         return labels;
     }
 

--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -83,9 +83,9 @@ public class Canary extends AbstractCanary {
     }
 
     private Map<String, String> getLabels(String canaryName) {
-        // TODO: adding label about observability
         Map<String, String> labels = OperandUtils.getDefaultLabels();
         labels.put("app", canaryName);
+        labels.put("app.kubernetes.io/component", "canary");
         return labels;
     }
 


### PR DESCRIPTION
We need predictable labels on the admin and canary pods in order that the observability will be able to locate the pods so that they may be scraped.