### PR TITLE
Fixed NPE when the MKA doesn't have status yet

### DIFF
--- a/operator/src/main/java/org/bf2/operator/StrimziManager.java
+++ b/operator/src/main/java/org/bf2/operator/StrimziManager.java
@@ -91,7 +91,7 @@ public class StrimziManager {
 
                     private void updateStatus() {
                         ManagedKafkaAgent resource = agentClient.getByName(agentClient.getNamespace(), ManagedKafkaAgentResourceClient.RESOURCE_NAME);
-                        if (resource != null) {
+                        if (resource != null && resource.getStatus() != null) {
                             log.debugf("Updating Strimzi versions %s", getStrimziVersions());
                             resource.getStatus().setStrimzi(getStrimziVersions());
                             agentClient.updateStatus(resource);


### PR DESCRIPTION
When the MKA controller doesn't have created the MKA `status` yet, it can happen that the informer in the StrimziManager gets events about strimzi operators and it tries to update a not existing status raising an NPE.
This PR fixes this issue.