### PR TITLE
Use TLS passthrough for adminserver using Kafka TLS secret cert+key

### DIFF
--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
@@ -14,7 +14,6 @@ import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
 import org.bf2.common.AgentResourceClient;
 import org.bf2.common.ConditionUtils;
 import org.bf2.operator.InformerManager;
-import org.bf2.operator.operands.ObservabilityManager;
 import org.bf2.operator.resources.v1alpha1.ClusterCapacity;
 import org.bf2.operator.resources.v1alpha1.ClusterCapacityBuilder;
 import org.bf2.operator.resources.v1alpha1.ClusterResizeInfo;
@@ -27,6 +26,7 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Type;
 import org.bf2.operator.resources.v1alpha1.NodeCounts;
 import org.bf2.operator.resources.v1alpha1.NodeCountsBuilder;
+import org.bf2.operator.secrets.ObservabilityManager;
 import org.jboss.logging.Logger;
 
 import javax.inject.Inject;

--- a/operator/src/main/java/org/bf2/operator/operands/dev/DevelopmentKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/dev/DevelopmentKafkaCluster.java
@@ -1,5 +1,6 @@
 package org.bf2.operator.operands.dev;
 
+import io.javaoperatorsdk.operator.api.Context;
 import io.quarkus.arc.properties.IfBuildProperty;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaBuilder;
@@ -18,6 +19,7 @@ import org.bf2.common.OperandUtils;
 import org.bf2.operator.operands.AbstractKafkaCluster;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.secrets.ImagePullSecretManager;
+import org.bf2.operator.secrets.SecuritySecretManager;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -34,7 +36,27 @@ import java.util.Map;
 public class DevelopmentKafkaCluster extends AbstractKafkaCluster {
 
     @Inject
+    protected SecuritySecretManager secretManager;
+
+    @Inject
     protected ImagePullSecretManager imagePullSecretManager;
+
+    @Override
+    public void createOrUpdate(ManagedKafka managedKafka) {
+        super.createOrUpdate(managedKafka);
+        secretManager.createOrUpdate(managedKafka);
+    }
+
+    @Override
+    public void delete(ManagedKafka managedKafka, Context<ManagedKafka> context) {
+        super.delete(managedKafka, context);
+        secretManager.delete(managedKafka);
+    }
+
+    @Override
+    public boolean isDeleted(ManagedKafka managedKafka) {
+        return super.isDeleted(managedKafka) && secretManager.isDeleted(managedKafka);
+    }
 
     /* test */
     @Override

--- a/operator/src/main/java/org/bf2/operator/operands/test/NoDeploymentKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/test/NoDeploymentKafkaCluster.java
@@ -63,16 +63,9 @@ public class NoDeploymentKafkaCluster extends org.bf2.operator.operands.KafkaClu
                 .withName(kafkaClusterName(managedKafka))
                 .delete();
 
+        secretManager.delete(managedKafka);
         configMapResource(managedKafka, kafkaMetricsConfigMapName(managedKafka)).delete();
         configMapResource(managedKafka, zookeeperMetricsConfigMapName(managedKafka)).delete();
-
-        if (isKafkaExternalCertificateEnabled) {
-            secretResource(managedKafka, kafkaTlsSecretName(managedKafka)).delete();
-        }
-        if (isKafkaAuthenticationEnabled) {
-            secretResource(managedKafka, ssoClientSecretName(managedKafka)).delete();
-            secretResource(managedKafka, ssoTlsSecretName(managedKafka)).delete();
-        }
     }
 
     @Override

--- a/operator/src/main/java/org/bf2/operator/secrets/ObservabilityManager.java
+++ b/operator/src/main/java/org/bf2/operator/secrets/ObservabilityManager.java
@@ -1,4 +1,4 @@
-package org.bf2.operator.operands;
+package org.bf2.operator.secrets;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;

