### PR TITLE
Make canary and admin-server use fixed container names

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -203,10 +203,8 @@ public class AdminServer extends AbstractAdminServer {
     }
 
     private List<Container> getContainers(ManagedKafka managedKafka) {
-        String adminServerName = adminServerName(managedKafka);
-
         Container container = new ContainerBuilder()
-                .withName(adminServerName)
+                .withName("admin-server")
                 .withImage("quay.io/mk-ci-cd/kafka-admin-api:0.0.5")
                 .withEnv(getEnvVar(managedKafka))
                 .withPorts(getContainerPorts())

--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -69,10 +69,8 @@ public class Canary extends AbstractCanary {
     }
 
     private List<Container> getContainers(ManagedKafka managedKafka) {
-        String canaryName = canaryName(managedKafka);
-
         Container container = new ContainerBuilder()
-                .withName(canaryName)
+                .withName("canary")
                 .withImage("quay.io/mk-ci-cd/strimzi-canary:0.0.3")
                 .withEnv(getEnvVar(managedKafka))
                 .withPorts(getContainerPorts())


### PR DESCRIPTION
Switch canary and admin-server to use fixed container names.  The variable names hindered the writing of Prometheus rules.  This also follows the precedent set by Strimzi.  