### PR TITLE
Enable client.quota.callback.static.disable-quota-anonymous …

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -505,6 +505,10 @@ public class KafkaCluster extends AbstractKafkaCluster {
 
         // Check storage every 30 seconds
         config.put("client.quota.callback.static.storage.check-interval", "30");
+
+        // Anonymous users bypass the quota.  We do this so the Canary is not subjected to the quota checks.
+        config.put("client.quota.callback.static.disable-quota-anonymous", Boolean.TRUE.toString());
+
         config.put("quota.window.num", "30");
         config.put("quota.window.size.seconds", "2");
 

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -95,6 +95,7 @@ spec:
       client.quota.callback.static.consume: "699050"
       client.quota.callback.static.storage.hard: "71403831296"
       client.quota.callback.static.storage.check-interval: "30"
+      client.quota.callback.static.disable-quota-anonymous: "true"
       default.replication.factor: 3
       max.connections.creation.rate: "33"
       max.connections: "166"


### PR DESCRIPTION
so that the canary is not subject to the quota throttling.