### PR TITLE
Fix version and customClaimCheck in example CR

### DIFF
--- a/operator/examples/my-managedkafka.yaml
+++ b/operator/examples/my-managedkafka.yaml
@@ -70,6 +70,6 @@ spec:
         -----END PRIVATE KEY-----
   versions:
     kafka: 2.7.0
-    strimzi-cluster-operator.v0.23.0-0
+    strimzi: strimzi-cluster-operator.v0.23.0-0
 
 


### PR DESCRIPTION
The latest Strimzi operator gives an error if the version is less
than 2.7.0 and it complains that the customClaimCheck is not a
valid Json path filter. The new customClaimCheck value comes from
the Strimzi docs.