### PR TITLE
Added liveness and readiness probes on canary

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -6,6 +6,10 @@ import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.HTTPGetActionBuilder;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
@@ -80,9 +84,37 @@ public class Canary extends AbstractCanary {
                 .withEnv(getEnvVar(managedKafka))
                 .withPorts(getContainerPorts())
                 .withResources(getResources())
+                .withReadinessProbe(getReadinessProbe())
+                .withLivenessProbe(getLivenessProbe())
                 .build();
 
         return Collections.singletonList(container);
+    }
+
+    private Probe getLivenessProbe() {
+        return new ProbeBuilder()
+                .withHttpGet(
+                        new HTTPGetActionBuilder()
+                                .withPath("/liveness")
+                                .withPort(new IntOrString(8080))
+                                .build()
+                )
+                .withTimeoutSeconds(5)
+                .withInitialDelaySeconds(15)
+                .build();
+    }
+
+    private Probe getReadinessProbe() {
+        return new ProbeBuilder()
+                .withHttpGet(
+                        new HTTPGetActionBuilder()
+                                .withPath("/readiness")
+                                .withPort(new IntOrString(8080))
+                                .build()
+                )
+                .withTimeoutSeconds(5)
+                .withInitialDelaySeconds(15)
+                .build();
     }
 
     private Map<String, String> getSelectorLabels(String canaryName) {

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -5,7 +5,7 @@ kafka.external.certificate.enabled=true
 quarkus.log.category."io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher".level=WARNING
 
 image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.0.7
-image.canary=quay.io/mk-ci-cd/strimzi-canary:0.0.4
+image.canary=quay.io/mk-ci-cd/strimzi-canary:0.0.5
 
 %dev.quarkus.log.console.level=DEBUG
 %dev.quarkus.log.console.color=true


### PR DESCRIPTION
This PR configures the Canary Deployment with liveness and readiness probes hitting the new HTTP endpoints added in canary 0.0.5 image.