### PR TITLE
Fixed status updated only when Kafka instance ready with no updating

### DIFF
--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -131,9 +131,13 @@ public class ManagedKafkaController implements ResourceController<ManagedKafka> 
 
         ConditionUtils.updateConditionStatus(ready, readiness.getStatus(), readiness.getReason(), readiness.getMessage());
 
-        if (Status.True.equals(readiness.getStatus()) && !Reason.StrimziUpdating.equals(readiness.getReason())) {
+        if (Status.True.equals(readiness.getStatus())) {
             status.setCapacity(new ManagedKafkaCapacityBuilder(managedKafka.getSpec().getCapacity()).build());
-            status.setVersions(new VersionsBuilder(managedKafka.getSpec().getVersions()).build());
+            if (!Reason.StrimziUpdating.equals(readiness.getReason())) {
+                status.setVersions(new VersionsBuilder(managedKafka.getSpec().getVersions()).build());
+            } else {
+                // just keep the current version
+            }
             status.setAdminServerURI(kafkaInstance.getAdminServer().uri(managedKafka));
         }
     }


### PR DESCRIPTION
When a Strimzi version upgrade is started by changing the `spec.versions.strimzi` in the ManagedKafka resource, the corresponding `status.versions.strimzi` field should still report the older one while the upgrade is in process so when the StrimziUpdating condition is still true.

Currently, there is a bug with fleetshard operator reporting the new Strimzi version in the status while the updating is still in progress; the status field should be updated only at the end of the update.

This PR fixes this issue checking that even if ready, Kafka instance is not updating.