### PR TITLE
Change 'apply' to 'create' to deploy Strimzi successfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```shell
 kubectl create namespace kafka
-kubectl apply -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
+kubectl create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
 ```
 
 The first step is to install the operator allowing the `dekorate` plugin to generate the `ManagedKafka` CRD.


### PR DESCRIPTION
Using oc apply in a CRC gives error that one of the CRD's is over the maximum size. Proposing to change to 'create' rather than 'apply'.

**Error given:** 

The CustomResourceDefinition "kafkas.kafka.strimzi.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes