### PR TITLE
Update version of strimzi in default mk resource

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -90,7 +90,7 @@ public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaS
                         .build())
                 .withSpec(new ManagedKafkaSpecBuilder().withNewVersions()
                         .withKafka("2.7.0")
-                        .withStrimzi("0.21.1")
+                        .withStrimzi("0.22.1")
                         .endVersions()
                         .withNewCapacity()
                         .withNewIngressEgressThroughputPerSec("4Mi")


### PR DESCRIPTION
In case of testing on OSD with systemtest suite we need to bump strimzi version in default mk resource, otherwise current strimzi operator does not care about older version and kafka is not created