### PR TITLE
Update default OSD version to latest 4.7.19

### DIFF
--- a/perf/scripts/osd-provision.sh
+++ b/perf/scripts/osd-provision.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEFAULT_VERSION="4.7.12"
+DEFAULT_VERSION="4.7.19"
 MULTI_AZ="true"
 REPO_ROOT="${DIR}/../"
 SED=sed


### PR DESCRIPTION
This is the latest reported by `ocm list versions` at the time of this commit.

A suggestion for a future change: rather than having this "DEFAULT_VERSION", the default should be to dynamically determine the version by querying `ocm list versions` and getting the latest.