### PR TITLE
DrainCleaner webhook auto configuration 

### DIFF
--- a/operator/src/main/java/org/bf2/operator/DrainCleanerManager.java
+++ b/operator/src/main/java/org/bf2/operator/DrainCleanerManager.java
@@ -1,0 +1,76 @@
+package org.bf2.operator;
+
+import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfiguration;
+import io.fabric8.kubernetes.api.model.admissionregistration.v1.ValidatingWebhookConfigurationList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.quarkus.runtime.Startup;
+import org.bf2.common.ResourceInformer;
+import org.bf2.operator.operands.KafkaCluster;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@Startup
+@ApplicationScoped
+public class DrainCleanerManager {
+    @Inject
+    Logger log;
+
+    @Inject
+    InformerManager informerManager;
+
+    @Inject
+    KafkaCluster kafkaCluster;
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @ConfigProperty(name = "drain.cleaner.webhook.label.key")
+    String drainCleanerWebhookLabelKey;
+
+    @ConfigProperty(name = "drain.cleaner.webhook.label.value")
+    String drainCleanerWebhookLabelValue;
+
+    private volatile boolean drainCleanerWebhookFound;
+
+    public boolean isDrainCleanerWebhookFound() {
+        return drainCleanerWebhookFound;
+    }
+
+    @PostConstruct
+    protected void onStart() {
+        FilterWatchListDeletable<ValidatingWebhookConfiguration, ValidatingWebhookConfigurationList> withLabel =
+        kubernetesClient.admissionRegistration()
+                .v1()
+                .validatingWebhookConfigurations()
+                .withLabel(drainCleanerWebhookLabelKey, drainCleanerWebhookLabelValue);
+
+        ResourceInformer.start(ValidatingWebhookConfiguration.class,
+            withLabel,
+            new ResourceEventHandler<ValidatingWebhookConfiguration>() {
+                @Override
+                public void onAdd(ValidatingWebhookConfiguration obj) {
+                    log.debugf("Add event received for webhook %s", obj.getMetadata().getName());
+                    drainCleanerWebhookFound = true;
+                    informerManager.resyncKafkas();
+                }
+
+                @Override
+                public void onDelete(ValidatingWebhookConfiguration obj, boolean deletedFinalStateUnknown) {
+                    log.debugf("Delete event received for webhook %s", obj.getMetadata().getName());
+                    drainCleanerWebhookFound = false;
+                    informerManager.resyncKafkas();
+                }
+
+                @Override
+                public void onUpdate(ValidatingWebhookConfiguration oldObj, ValidatingWebhookConfiguration newObj) {
+                    // do nothing (the OLM manages this resource)
+                }
+            });
+    }
+}

--- a/operator/src/main/java/org/bf2/operator/InformerManager.java
+++ b/operator/src/main/java/org/bf2/operator/InformerManager.java
@@ -24,6 +24,8 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import java.util.List;
+
 @Startup
 @ApplicationScoped
 public class InformerManager {
@@ -107,5 +109,16 @@ public class InformerManager {
                 && configMapInformer.isReady()
                 && secretInformer.isReady()
                 && (!isOpenShift() || routeInformer.isReady());
+    }
+
+    /**
+     * Trigger Kafka CR changes following external context changes.
+     */
+    public void resyncKafkas() {
+        List<Kafka> kafkaList = kafkaInformer.getList();
+        log.debugf("Kafka instances to be resynced: %d", kafkaList.size());
+        kafkaList.forEach(k -> {
+            this.eventSource.onUpdate(k, k);
+        });
     }
 }

