### PR TITLE
Set UTC timezone on Canary for proper logging

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -144,6 +144,7 @@ public class Canary extends AbstractCanary {
         envVars.add(new EnvVarBuilder().withName("RECONCILE_INTERVAL_MS").withValue("5000").build());
         envVars.add(new EnvVarBuilder().withName("EXPECTED_CLUSTER_SIZE").withValue(String.valueOf(KafkaCluster.KAFKA_BROKERS)).build());
         envVars.add(new EnvVarBuilder().withName("KAFKA_VERSION").withValue(managedKafka.getSpec().getVersions().getKafka()).build());
+        envVars.add(new EnvVarBuilder().withName("TZ").withValue("UTC").build());
 
         EnvVarSource saramaLogEnabled =
                 new EnvVarSourceBuilder()


### PR DESCRIPTION
Currently the glog library used for canary logging doesn't support a way to change the timezone, so it's logging using local time which is not so helpful.
This PR changes the timezone at system level via the `TZ` env var so that the logging will be in UTC as well.