### PR TITLE
marking crd fields as required

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,6 +23,10 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -32,6 +32,22 @@ public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaS
     public static final String ID = BF2_DOMAIN + "id";
     public static final String PLACEMENT_ID = BF2_DOMAIN + "placementId";
 
+    @Override
+    protected ManagedKafkaSpec initSpec() {
+        return new ManagedKafkaSpec();
+    }
+
+    /**
+     * A null value will be treated as empty instead
+     */
+    @Override
+    public void setSpec(ManagedKafkaSpec spec) {
+        if (spec == null) {
+            spec = initSpec();
+        }
+        super.setSpec(spec);
+    }
+
     @JsonIgnore
     public String getId() {
         return getOrCreateAnnotations().get(ID);

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAgent.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAgent.java
@@ -18,4 +18,20 @@ public class ManagedKafkaAgent extends CustomResource<ManagedKafkaAgentSpec, Man
         implements Namespaced {
     private static final long serialVersionUID = 1L;
 
+    @Override
+    protected ManagedKafkaAgentSpec initSpec() {
+        return new ManagedKafkaAgentSpec();
+    }
+
+    /**
+     * A null value will be treated as empty instead
+     */
+    @Override
+    public void setSpec(ManagedKafkaAgentSpec spec) {
+        if (spec == null) {
+            spec = initSpec();
+        }
+        super.setSpec(spec);
+    }
+
 }

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAgentSpec.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAgentSpec.java
@@ -4,6 +4,8 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
 @Buildable(
         builderPackage = "io.fabric8.kubernetes.api.builder",
         editableEnabled = false
@@ -11,6 +13,7 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public class ManagedKafkaAgentSpec {
+    @NotNull
     ObservabilityConfiguration observability;
 
     public ObservabilityConfiguration getObservability() {

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAuthenticationOAuth.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAuthenticationOAuth.java
@@ -5,6 +5,8 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Defines the configuration for the Kafka instance authentication against an OAuth server
  */
@@ -18,6 +20,7 @@ import lombok.ToString;
 public class ManagedKafkaAuthenticationOAuth {
 
     private String clientId;
+    @NotNull
     private String clientSecret;
     private String tokenEndpointURI;
     private String jwksEndpointURI;

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaEndpoint.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaEndpoint.java
@@ -5,6 +5,8 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Defines the endpoint related information used for reaching the ManagedKafka instance
  */
@@ -17,6 +19,7 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ManagedKafkaEndpoint {
 
+    @NotNull
     private String bootstrapServerHost;
     private TlsKeyPair tls;
 

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaSpec.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaSpec.java
@@ -4,6 +4,8 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Defines the specification of the ManagedKafka instance
  */
@@ -15,17 +17,28 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class ManagedKafkaSpec {
 
-    private ManagedKafkaCapacity capacity;
+    private ManagedKafkaCapacity capacity = new ManagedKafkaCapacity();
     private ManagedKafkaAuthenticationOAuth oauth;
+    @NotNull
     private ManagedKafkaEndpoint endpoint;
+    @NotNull
     private Versions versions;
     private boolean deleted;
 
+    /**
+     * Never null
+     */
     public ManagedKafkaCapacity getCapacity() {
         return capacity;
     }
 
+    /**
+     * A null value will be treated as empty instead
+     */
     public void setCapacity(ManagedKafkaCapacity capacity) {
+        if (capacity == null) {
+            capacity = new ManagedKafkaCapacity();
+        }
         this.capacity = capacity;
     }
 

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ObservabilityConfiguration.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ObservabilityConfiguration.java
@@ -5,6 +5,8 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
 @Buildable(
         builderPackage = "io.fabric8.kubernetes.api.builder",
         editableEnabled = false
@@ -13,9 +15,10 @@ import lombok.ToString;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ObservabilityConfiguration {
-
+    @NotNull
     private String accessToken;
     private String channel;
+    @NotNull
     private String repository;
     private String tag;
 

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/TlsKeyPair.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/TlsKeyPair.java
@@ -5,6 +5,8 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Represents a TLS keys pair, both public (signed certificate) and private
  */
@@ -17,7 +19,9 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TlsKeyPair {
 
+    @NotNull
     private String cert;
+    @NotNull
     private String key;
 
     public String getCert() {

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/Versions.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/Versions.java
@@ -5,6 +5,8 @@ import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import javax.validation.constraints.NotNull;
+
 /**
  * Represents different versions supported by the ManagedKafka instance
  */
@@ -17,7 +19,9 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Versions {
 
+    @NotNull
     private String kafka;
+    @NotNull
     private String strimzi;
 
     public String getKafka() {

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -59,7 +59,6 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaAuthenticationOAuth;
 import org.bf2.operator.secrets.ImagePullSecretManager;
 import org.bf2.operator.secrets.SecuritySecretManager;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -117,12 +116,6 @@ public class KafkaCluster extends AbstractKafkaCluster {
 
     @Inject
     protected SecuritySecretManager secretManager;
-
-    @ConfigProperty(name = "kafka.authentication.enabled", defaultValue = "false")
-    protected boolean isKafkaAuthenticationEnabled;
-
-    @ConfigProperty(name = "kafka.external.certificate.enabled", defaultValue = "false")
-    protected boolean isKafkaExternalCertificateEnabled;
 
     @Inject
     protected ImagePullSecretManager imagePullSecretManager;
@@ -263,7 +256,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
     }
 
     protected CertSecretSource getSsoTlsCertSecretSource(ManagedKafka managedKafka) {
-        if (!isKafkaAuthenticationEnabled || managedKafka.getSpec().getOauth().getTlsTrustedCertificate() == null) {
+        if (!SecuritySecretManager.isKafkaAuthenticationEnabled(managedKafka) || managedKafka.getSpec().getOauth().getTlsTrustedCertificate() == null) {
             return null;
         }
         return new CertSecretSourceBuilder()
@@ -273,7 +266,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
     }
 
     protected CertAndKeySecretSource getTlsCertAndKeySecretSource(ManagedKafka managedKafka) {
-        if (!isKafkaExternalCertificateEnabled) {
+        if (!SecuritySecretManager.isKafkaExternalCertificateEnabled(managedKafka)) {
             return null;
         }
         return new CertAndKeySecretSourceBuilder()
@@ -448,7 +441,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         KafkaListenerAuthentication plainOverOauthAuthenticationListener = null;
         KafkaListenerAuthentication oauthAuthenticationListener = null;
 
-        if (isKafkaAuthenticationEnabled) {
+        if (SecuritySecretManager.isKafkaAuthenticationEnabled(managedKafka)) {
             ManagedKafkaAuthenticationOAuth managedKafkaAuthenticationOAuth = managedKafka.getSpec().getOauth();
 
             CertSecretSource ssoTlsCertSecretSource = getSsoTlsCertSecretSource(managedKafka);

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -1,8 +1,5 @@
 agent.status.interval=60s
 
-kafka.authentication.enabled=true
-kafka.external.certificate.enabled=true
-
 # can be removed after https://github.com/fabric8io/kubernetes-client/pull/2993
 quarkus.log.category."io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher".level=WARNING
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %x %s%e%n

--- a/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
@@ -36,6 +36,7 @@ public class AdminServerTest {
                                 .build())
                 .withSpec(
                         new ManagedKafkaSpecBuilder()
+                                .withNewEndpoint().endEndpoint()
                                 .withNewVersions()
                                 .withKafka("2.6.0")
                                 .endVersions()

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -47,10 +47,6 @@ spec:
         enableOauthBearer: true
         type: "oauth"
       configuration:
-        brokerCertChainAndKey:
-          secretName: "test-mk-tls-secret"
-          certificate: "tls.crt"
-          key: "tls.key"
         bootstrap:
           host: "xxx.yyy.zzz"
         brokers:

--- a/sync/src/main/java/org/bf2/sync/ManagedKafkaAgentSync.java
+++ b/sync/src/main/java/org/bf2/sync/ManagedKafkaAgentSync.java
@@ -13,6 +13,8 @@ import org.jboss.logging.Logger;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import java.util.Objects;
+
 @ApplicationScoped
 public class ManagedKafkaAgentSync {
 
@@ -37,6 +39,7 @@ public class ManagedKafkaAgentSync {
             return;
         }
         ManagedKafkaAgent managedKafkaAgent = controlPlane.getManagedKafkaAgent();
+        Objects.requireNonNull(managedKafkaAgent);
         createOrUpdateManagedKafkaAgent(managedKafkaAgent);
     }
 
@@ -52,7 +55,7 @@ public class ManagedKafkaAgentSync {
             remoteAgent.getMetadata().setName(AgentResourceClient.RESOURCE_NAME);
             this.agentClient.create(remoteAgent);
             log.infof("ManagedKafkaAgent CR created");
-        } else if (remoteAgent.getSpec() != null && !remoteAgent.getSpec().equals(resource.getSpec())) {
+        } else if (!remoteAgent.getSpec().equals(resource.getSpec())) {
             this.agentClient.edit(this.agentClient.getNamespace(), AgentResourceClient.RESOURCE_NAME, mka -> {
                 mka.setSpec(remoteAgent.getSpec());
                 return mka;


### PR DESCRIPTION
This is for https://issues.redhat.com/browse/MGDSTRM-3288

Based upon our usage, this appears the set of fields / objects that are required.  In some cases not having the field will produce NPEs - such as when the spec is missing.  In other cases there's just no explicit null check and a null value could be used directly, like in the oauth properties.

Please review this so that we can identify which fields should have default handling and/or aren't actually required.

Note that due to https://github.com/fabric8io/kubernetes-client/issues/3096 we can't yet mark the spec as required.

cc @rareddy @ppatierno @k-wall 