--- a/operator/src/main/java/org/bf2/operator/secrets/SecuritySecretManager.java
+++ b/operator/src/main/java/org/bf2/operator/secrets/SecuritySecretManager.java
@@ -1,0 +1,174 @@
+package org.bf2.operator.secrets;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.bf2.common.OperandUtils;
+import org.bf2.operator.InformerManager;
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class SecuritySecretManager {
+
+    @Inject
+    private KubernetesClient kubernetesClient;
+
+    @Inject
+    private InformerManager informerManager;
+
+    @ConfigProperty(name = "kafka.authentication.enabled", defaultValue = "false")
+    private boolean isKafkaAuthenticationEnabled;
+
+    @ConfigProperty(name = "kafka.external.certificate.enabled", defaultValue = "false")
+    private boolean isKafkaExternalCertificateEnabled;
+
+    public static String kafkaTlsSecretName(ManagedKafka managedKafka) {
+        return managedKafka.getMetadata().getName() + "-tls-secret";
+    }
+
+    public static String ssoClientSecretName(ManagedKafka managedKafka) {
+        return managedKafka.getMetadata().getName() + "-sso-secret";
+    }
+
+    public static String ssoTlsSecretName(ManagedKafka managedKafka) {
+        return managedKafka.getMetadata().getName() + "-sso-cert";
+    }
+
+    public static String kafkaClusterNamespace(ManagedKafka managedKafka) {
+        return managedKafka.getMetadata().getNamespace();
+    }
+
+    public boolean isDeleted(ManagedKafka managedKafka) {
+        boolean isDeleted = true;
+
+        if (isKafkaExternalCertificateEnabled) {
+            isDeleted = cachedSecret(managedKafka, kafkaTlsSecretName(managedKafka)) == null;
+        }
+
+        if (isKafkaAuthenticationEnabled) {
+            isDeleted = isDeleted && cachedSecret(managedKafka, ssoClientSecretName(managedKafka)) == null &&
+                    cachedSecret(managedKafka, ssoTlsSecretName(managedKafka)) == null;
+        }
+
+        return isDeleted;
+    }
+
+    public void createOrUpdate(ManagedKafka managedKafka) {
+        if (isKafkaExternalCertificateEnabled) {
+            Secret currentKafkaTlsSecret = cachedSecret(managedKafka, kafkaTlsSecretName(managedKafka));
+            Secret kafkaTlsSecret = kafkaTlsSecretFrom(managedKafka, currentKafkaTlsSecret);
+            createOrUpdate(kafkaTlsSecret);
+        }
+
+        if (isKafkaAuthenticationEnabled) {
+            Secret currentSsoClientSecret = cachedSecret(managedKafka, ssoClientSecretName(managedKafka));
+            Secret ssoClientSecret = ssoClientSecretFrom(managedKafka, currentSsoClientSecret);
+            createOrUpdate(ssoClientSecret);
+
+            Secret currentSsoTlsSecret = cachedSecret(managedKafka, ssoTlsSecretName(managedKafka));
+            Secret ssoTlsSecret = ssoTlsSecretFrom(managedKafka, currentSsoTlsSecret);
+            createOrUpdate(ssoTlsSecret);
+        }
+    }
+
+    public void delete(ManagedKafka managedKafka) {
+        if (isKafkaExternalCertificateEnabled) {
+            secretResource(managedKafka, kafkaTlsSecretName(managedKafka)).delete();
+        }
+
+        if (isKafkaAuthenticationEnabled) {
+            secretResource(managedKafka, ssoClientSecretName(managedKafka)).delete();
+            secretResource(managedKafka, ssoTlsSecretName(managedKafka)).delete();
+        }
+    }
+
+    private Secret cachedSecret(ManagedKafka managedKafka, String name) {
+        return informerManager.getLocalSecret(kafkaClusterNamespace(managedKafka), name);
+    }
+
+    private Resource<Secret> secretResource(ManagedKafka managedKafka, String name) {
+        return kubernetesClient.secrets()
+                .inNamespace(kafkaClusterNamespace(managedKafka))
+                .withName(name);
+    }
+
+    private void createOrUpdate(Secret secret) {
+        // Secret resource doesn't exist, has to be created
+        if (kubernetesClient.secrets()
+                .inNamespace(secret.getMetadata().getNamespace())
+                .withName(secret.getMetadata().getName()).get() == null) {
+            kubernetesClient.secrets().inNamespace(secret.getMetadata().getNamespace()).createOrReplace(secret);
+        // Secret resource already exists, has to be updated
+        } else {
+            kubernetesClient.secrets()
+                    .inNamespace(secret.getMetadata().getNamespace())
+                    .withName(secret.getMetadata().getName())
+                    .patch(secret);
+        }
+    }
+
+    private static Secret buildSecretFrom(String name, String type, ManagedKafka managedKafka, Secret current, Map<String, String> dataSource) {
+        SecretBuilder builder = current != null ? new SecretBuilder(current) : new SecretBuilder();
+
+        Map<String, String> data = dataSource.entrySet()
+                .stream()
+                .map(entry -> Map.entry(entry.getKey(), encode(entry.getValue())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        Secret secret = builder
+                .editOrNewMetadata()
+                    .withNamespace(kafkaClusterNamespace(managedKafka))
+                    .withName(name)
+                    .withLabels(OperandUtils.getDefaultLabels())
+                .endMetadata()
+                .withType(type)
+                .withData(data)
+                .build();
+
+        // setting the ManagedKafka has owner of the Secret resource is needed
+        // by the operator sdk to handle events on the Secret resource properly
+        OperandUtils.setAsOwner(managedKafka, secret);
+
+        return secret;
+    }
+
+    private static Secret kafkaTlsSecretFrom(ManagedKafka managedKafka, Secret current) {
+        return buildSecretFrom(kafkaTlsSecretName(managedKafka),
+                               "kubernetes.io/tls",
+                               managedKafka,
+                               current,
+                               Map.of("tls.crt", managedKafka.getSpec().getEndpoint().getTls().getCert(),
+                                      "tls.key", managedKafka.getSpec().getEndpoint().getTls().getKey()));
+    }
+
+    private static Secret ssoClientSecretFrom(ManagedKafka managedKafka, Secret current) {
+        return buildSecretFrom(ssoClientSecretName(managedKafka),
+                               "Opaque",
+                               managedKafka,
+                               current,
+                               Map.of("ssoClientSecret", managedKafka.getSpec().getOauth().getClientSecret()));
+    }
+
+    private static Secret ssoTlsSecretFrom(ManagedKafka managedKafka, Secret current) {
+        return buildSecretFrom(ssoTlsSecretName(managedKafka),
+                               "Opaque",
+                               managedKafka,
+                               current,
+                               Map.of("keycloak.crt", managedKafka.getSpec().getOauth().getTlsTrustedCertificate()));
+    }
+
+    private static String encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+}

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -2,11 +2,12 @@ agent.status.interval=60s
 
 kafka.authentication.enabled=true
 kafka.external.certificate.enabled=true
+
 # can be removed after https://github.com/fabric8io/kubernetes-client/pull/2993
 quarkus.log.category."io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher".level=WARNING
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %x %s%e%n
 
-image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.0.7
+image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.0.8
 image.canary=quay.io/mk-ci-cd/strimzi-canary:0.0.6
 
 %dev.quarkus.log.console.level=DEBUG

--- a/operator/src/test/java/org/bf2/operator/secrets/ObservabilityManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/secrets/ObservabilityManagerTest.java
@@ -1,4 +1,4 @@
-package org.bf2.operator.operands;
+package org.bf2.operator.secrets;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/systemtest/src/main/java/org/bf2/systemtest/framework/SecurityUtils.java
+++ b/systemtest/src/main/java/org/bf2/systemtest/framework/SecurityUtils.java
@@ -1,0 +1,109 @@
+package org.bf2.systemtest.framework;
+
+import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.cert.X509ExtensionUtils;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DigestCalculator;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.bc.BcDigestCalculatorProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SecurityUtils {
+
+    public static final String CERT = "cert";
+    public static final String KEY = "key";
+
+    public static void main(String[] args) throws Exception {
+        var config = getTLSConfig("example.com");
+        System.out.println(config);
+    }
+
+    public static Map<String, String> getTLSConfig(String domain) throws Exception {
+        Map<String, String> config = new HashMap<>(2);
+
+        try {
+            java.security.KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048);
+            KeyPair keyPair = keyPairGenerator.generateKeyPair();
+            PrivateKey privateKey = keyPair.getPrivate();
+            X509Certificate selfCert = generate(keyPair, "SHA256WITHRSA", domain, 1);
+
+            StringWriter keyWriter = new StringWriter();
+            try (JcaPEMWriter writer = new JcaPEMWriter(keyWriter)) {
+                writer.writeObject(privateKey);
+            }
+            config.put(KEY, keyWriter.toString());
+
+            StringWriter certWriter = new StringWriter();
+            try (JcaPEMWriter writer = new JcaPEMWriter(certWriter)) {
+                writer.writeObject(selfCert);
+            }
+            config.put(CERT, certWriter.toString());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new AssertionError(e.getMessage());
+        }
+
+        return config;
+    }
+
+    private static X509Certificate generate(final KeyPair keyPair,
+                                           final String hashAlgorithm,
+                                           final String domain,
+                                           final int days)
+            throws OperatorCreationException, CertificateException, CertIOException {
+
+        final Instant now = Instant.now();
+        final Date notBefore = Date.from(now);
+        final Date notAfter = Date.from(now.plus(Duration.ofDays(days)));
+        final X500Name x500Issuer = new X500Name("CN=" + domain);
+        final X500Name x500Name = new X500Name("CN=*." + domain);
+        final SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
+        final DigestCalculator digCalc = new BcDigestCalculatorProvider().get(new AlgorithmIdentifier(OIWObjectIdentifiers.idSHA1));
+        final SubjectKeyIdentifier subject = new X509ExtensionUtils(digCalc).createSubjectKeyIdentifier(publicKeyInfo);
+        final AuthorityKeyIdentifier authority = new X509ExtensionUtils(digCalc).createAuthorityKeyIdentifier(publicKeyInfo);
+        final X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(x500Issuer,
+                                                                                            BigInteger.valueOf(now.toEpochMilli()),
+                                                                                            notBefore,
+                                                                                            notAfter,
+                                                                                            x500Name,
+                                                                                            keyPair.getPublic());
+        certificateBuilder.addExtension(Extension.subjectKeyIdentifier, false, subject);
+        certificateBuilder.addExtension(Extension.authorityKeyIdentifier, false, authority);
+        certificateBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+
+        final ContentSigner contentSigner = new JcaContentSignerBuilder(hashAlgorithm).build(keyPair.getPrivate());
+
+        return new JcaX509CertificateConverter()
+                                                .setProvider(new BouncyCastleProvider())
+                                                .getCertificate(certificateBuilder.build(contentSigner));
+    }
+
+}

--- a/systemtest/src/main/java/org/bf2/systemtest/framework/resource/ManagedKafkaResourceType.java
+++ b/systemtest/src/main/java/org/bf2/systemtest/framework/resource/ManagedKafkaResourceType.java
@@ -7,11 +7,13 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatus;
+import org.bf2.systemtest.framework.SecurityUtils;
 import org.bf2.test.Environment;
 import org.bf2.test.TestUtils;
 import org.bf2.test.k8s.KubeClient;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ManagedKafkaResourceType implements ResourceType<ManagedKafka> {
@@ -102,10 +104,23 @@ public class ManagedKafkaResourceType implements ResourceType<ManagedKafka> {
 
     /**
      * get common default managedkafka instance
+     * @throws Exception
      */
-    public static ManagedKafka getDefault(String namespace, String appName) {
+    public static ManagedKafka getDefault(String namespace, String appName) throws Exception {
+        final String tlsCert;
+        final String tlsKey;
+
+        if (Environment.DUMMY_CERT.equals(Environment.ENDPOINT_TLS_CERT)) {
+            Map<String, String> tlsConfig = SecurityUtils.getTLSConfig(Environment.BOOTSTRAP_HOST_DOMAIN);
+            tlsCert = tlsConfig.get(SecurityUtils.CERT);
+            tlsKey = tlsConfig.get(SecurityUtils.KEY);
+        } else {
+            tlsCert = Environment.ENDPOINT_TLS_CERT;
+            tlsKey = Environment.ENDPOINT_TLS_KEY;
+        }
+
         return ManagedKafka.getDefault(appName, namespace, Environment.BOOTSTRAP_HOST_DOMAIN,
-                Environment.ENDPOINT_TLS_CERT, Environment.ENDPOINT_TLS_KEY, Environment.OAUTH_CLIENT_ID,
+                                       tlsCert, tlsKey, Environment.OAUTH_CLIENT_ID,
                 Environment.OAUTH_TLS_CERT, Environment.OAUTH_CLIENT_SECRET, Environment.OAUTH_USER_CLAIM,
                 Environment.OAUTH_JWKS_ENDPOINT, Environment.OAUTH_TOKEN_ENDPOINT, Environment.OAUTH_ISSUER_ENDPOINT);
     }

--- a/systemtest/src/test/java/org/bf2/systemtest/integration/ManagedKafkaST.java
+++ b/systemtest/src/test/java/org/bf2/systemtest/integration/ManagedKafkaST.java
@@ -78,7 +78,7 @@ public class ManagedKafkaST extends AbstractST {
     }
 
     @ParallelTest
-    void testDeleteDeployedResources(ExtensionContext extensionContext) {
+    void testDeleteDeployedResources(ExtensionContext extensionContext) throws Exception {
         String mkAppName = "mk-test-resource-recovery";
 
         var kafkacli = kube.client().customResources(Kafka.class, KafkaList.class);

--- a/systemtest/src/test/java/org/bf2/systemtest/integration/SmokeST.java
+++ b/systemtest/src/test/java/org/bf2/systemtest/integration/SmokeST.java
@@ -51,7 +51,7 @@ public class SmokeST extends AbstractST {
 
     @Tag(TestTags.SMOKE)
     @ParallelTest
-    void testCreateManagedKafkaByOperator(ExtensionContext extensionContext) {
+    void testCreateManagedKafkaByOperator(ExtensionContext extensionContext) throws Exception {
         String mkAppName = "mk-test-create";
 
         LOGGER.info("Create namespace");

--- a/test/src/main/java/org/bf2/test/Environment.java
+++ b/test/src/main/java/org/bf2/test/Environment.java
@@ -56,6 +56,7 @@ public class Environment {
      */
     public static final String SUITE_ROOT = System.getProperty("user.dir");
     public static final Path LOG_DIR = getOrDefault(LOG_DIR_ENV, Paths::get, Paths.get(SUITE_ROOT, "target", "logs")).resolve("test-run-" + DATE_FORMAT.format(LocalDateTime.now()));
+    public static final String DUMMY_CERT = "cert";
 
     public static final String BOOTSTRAP_HOST_DOMAIN = getOrDefault(BOOTSTRAP_HOST_DOMAIN_ENV, "my-domain.com");
     public static final String OAUTH_CLIENT_SECRET = getOrDefault(OAUTH_CLIENT_SECRET_ENV, "client_secret");
@@ -64,8 +65,8 @@ public class Environment {
     public static final String OAUTH_TOKEN_ENDPOINT = getOrDefault(OAUTH_TOKEN_ENDPOINT_ENV, "token_ednpoint");
     public static final String OAUTH_ISSUER_ENDPOINT = getOrDefault(OAUTH_ISSUER_ENDPOINT_ENV, "issuer_endpoint");
     public static final String OAUTH_CLIENT_ID = getOrDefault(OAUTH_CLIENT_ID_ENV, "client_id");
-    public static final String OAUTH_TLS_CERT = getOrDefault(OAUTH_TLS_CERT_ENV, "cert");
-    public static final String ENDPOINT_TLS_CERT = getOrDefault(ENDPOINT_TLS_CERT_ENV, "cert");
+    public static final String OAUTH_TLS_CERT = getOrDefault(OAUTH_TLS_CERT_ENV, DUMMY_CERT);
+    public static final String ENDPOINT_TLS_CERT = getOrDefault(ENDPOINT_TLS_CERT_ENV, DUMMY_CERT);
     public static final String ENDPOINT_TLS_KEY = getOrDefault(ENDPOINT_TLS_KEY_ENV, "key");
 
     public static final boolean SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, Boolean::parseBoolean, false);


### PR DESCRIPTION
Use TLS passthrough for adminserver using Kafka TLS secret cert+key

- Remove option to disable TLS (Kafka and Admin Server)
- Move TLS secret management to `AbstractKafkaCluster`
- Uses a generated cert/key in systemtests using Bouncy Castle (it seems there is no standard way to do this with just the JDK unfortunately).

~~This still requires some additional testing in OpenShift, but opening the PR in case anyone spots something that could be a problem.~~

CC: @shawkins , @k-wall , @rareddy 