### PR TITLE
minor logging adjustments

### DIFF
--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -73,11 +73,11 @@ public class ManagedKafkaController implements ResourceController<ManagedKafka> 
         if (managedKafka.getSpec().isDeleted()) {
             // check that it's actually not deleted yet, so operands are gone
             if (!kafkaInstance.isDeleted(managedKafka)) {
-                log.infof("Deleting Kafka instance %s/%s - modified %s", managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName(), context.getEvents().getList());
+                log.infof("Deleting Kafka instance %s/%s %s - modified %s", managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName(), managedKafka.getMetadata().getResourceVersion(), context.getEvents().getList());
                 kafkaInstance.delete(managedKafka, context);
             }
         } else {
-            log.infof("Updating Kafka instance %s/%s - modified %s", managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName(), context.getEvents().getList());
+            log.infof("Updating Kafka instance %s/%s %s - modified %s", managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName(), managedKafka.getMetadata().getResourceVersion(), context.getEvents().getList());
             kafkaInstance.createOrUpdate(managedKafka);
         }
     }

--- a/operator/src/main/java/org/bf2/operator/events/ResourceEvent.java
+++ b/operator/src/main/java/org/bf2/operator/events/ResourceEvent.java
@@ -30,7 +30,7 @@ public class ResourceEvent<T extends HasMetadata> extends AbstractEvent {
                 + resource.getMetadata().getNamespace() + "/" + resource.getMetadata().getName()
                 + " relatedCustomResourceUid="
                 + getRelatedCustomResourceUid()
-                + " ,resourceVersion="
+                + " , resourceVersion="
                 + resource.getMetadata().getResourceVersion()
                 + " }";
     }

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractAdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractAdminServer.java
@@ -79,7 +79,7 @@ public abstract class AbstractAdminServer implements Operand<ManagedKafka> {
     public boolean isInstalling(ManagedKafka managedKafka) {
         Deployment deployment = cachedDeployment(managedKafka);
         boolean isInstalling = deployment == null || deployment.getStatus() == null;
-        log.debugf("Admin Server isInstalling = %s", isInstalling);
+        log.tracef("Admin Server isInstalling = %s", isInstalling);
         return isInstalling;
     }
 
@@ -88,7 +88,7 @@ public abstract class AbstractAdminServer implements Operand<ManagedKafka> {
         Deployment deployment = cachedDeployment(managedKafka);
         boolean isReady = deployment != null && (deployment.getStatus() == null ||
                 (deployment.getStatus().getReadyReplicas() != null && deployment.getStatus().getReadyReplicas().equals(deployment.getSpec().getReplicas())));
-        log.debugf("Admin Server isReady = %s", isReady);
+        log.tracef("Admin Server isReady = %s", isReady);
         return isReady;
     }
 
@@ -101,7 +101,7 @@ public abstract class AbstractAdminServer implements Operand<ManagedKafka> {
     @Override
     public boolean isDeleted(ManagedKafka managedKafka) {
         boolean isDeleted = cachedDeployment(managedKafka) == null && cachedService(managedKafka) == null;
-        log.debugf("Admin Server isDeleted = %s", isDeleted);
+        log.tracef("Admin Server isDeleted = %s", isDeleted);
         return isDeleted;
     }
 

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractCanary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractCanary.java
@@ -54,7 +54,7 @@ public abstract class AbstractCanary implements Operand<ManagedKafka> {
     public boolean isInstalling(ManagedKafka managedKafka) {
         Deployment deployment = cachedDeployment(managedKafka);
         boolean isInstalling = deployment == null || deployment.getStatus() == null;
-        log.debugf("Canary isInstalling = %s", isInstalling);
+        log.tracef("Canary isInstalling = %s", isInstalling);
         return isInstalling;
     }
 
@@ -63,7 +63,7 @@ public abstract class AbstractCanary implements Operand<ManagedKafka> {
         Deployment deployment = cachedDeployment(managedKafka);
         boolean isReady = deployment != null && (deployment.getStatus() == null ||
                 (deployment.getStatus().getReadyReplicas() != null && deployment.getStatus().getReadyReplicas().equals(deployment.getSpec().getReplicas())));
-        log.debugf("Canary isReady = %s", isReady);
+        log.tracef("Canary isReady = %s", isReady);
         return isReady;
     }
 
@@ -76,7 +76,7 @@ public abstract class AbstractCanary implements Operand<ManagedKafka> {
     @Override
     public boolean isDeleted(ManagedKafka managedKafka) {
         boolean isDeleted = cachedDeployment(managedKafka) == null;
-        log.debugf("Canary isDeleted = %s", isDeleted);
+        log.tracef("Canary isDeleted = %s", isDeleted);
         return isDeleted;
     }
 

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -50,7 +50,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                 kafkaCondition(kafka, c->c.getType().equals("NotReady")
                 && c.getStatus().equals("True")
                 && c.getReason().equals("Creating"));
-        log.debugf("KafkaCluster isInstalling = %s", isInstalling);
+        log.tracef("KafkaCluster isInstalling = %s", isInstalling);
         return isInstalling;
     }
 
@@ -59,7 +59,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
         Kafka kafka = cachedKafka(managedKafka);
         boolean isReady = kafka != null && (kafka.getStatus() == null ||
                 kafkaCondition(kafka, c->c.getType().equals("Ready") && c.getStatus().equals("True")));
-        log.debugf("KafkaCluster isReady = %s", isReady);
+        log.tracef("KafkaCluster isReady = %s", isReady);
         return isReady;
     }
 
@@ -70,14 +70,14 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
             && kafkaCondition(kafka, c->c.getType().equals("NotReady")
             && c.getStatus().equals("True")
             && !c.getReason().equals("Creating"));
-        log.debugf("KafkaCluster isError = %s", isError);
+        log.tracef("KafkaCluster isError = %s", isError);
         return isError;
     }
 
     @Override
     public boolean isDeleted(ManagedKafka managedKafka) {
         boolean isDeleted = cachedKafka(managedKafka) == null;
-        log.debugf("KafkaCluster isDeleted = %s", isDeleted);
+        log.tracef("KafkaCluster isDeleted = %s", isDeleted);
         return isDeleted;
     }
 

--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -300,7 +300,7 @@ public class AdminServer extends AbstractAdminServer {
         if (openShiftClient != null) {
             isDeleted = isDeleted && cachedRoute(managedKafka) == null;
         }
-        log.debugf("Admin Server isDeleted = %s", isDeleted);
+        log.tracef("Admin Server isDeleted = %s", isDeleted);
         return isDeleted;
     }
 

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -729,7 +729,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
             isDeleted = isDeleted && cachedSecret(managedKafka, ssoClientSecretName(managedKafka)) == null &&
                     cachedSecret(managedKafka, ssoTlsSecretName(managedKafka)) == null;
         }
