### PR TITLE
Remove gh api unit tests

### DIFF
--- a/systemtest/src/test/java/org/bf2/systemtest/unit/SuiteUnitTest.java
+++ b/systemtest/src/test/java/org/bf2/systemtest/unit/SuiteUnitTest.java
@@ -14,7 +14,6 @@ import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bf2.systemtest.api.github.GithubApiClient;
 import org.bf2.systemtest.framework.KeycloakInstance;
 import org.bf2.systemtest.framework.ParallelTest;
 import org.bf2.systemtest.framework.SecurityUtils;
@@ -30,10 +29,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -133,10 +130,5 @@ public class SuiteUnitTest extends AbstractST {
         assertEquals("admin", k.getUsername());
         assertEquals("admin", k.getPassword());
         assertNotNull(k.getKeycloakCert());
-    }
-
-    @ParallelTest
-    void testGithubApiClient() throws ExecutionException, InterruptedException {
-        assertNotEquals(0, GithubApiClient.getReleases("strimzi", "strimzi-kafka-operator").length);
     }
 }


### PR DESCRIPTION
I have to remove gh api unit test from systemtest module. It causes random issues in AppSRE jenkins CI becasue of limits to gh api.