### PR TITLE
Workaround to apply delete propagation backgroud

### DIFF
--- a/common/src/main/java/org/bf2/common/AbstractCustomResourceClient.java
+++ b/common/src/main/java/org/bf2/common/AbstractCustomResourceClient.java
@@ -1,5 +1,6 @@
 package org.bf2.common;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.CustomResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -36,6 +37,7 @@ public abstract class AbstractCustomResourceClient<T extends CustomResource<?, ?
         resourceClient
                 .inNamespace(namespace)
                 .withName(name)
+                .withPropagationPolicy(DeletionPropagation.BACKGROUND)
                 .delete();
     }
 


### PR DESCRIPTION
It seems that with newer fabric8 version, the deletion propagation was changed to "orphan" and not "background" anymore.
It's causing this problem https://github.com/strimzi/strimzi-kafka-operator/issues/5042 deleting a Kafka custom resource from the operator.
More info are also here: https://github.com/quarkiverse/quarkus-operator-sdk/issues/48