--- a/operator/src/main/java/org/bf2/operator/events/ResourceEventSource.java
+++ b/operator/src/main/java/org/bf2/operator/events/ResourceEventSource.java
@@ -9,8 +9,6 @@ import org.jboss.logging.Logger;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import java.util.Objects;
-
 @ApplicationScoped
 public class ResourceEventSource extends AbstractEventSource implements ResourceEventHandler<HasMetadata> {
 
@@ -25,9 +23,6 @@ public class ResourceEventSource extends AbstractEventSource implements Resource
 
     @Override
     public void onUpdate(HasMetadata oldResource, HasMetadata newResource) {
-        if (Objects.equals(oldResource.getMetadata().getResourceVersion(), newResource.getMetadata().getResourceVersion())) {
-            return; // no need to handle an event where nothing has changed
-        }
         log.debugf("Update event received for %s %s/%s", oldResource.getKind(), oldResource.getMetadata().getNamespace(), oldResource.getMetadata().getName());
         handleEvent(newResource, Watcher.Action.MODIFIED);
     }

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -105,6 +105,15 @@ rules:
       - delete
       - patch
       - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      # created by the OLM for the DrainCleaner
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -7,6 +7,10 @@ quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %x %s%
 image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.0.10
 image.canary=quay.io/mk-ci-cd/strimzi-canary:0.0.6
 
+# unique label required to identify the DrainCleaner's validating webhook
+drain.cleaner.webhook.label.key=olm.webhook-description-generate-name
+drain.cleaner.webhook.label.value=strimzi-drain-cleaner.kb.io
+
 %dev.quarkus.log.console.level=DEBUG
 %dev.quarkus.log.category."org.bf2".level=DEBUG
 

--- a/operator/src/test/java/org/bf2/operator/MockProfile.java
+++ b/operator/src/test/java/org/bf2/operator/MockProfile.java
@@ -2,14 +2,18 @@ package org.bf2.operator;
 
 import io.quarkus.test.junit.QuarkusTestProfile;
 
-import java.util.Collections;
 import java.util.Map;
+
+import static java.util.Map.entry;
 
 public class MockProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Collections.singletonMap("quarkus.scheduler.enabled", "false");
+        Map<String, String> overrides = Map.ofEntries(
+            entry("quarkus.scheduler.enabled", "false")
+        );
+        return overrides;
     }
 
 }

--- a/operator/src/test/java/org/bf2/operator/utils/ManagedKafkaUtils.java
+++ b/operator/src/test/java/org/bf2/operator/utils/ManagedKafkaUtils.java
@@ -1,0 +1,58 @@
+package org.bf2.operator.utils;
+
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaAuthenticationOAuthBuilder;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaEndpointBuilder;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
+
+public class ManagedKafkaUtils {
+    private ManagedKafkaUtils() {
+    }
+
+    public static ManagedKafka dummyManagedKafka(String id) {
+        ManagedKafka mk = ManagedKafka.getDummyInstance(1);
+        mk.setId(id);
+        return mk;
+    }
+
+    public static ManagedKafka exampleManagedKafka(String size) {
+        ManagedKafka mk = new ManagedKafkaBuilder()
+            .withMetadata(
+                new ObjectMetaBuilder()
+                    .withNamespace("test")
+                    .withName("test-mk")
+                    .build())
+            .withSpec(
+                new ManagedKafkaSpecBuilder()
+                    .withEndpoint(
+                        new ManagedKafkaEndpointBuilder()
+                            .withBootstrapServerHost("xxx.yyy.zzz")
+                            .build()
+                    )
+                    .withOauth(
+                        new ManagedKafkaAuthenticationOAuthBuilder()
+                            .withClientId("clientId")
+                            .withClientSecret("clientSecret")
+                            .withTokenEndpointURI("https://tokenEndpointURI")
+                            .withJwksEndpointURI("https://jwksEndpointURI")
+                            .withValidIssuerEndpointURI("https://validIssuerEndpointURI")
+                            .withUserNameClaim("userNameClaim")
+                            .withTlsTrustedCertificate("TLS trusted cert")
+                            .build()
+                    )
+                    .withNewCapacity()
+                    .withMaxDataRetentionSize(Quantity.parse(size))
+                    .withIngressEgressThroughputPerSec(Quantity.parse("2Mi"))
+                    .endCapacity()
+                    .withNewVersions()
+                        .withKafka("2.6.0")
+                        .withStrimzi("0.22.1")
+                    .endVersions()
+                    .build())
+            .build();
+        return mk;
+    }
+}


### PR DESCRIPTION
This new option is required to set PDB maxUnavailable=0 for both Kafka and Zookeeper, in order to block any K8s node draining that must be managed by the combined work of the drain-cleaner and strimzi-operator.