### PR TITLE
Added readiness of installed Strimzi versions

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAgentStatus.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafkaAgentStatus.java
@@ -21,7 +21,7 @@ public class ManagedKafkaAgentStatus {
 
     private String updatedTimestamp;
 
-    private List<String> strimziVersions;
+    private List<StrimziVersionStatus> strimzi;
 
     public List<ManagedKafkaCondition> getConditions() {
         return conditions;
@@ -71,11 +71,11 @@ public class ManagedKafkaAgentStatus {
         this.updatedTimestamp = updatedTimestamp;
     }
 
-    public List<String> getStrimziVersions() {
-        return strimziVersions;
+    public List<StrimziVersionStatus> getStrimzi() {
+        return strimzi;
     }
 
-    public void setStrimziVersions(List<String> strimziVersions) {
-        this.strimziVersions = strimziVersions;
+    public void setStrimzi(List<StrimziVersionStatus> strimzi) {
+        this.strimzi = strimzi;
     }
 }

--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/StrimziVersionStatus.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/StrimziVersionStatus.java
@@ -1,0 +1,41 @@
+package org.bf2.operator.resources.v1alpha1;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.sundr.builder.annotations.Buildable;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * Define the status for installed Strimzi versions on the Kubernetes cluster
+ * and if they are ready or not
+ */
+@Buildable(
+        builderPackage = "io.fabric8.kubernetes.api.builder",
+        editableEnabled = false
+)
+@ToString
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StrimziVersionStatus {
+
+    @NotNull
+    private String version;
+    @NotNull
+    private boolean ready;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public boolean isReady() {
+        return ready;
+    }
+
+    public void setReady(boolean ready) {
+        this.ready = ready;
+    }
+}

--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
@@ -27,6 +27,7 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Type;
 import org.bf2.operator.resources.v1alpha1.NodeCounts;
 import org.bf2.operator.resources.v1alpha1.NodeCountsBuilder;
+import org.bf2.operator.resources.v1alpha1.StrimziVersionStatus;
 import org.bf2.operator.secrets.ObservabilityManager;
 import org.jboss.logging.Logger;
 
@@ -116,7 +117,7 @@ public class ManagedKafkaAgentController implements ResourceController<ManagedKa
             ConditionUtils.updateConditionStatus(readyCondition, statusValue, null);
         }
 
-        List<String> strimziVersions = this.strimziManager.getStrimziVersions();
+        List<StrimziVersionStatus> strimziVersions = this.strimziManager.getStrimziVersions();
 
         ClusterCapacity total = new ClusterCapacityBuilder()
                 .withConnections(10000)
@@ -158,7 +159,7 @@ public class ManagedKafkaAgentController implements ResourceController<ManagedKa
                 .withNodeInfo(nodeInfo)
                 .withResizeInfo(resize)
                 .withUpdatedTimestamp(ConditionUtils.iso8601Now())
-                .withStrimziVersions(strimziVersions)
+                .withStrimzi(strimziVersions)
                 .build();
     }
 }


### PR DESCRIPTION
This PR adds to the MKA status a readiness information about the Strimzi versions installed on the cluster.
It's useful to understand if a Strimzi version provided through a MK resource is not "valid" because it's not in the list (not installed at all) or there is a temporary problem about the Strimzi operator not running/not ready yet.
It's being useful for the validation task https://github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard/pull/393.
The PR removes the `strimziVersions` field from the CRD adding a new `strimzi` field on the MKS status for this.