### PR TITLE
Handle possible null status on ManagedKafka

### DIFF
--- a/operator/src/main/java/org/bf2/operator/StrimziManager.java
+++ b/operator/src/main/java/org/bf2/operator/StrimziManager.java
@@ -49,7 +49,7 @@ public class StrimziManager {
         // a Strimzi version change was asked via the ManagedKafka resource
         if (this.hasStrimziChanged(managedKafka)) {
             log.infof("Strimzi change from %s to %s",
-                    managedKafka.getStatus().getVersions().getStrimzi(), managedKafka.getSpec().getVersions().getStrimzi());
+                    this.currentStrimziVersion(managedKafka), managedKafka.getSpec().getVersions().getStrimzi());
             // Kafka cluster is running and ready --> pause reconcile
             if (kafkaCluster.isReady(managedKafka)) {
                 pauseReconcile(managedKafka, annotations);


### PR DESCRIPTION
Without this change, there's an intermittent test failure due to a NullPointerException on the call to `managedKafka.getStatus().getVersions().getStrimzi()` when the status is null.

The following can help to reproduce the problem before this change:
```sh
while [ $? -eq 0 ]; do mvn -pl operator test ; done
```

I've updated it to use the same way of getting the version as in the `hasStrimziChanged` method used in the `if` condition on the line above.