-        log.debugf("KafkaCluster isDeleted = %s", isDeleted);
+        log.tracef("KafkaCluster isDeleted = %s", isDeleted);
         return isDeleted;
     }
 

--- a/sync/src/main/java/org/bf2/sync/controlplane/ControlPlane.java
+++ b/sync/src/main/java/org/bf2/sync/controlplane/ControlPlane.java
@@ -104,7 +104,7 @@ public class ControlPlane {
     }
 
     private void updateAgentStatus() {
-        log.debug("Updating agnet status");
+        log.debug("Updating agent status");
         executorService.execute(() -> {
             ManagedKafkaAgent localManagedKafkaAgent = localLookup.getLocalManagedKafkaAgent();
             if (localManagedKafkaAgent != null) {

--- a/sync/src/main/java/org/bf2/sync/informer/CustomResourceEventHandler.java
+++ b/sync/src/main/java/org/bf2/sync/informer/CustomResourceEventHandler.java
@@ -29,16 +29,16 @@ final class CustomResourceEventHandler<T extends CustomResource<?,?>> implements
 
     @Override
     public void onAdd(T obj) {
-        if (log.isTraceEnabled()) {
-            log.tracef("Add event for %s", Cache.metaNamespaceKeyFunc(obj));
+        if (log.isDebugEnabled()) {
+            log.debugf("Add event for %s %s", Cache.metaNamespaceKeyFunc(obj), obj.getMetadata().getResourceVersion());
         }
         consumer.accept(null, obj);
     }
 
     @Override
     public void onDelete(T obj, boolean deletedFinalStateUnknown) {
-        if (log.isTraceEnabled()) {
-            log.tracef("Delete event for %s, with deletedStateUknown %s", Cache.metaNamespaceKeyFunc(obj),
+        if (log.isDebugEnabled()) {
+            log.debugf("Delete event for %s %s, with deletedStateUknown %s", Cache.metaNamespaceKeyFunc(obj), obj.getMetadata().getResourceVersion(),
                     deletedFinalStateUnknown);
         }
         // this will depend upon the delete strategy chosen
@@ -61,8 +61,8 @@ final class CustomResourceEventHandler<T extends CustomResource<?,?>> implements
         if (Objects.equals(oldObj.getMetadata().getResourceVersion(), newObj.getMetadata().getResourceVersion())) {
             return;
         }
-        if (log.isTraceEnabled()) {
-            log.tracef("Update event for %s", Cache.metaNamespaceKeyFunc(newObj));
+        if (log.isDebugEnabled()) {
+            log.debugf("Update event for %s %s", Cache.metaNamespaceKeyFunc(newObj), newObj.getMetadata().getResourceVersion());
         }
         consumer.accept(oldObj, newObj);
     }


### PR DESCRIPTION
Adjusting some of the logging based upon running in debug mode - the operand messages are quite voluminous at debug and don't convey enough information to be useful, so they are being moved to trace.