### PR TITLE
Upgrade to canary 0.0.6 and configure Kafka version on Sarama

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -135,6 +135,7 @@ public class Canary extends AbstractCanary {
         envVars.add(new EnvVarBuilder().withName("KAFKA_BOOTSTRAP_SERVERS").withValue(managedKafka.getMetadata().getName() + "-kafka-bootstrap:9092").build());
         envVars.add(new EnvVarBuilder().withName("RECONCILE_INTERVAL_MS").withValue("5000").build());
         envVars.add(new EnvVarBuilder().withName("EXPECTED_CLUSTER_SIZE").withValue(String.valueOf(KafkaCluster.KAFKA_BROKERS)).build());
+        envVars.add(new EnvVarBuilder().withName("KAFKA_VERSION").withValue(managedKafka.getSpec().getVersions().getKafka()).build());
         return envVars;
     }
 

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -8,7 +8,7 @@ quarkus.log.min-level=DEBUG
 quarkus.log.category."io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher".level=WARNING
 
 image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.0.7
-image.canary=quay.io/mk-ci-cd/strimzi-canary:0.0.5
+image.canary=quay.io/mk-ci-cd/strimzi-canary:0.0.6
 
 %dev.quarkus.log.console.level=DEBUG
 %dev.quarkus.log.category."org.bf2".level=DEBUG


### PR DESCRIPTION
This PR uses a latest release of canary that fixes following issues:

* https://github.com/strimzi/strimzi-canary/issues/38
* https://github.com/Shopify/sarama/issues/1927 (canary uses latest release of Sarama with this fix)

and it also set the right Kafka version for the underlying Sarama client (https://github.com/strimzi/strimzi-canary/issues/12)