### PR TITLE
more logging runtime updates

### DIFF
--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -155,6 +155,18 @@ spec:
             requests:
               cpu: 500m
               memory: 512Mi
+          volumeMounts:
+          - mountPath: /config
+            name: logging-config-volume
+            readOnly: false
+            subPath: ""
+      volumes:
+      - configMap:
+          defaultMode: 384
+          name: operator-logging-config-override
+          optional: true
+        name: logging-config-volume
+
   selector:
     matchLabels:
       app: kas-fleetshard-operator


### PR DESCRIPTION
the file watch strategy was problematic for the version of crc rareddy
was testing on, when the configmap did not exist some metadata in the
config directory was being updated every 30 seconds resulting in an
attempt to read a non-existant file.  my minikube did not exhibit that
same behavior... so now switching to a last updated check instead

also adding the config volume mount to the operator