### PR TITLE
Avoid GH api call for strimzi releases when strimzi is installed by addon

### DIFF
--- a/systemtest/src/test/java/org/bf2/systemtest/integration/UpgradeST.java
+++ b/systemtest/src/test/java/org/bf2/systemtest/integration/UpgradeST.java
@@ -38,7 +38,7 @@ public class UpgradeST extends AbstractST {
     @BeforeAll
     void deploy() throws Exception {
         strimziOperatorManagerOld = new StrimziOperatorManager(
-                StrimziOperatorManager.getPreviousStrimziVersion(SystemTestEnvironment.STRIMZI_VERSION));
+                StrimziOperatorManager.getPreviousUpstreamStrimziVersion(SystemTestEnvironment.STRIMZI_VERSION));
         strimziOperatorManagerNew = new StrimziOperatorManager(SystemTestEnvironment.STRIMZI_VERSION);
         CompletableFuture.allOf(
                 KeycloakOperatorManager.installKeycloak(kube),


### PR DESCRIPTION
avoid gh api call for strimzi releases in pipelines on OSD when strimzi is already installed by addon and we don't need to install it.