### PR TITLE
Default refresh-token-time-skew

### DIFF
--- a/sync/src/main/resources/application.properties
+++ b/sync/src/main/resources/application.properties
@@ -40,6 +40,7 @@ quarkus.oidc-client-filter.register-filter=${sso.enabled}
 quarkus.oidc-client.auth-server-url=${sso.auth-server-url}
 quarkus.oidc-client.client-id=${sso.client-id}
 quarkus.oidc-client.credentials.secret=${sso.secret}
+quarkus.oidc-client.refresh-token-time-skew=${sso.refresh-token-time-skew:5S}
 
 # properties for secret handling
 quarkus.kubernetes-config.secrets.enabled=true


### PR DESCRIPTION
We are seeing occasionally 401 in some environments from kas-fleetshard-sync. As @machi1990 pointed out, the omission of this setting is a possible cause.

https://quarkus.io/guides/security-openid-connect#quarkus-oidc_quarkus.oidc.token.refresh-token-time-skew