### PR TITLE
updating the build to run additional checks, updating to allow pushing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build and run Unit tests
-      run: mvn package --file pom.xml --no-transfer-progress -Dno-format
+      run: mvn install --file pom.xml --no-transfer-progress -Dno-format

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,9 @@
         <basepom.failsafe.reuse-vm>true</basepom.failsafe.reuse-vm>
         <basepom.test.timeout>150</basepom.test.timeout>
         
+        <basepom.release.push-changes>true</basepom.release.push-changes>
+        <basepom.release.tag-name-format>@{project.version}</basepom.release.tag-name-format>
+        
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.systemJdk>${maven.compiler.release}</project.build.systemJdk>
         <project.build.targetJdk>${maven.compiler.release}</project.build.targetJdk>
@@ -370,12 +373,8 @@
                     <plugin>
                         <artifactId>maven-release-plugin</artifactId>
                         <configuration>
-                            <autoVersionSubmodules>true</autoVersionSubmodules>
-                            <tagNameFormat>@{project.version}</tagNameFormat>
-                            <ignoreSnapshots>true</ignoreSnapshots>
                             <releaseProfiles>release-perform,quickly</releaseProfiles>
                             <arguments>${release.properties}</arguments>
-                            <pushChanges>true</pushChanges>
                         </configuration>
                     </plugin>
                 </plugins>  


### PR DESCRIPTION
I tried locally and using the built-in basepom property for pushChanges worked.  Also we aren't running all of our checks with the unit tests, switching to install