### PR TITLE
Added metrics to expose custom metrics from quota plugin

### DIFF
--- a/operator/src/main/resources/kafka-metrics.yaml
+++ b/operator/src/main/resources/kafka-metrics.yaml
@@ -223,3 +223,6 @@ data:
       - pattern: kafka.server<type=Fetch, quota.type=FETCH><>throttle-time
         name: kafka_server_fetch_throttle_time
         type: GAUGE
+      - pattern : io.strimzi.kafka.quotas<type=(.+), name=(.+)><>Value
+        name: kafka_broker_quota_$2
+        type: GAUGE


### PR DESCRIPTION
For work done on below link. Need to expose the metrics provided by the below change for used_bytes and limit_bytes.

https://github.com/strimzi/kafka-quotas-plugin/pull/6