### PR TITLE
Add Admin Server optional config map volume mount

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
@@ -139,13 +140,8 @@ public class AdminServer extends AbstractAdminServer {
                             .withLabels(getLabels(adminServerName))
                         .endMetadata()
                         .editOrNewSpec()
-                            .withVolumes(new VolumeBuilder()
-                                .withName(adminServerConfigVolumeName(managedKafka))
-                                .editOrNewConfigMap()
-                                    .withName(adminServerName(managedKafka))
-                                .endConfigMap()
-                                .build())
                             .withContainers(getContainers(managedKafka))
+                            .withVolumes(getVolumes(managedKafka))
                         .endSpec()
                     .endTemplate()
                 .endSpec()
@@ -264,6 +260,16 @@ public class AdminServer extends AbstractAdminServer {
                     .withName(adminServerConfigVolumeName(managedKafka))
                     /* Matches location expected by kafka-admin-api container. */
                     .withMountPath("/opt/kafka-admin-api/custom-config/")
+                .build());
+    }
+
+    private List<Volume> getVolumes(ManagedKafka managedKafka) {
+        return Collections.singletonList(new VolumeBuilder()
+                .withName(adminServerConfigVolumeName(managedKafka))
+                .editOrNewConfigMap()
+                    .withName(adminServerName(managedKafka))
+                    .withOptional(Boolean.TRUE)
+                .endConfigMap()
                 .build());
     }
 


### PR DESCRIPTION
General approach, similar to Strimzi's use of a ConfigMap with log4j2.properties. This change is a companion to another PR for the Admin server required to actually read the properties in the ConfigMap.

* Admin server will expect an override `log4j2.properties` at a well-known path, `/opt/kafka-admin-api/custom-config/log4j2.properties`
* Fleetshard creates an ~~"empty" properties file in a volume-mounted ConfigMap, with a 30s refresh interval (i.e. Log4J will scan the mounted file for changes every 30s)~~ optional ConfigMap volume mount that can be utilized to provide the `log4j2.properties` entry when necessary
* Any changes made to the file via the ConfigMap will override or add to the properties defined in the static configuration that is in the Admin server image
* ~~The ConfigMap will only be created, never updated if it already exists. Any changes made to the configuration to enable additional logging must be manually reverted. Otherwise, they will remain in place.~~
* Removal of the ConfigMap will trigger the admin server to restore the logging configuration to the defaults defined in the container.

CC: @shawkins , @ppatierno , @rareddy , @k-wall 

Signed-off-by: Michael Edgar <medgar@redhat.com>