### PR TITLE
Remove redundant support for Strimzi 0.22 connection limits config

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/Versions.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/Versions.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 @EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Versions {
-    public static String VERSION_0_22 = "0.22";
     static final Pattern strimziVersionPattern = Pattern.compile("[a-z\\.\\-]*(\\d+\\.\\d+\\.\\d+)(?:-(\\d+))?");
     private static final Comparator<String> strimziComparator = new StrimziVersionComparator();
 

--- a/api/src/test/java/org/bf2/resources/VersionsTest.java
+++ b/api/src/test/java/org/bf2/resources/VersionsTest.java
@@ -16,16 +16,16 @@ public class VersionsTest {
         Versions versions = new Versions();
 
         versions.setStrimzi("0.22.1");
-        assertTrue(versions.isStrimziVersionIn(Versions.VERSION_0_22));
+        assertTrue(versions.isStrimziVersionIn("0.22"));
 
         versions.setStrimzi("strimzi-cluster-operator.v0.22.1");
-        assertTrue(versions.isStrimziVersionIn(Versions.VERSION_0_22));
+        assertTrue(versions.isStrimziVersionIn("0.22"));
 
         versions.setStrimzi("strimzi-cluster-operator.v0.22.1-6");
-        assertTrue(versions.isStrimziVersionIn(Versions.VERSION_0_22));
+        assertTrue(versions.isStrimziVersionIn("0.22"));
 
         versions.setStrimzi("strimzi-cluster-operator.v0.23.0");
-        assertFalse(versions.isStrimziVersionIn(Versions.VERSION_0_22));
+        assertFalse(versions.isStrimziVersionIn("0.22"));
     }
 
     @ParameterizedTest

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -30,7 +30,6 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafkaAuthenticationOAuth;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Reason;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
-import org.bf2.operator.resources.v1alpha1.Versions;
 import org.bf2.operator.secrets.SecuritySecretManager;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -213,13 +212,9 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                         .build()
                 )
                 .withBrokers(buildBrokerOverrides(managedKafka))
