### PR TITLE
Added label for observability on Kafka namespace

### DIFF
--- a/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
+++ b/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
@@ -214,7 +214,7 @@ public class ManagedKafkaSync {
                 new NamespaceBuilder()
                         .withNewMetadata()
                             .withName(remote.getMetadata().getNamespace())
-                            .withLabels(Collections.singletonMap("mas-managed", "true"))
+                            .withLabels(Collections.singletonMap("observability-operator/scrape-logging", "true"))
                         .endMetadata()
                         .build());
 


### PR DESCRIPTION
The observability operator needs a `mas-managed: true` label on the namespace where the Kafka cluster will be created in order to scrape logs.
This PR addresses this missing point.