### PR TITLE
Reconcile StorageClasses from within test method

### DIFF
--- a/operator/src/main/java/org/bf2/operator/StorageClassManager.java
+++ b/operator/src/main/java/org/bf2/operator/StorageClassManager.java
@@ -83,7 +83,7 @@ public class StorageClassManager {
     }
 
     @Scheduled(every = "3m", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
-    void reconcileStorageClasses() {
+    public void reconcileStorageClasses() {
         if (nodeInformer == null || storageClassInformer == null) {
             log.warn("One or more informers are not yet ready");
             return;

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -18,6 +18,7 @@ import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.model.Kafka;
 import org.bf2.operator.DrainCleanerManager;
+import org.bf2.operator.StorageClassManager;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,8 @@ class KafkaClusterTest {
     @Inject
     KafkaCluster kafkaCluster;
 
+    @Inject StorageClassManager storageClassManager;
+
     @BeforeEach
     void createDefaultStorageClass() {
         StorageClass defaultStorageClass = new StorageClassBuilder()
@@ -57,6 +60,7 @@ class KafkaClusterTest {
                 .build();
 
         server.getClient().storage().storageClasses().createOrReplace(defaultStorageClass);
+        storageClassManager.reconcileStorageClasses();
     }
 
     @Test


### PR DESCRIPTION
I don't know if this is actually a good idea or not.

Even though this BeforeEach test method creates a default
StorageClass, it seems like this isn't found sometimes, by the time
the test asks for it. My guess is that the reconciliation hasn't
happened in time, & when the ManagedKafka controller asks for it, it
gets the fallback empty string.

An alternative approach here could be to have a wait loop at the end
of the BeforeEach method that waits for the expected list of storage
classes before continuing to run the actual tests.