-                .withBrokerCertChainAndKey(buildTlsCertAndKeySecretSource(managedKafka));
-
-        if(!managedKafka.getSpec().getVersions().isStrimziVersionIn(Versions.VERSION_0_22)) {
-            listenerConfigBuilder
-                    .withMaxConnections(totalMaxConnections)
-                    .withMaxConnectionCreationRate(maxConnectionAttemptsPerSec);
-        }
+                .withBrokerCertChainAndKey(buildTlsCertAndKeySecretSource(managedKafka))
+                .withMaxConnections(totalMaxConnections)
+                .withMaxConnectionCreationRate(maxConnectionAttemptsPerSec);
 
         return new ArrayOrObjectKafkaListenersBuilder()
                 .withGenericKafkaListeners(

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -442,15 +442,6 @@ public class KafkaCluster extends AbstractKafkaCluster {
         //       this could be removed,  when we contribute to Sarama to have the support for Elect Leader API
         config.put("leader.imbalance.per.broker.percentage", 0);
 
-        if(managedKafka.getSpec().getVersions().isStrimziVersionIn(Versions.VERSION_0_22)) {
-            // Limit client connections per broker
-            Integer totalMaxConnections = managedKafka.getSpec().getCapacity().getTotalMaxConnections();
-            config.put("max.connections", String.valueOf((long)(Objects.requireNonNullElse(totalMaxConnections, this.config.getKafka().getMaxConnections()) / this.config.getKafka().getReplicas())));
-            // Limit connection attempts per broker
-            Integer maxConnectionAttemptsPerSec = managedKafka.getSpec().getCapacity().getMaxConnectionAttemptsPerSec();
-            config.put("max.connections.creation.rate", String.valueOf(Objects.requireNonNullElse(maxConnectionAttemptsPerSec, this.config.getKafka().getConnectionAttemptsPerSec()) / this.config.getKafka().getReplicas()));
-        }
-
         // configure quota plugin
         if (this.config.getKafka().isEnableQuota()) {
             addQuotaConfig(managedKafka, current, config);
@@ -465,7 +456,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
     private void addQuotaConfig(ManagedKafka managedKafka, Kafka current, Map<String, Object> config) {
 
         Versions versions = managedKafka.getSpec().getVersions();
-        boolean legacyQuotaClass = versions.isStrimziVersionIn(Versions.VERSION_0_22) || (versions.getStrimzi().endsWith("0.23.0-0"));
+        boolean legacyQuotaClass = versions.getStrimzi().endsWith("0.23.0-0");
         config.put("client.quota.callback.class", legacyQuotaClass ? ORG_APACHE_KAFKA_SERVER_QUOTA_STATIC_QUOTA_CALLBACK : IO_STRIMZI_KAFKA_QUOTA_STATIC_QUOTA_CALLBACK);
 
         // Throttle at Ingress/Egress MB/sec per broker

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -95,16 +95,6 @@ class KafkaClusterTest {
     }
 
     @Test
-    void testManagedKafkaWithMaxConnections() throws IOException {
-        ManagedKafka mk = exampleManagedKafka("60Gi");
-        mk.getSpec().getVersions().setStrimzi("0.23.0-0");
-        Kafka kafka = kafkaCluster.kafkaFrom(mk, null);
-
-        JsonNode patch = diffToExpected(kafka,"/expected/strimzi.yml");
-        assertEquals("[{\"op\":\"replace\",\"path\":\"/metadata/labels/managedkafka.bf2.org~1strimziVersion\",\"value\":\"0.23.0-0\"},{\"op\":\"add\",\"path\":\"/spec/kafka/listeners/1/configuration/maxConnections\",\"value\":166},{\"op\":\"add\",\"path\":\"/spec/kafka/listeners/1/configuration/maxConnectionCreationRate\",\"value\":33},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/max.connections\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/max.connections.creation.rate\"}]", patch.toString());
-    }
-
-    @Test
     void testManagedKafkaToKafkaWithCustomConfiguration() throws IOException {
         KafkaInstanceConfiguration config = kafkaCluster.getKafkaConfiguration();
         try {

--- a/operator/src/test/java/org/bf2/operator/utils/ManagedKafkaUtils.java
+++ b/operator/src/test/java/org/bf2/operator/utils/ManagedKafkaUtils.java
@@ -49,7 +49,7 @@ public class ManagedKafkaUtils {
                     .endCapacity()
                     .withNewVersions()
                         .withKafka("2.6.0")
-                        .withStrimzi("0.22.1")
+                        .withStrimzi("0.23.0-0")
                     .endVersions()
                     .withOwners("userid-123")
                     .build())

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: "kas-fleetshard-operator"
     ingressType: "sharded"
-    managedkafka.bf2.org/strimziVersion: "0.22.1"
+    managedkafka.bf2.org/strimziVersion: "0.23.0-0"
     managedkafka.bf2.org/kas-multi-zone: "true"
     managedkafka.bf2.org/kas-zone0: "true"
     managedkafka.bf2.org/kas-zone1: "true"
@@ -66,6 +66,8 @@ spec:
         enableOauthBearer: true
         type: "oauth"
       configuration:
+        maxConnections: 125
+        maxConnectionCreationRate: 75
         bootstrap:
           host: "xxx.yyy.zzz"
         brokers:
@@ -122,8 +124,6 @@ spec:
       client.quota.callback.static.storage.check-interval: "30"
       client.quota.callback.static.disable-quota-anonymous: "true"
       default.replication.factor: 3
-      max.connections.creation.rate: "75"
-      max.connections: "125"
       inter.broker.protocol.version: "2.6.0"
       client.quota.callback.static.produce: "524288"
       leader.imbalance.per.broker.percentage: 0

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: "kas-fleetshard-operator"
     ingressType: "sharded"
-    managedkafka.bf2.org/strimziVersion: "0.22.1"
+    managedkafka.bf2.org/strimziVersion: "0.23.0-0"
     managedkafka.bf2.org/kas-multi-zone: "true"
     managedkafka.bf2.org/kas-zone0: "true"
     managedkafka.bf2.org/kas-zone1: "true"
@@ -66,6 +66,8 @@ spec:
         enableOauthBearer: true
         type: "oauth"
       configuration:
+        maxConnections: 166
+        maxConnectionCreationRate: 33
         bootstrap:
           host: "xxx.yyy.zzz"
         brokers:
@@ -120,8 +122,6 @@ spec:
       client.quota.callback.static.storage.check-interval: "30"
       client.quota.callback.static.disable-quota-anonymous: "true"
       default.replication.factor: 3
-      max.connections: "166"
-      max.connections.creation.rate: "33"
       inter.broker.protocol.version: "2.6.0"
       client.quota.callback.static.produce: "699050"
       leader.imbalance.per.broker.percentage: 0


### PR DESCRIPTION
As we now have advanced beyond Strimzi 0.22 (and continuing to support it is not required), the code that configured connection based connection limits is redundant.  This also kills some clutter within the tests.