### PR TITLE
Do not set OAuth trusted TLS certificate when set to the dummy value (systemtest)

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -95,7 +95,7 @@ public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaS
         if (oauthClientId != null || oauthJwksEndpoint != null) {
             oauth = new ManagedKafkaAuthenticationOAuthBuilder()
                     .withClientId(oauthClientId)
-                    .withNewTlsTrustedCertificate(oauthTlsCert)
+                    .withTlsTrustedCertificate(oauthTlsCert)
                     .withClientSecret(oauthClientSecret)
                     .withUserNameClaim(oauthUserClaim)
                     .withNewJwksEndpointURI(oauthJwksEndpoint)

--- a/systemtest/src/main/java/org/bf2/systemtest/framework/resource/ManagedKafkaResourceType.java
+++ b/systemtest/src/main/java/org/bf2/systemtest/framework/resource/ManagedKafkaResourceType.java
@@ -157,7 +157,7 @@ public class ManagedKafkaResourceType implements ResourceType<ManagedKafka> {
         } else {
             //use defined values by env vars for oauth
             oauthClientId = SystemTestEnvironment.OAUTH_CLIENT_ID;
-            oauthTlsCert = SystemTestEnvironment.OAUTH_TLS_CERT;
+            oauthTlsCert = SystemTestEnvironment.DUMMY_CERT.equals(SystemTestEnvironment.OAUTH_TLS_CERT) ? null : SystemTestEnvironment.OAUTH_TLS_CERT;
             oauthClientSecret = SystemTestEnvironment.OAUTH_CLIENT_SECRET;
             oauthUserClaim = SystemTestEnvironment.OAUTH_USER_CLAIM;
             oauthJwksEndpoint = SystemTestEnvironment.OAUTH_JWKS_ENDPOINT;


### PR DESCRIPTION
This change is helpful when, for example, testing against `identity.api.stage.openshift.com` with the systemtest framework. There is no need to set the cert when signed by a valid CA. This should have no impact on the system tests as they are now using Keycloak.

Signed-off-by: Michael Edgar <medgar@redhat.com>