### PR TITLE
removing the reflector watcher info logs

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -2,6 +2,7 @@ agent.calculate-cluster-capacity.interval=60s
 
 kafka.authentication.enabled=true
 kafka.external.certificate.enabled=true
+quarkus.log.category."io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher".level=WARNING
 
 %dev.quarkus.log.console.level=DEBUG
 %dev.quarkus.log.console.color=true


### PR DESCRIPTION
This is a follow-up to the same change that was made on the sync side.