### PR TITLE
Cancel previous smoke tests run when new commit is added into PR

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
+        if: github.event_name == 'pull_request'
         uses: styfle/cancel-workflow-action@0.9.1
 
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
+        if: github.event_name == 'pull_request'
         uses: styfle/cancel-workflow-action@0.9.1
 
       - name: Checkout


### PR DESCRIPTION
We can save resources in GH actions in case when someone commits many fixes into opened PR and do not kill previous runs of smoke tests. So with this PR previous runs are killed automatically.