### PR TITLE
Expand owner cluster ACLs, correct and expand canary ACLs

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -48,13 +48,15 @@ default=true;permission=allow;group=*;operations=all \n\
 default=true;permission=allow;transactional_id=*;operations=all
 # Allow "owner" users full control of topics, groups, transactional_ids, and cluster ACLs
 managedkafka.kafka.acl.owner=\
-permission=allow;principal=%1$s;cluster=*;operations=describe,alter;apis=create_acls,describe_acls,delete_acls \n\
+permission=allow;principal=%1$s;cluster=*;operations=describe \n\
+permission=allow;principal=%1$s;cluster=*;operations=alter;apis=create_acls,delete_acls \n\
 permission=allow;principal=%1$s;topic=*;operations=all \n\
 permission=allow;principal=%1$s;group=*;operations=all \n\
 permission=allow;principal=%1$s;transactional_id=*;operations=all
 # "canary" service account allowed to read/write own topic, read own consumer group
 managedkafka.kafka.acl.service-accounts.canary=\
-permission=allow;principal=%1$s;topic=__strimzi_canary;operations=read,write \n\
-permission=allow;principal=%1$s;group=strimzi-canary-group;operations=read
+permission=allow;principal=service-account-%1$s;cluster=*;operations=alter;apis=alter_partition_reassignments \n\
+permission=allow;principal=service-account-%1$s;topic=__strimzi_canary;operations=create,describe,read,write,alter \n\
+permission=allow;principal=service-account-%1$s;group=strimzi-canary-group;operations=describe,read
 # Used for validation in Admin API and custom Kafka Authorizer
 managedkafka.kafka.acl.resource-operations={ "cluster": [ "describe", "alter" ], "group": [ "all", "delete", "describe", "read" ], "topic": [ "all", "alter", "alter_configs", "create", "delete", "describe", "describe_configs", "read", "write" ], "transactional_id": [ "all", "describe", "write" ] }

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -130,7 +130,28 @@ class KafkaClusterTest {
         Kafka kafka = kafkaCluster.kafkaFrom(mk, null);
 
         JsonNode patch = diffToExpected(kafka,"/expected/strimzi.yml");
-        assertEquals("[{\"op\":\"replace\",\"path\":\"/metadata/labels/managedkafka.bf2.org~1strimziVersion\",\"value\":\"0.23.0-1\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/authorization/authorizerClass\",\"value\":\"io.bf2.kafka.authorizer.GlobalAclAuthorizer\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.allowed-listeners\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.1\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.2\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.3\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.4\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.resource-operations\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.5\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.6\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.7\"},{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.8\"},{\"op\":\"add\",\"path\":\"/spec/kafka/config/strimzi.authorization.global-authorizer.acl.2\",\"value\":\"permission=allow;group=*;operations=all\"},{\"op\":\"add\",\"path\":\"/spec/kafka/config/strimzi.authorization.global-authorizer.acl.3\",\"value\":\"permission=allow;transactional_id=*;operations=all\"},{\"op\":\"add\",\"path\":\"/spec/kafka/config/strimzi.authorization.global-authorizer.acl.1\",\"value\":\"permission=allow;topic=*;operations=all\"},{\"op\":\"add\",\"path\":\"/spec/kafka/config/strimzi.authorization.global-authorizer.allowed-listeners\",\"value\":\"TLS-9093,SRE-9096\"}]", patch.toString());
+        assertEquals("["
+                + "{\"op\":\"replace\",\"path\":\"/metadata/labels/managedkafka.bf2.org~1strimziVersion\",\"value\":\"0.23.0-1\"},"
+                + "{\"op\":\"replace\",\"path\":\"/spec/kafka/authorization/authorizerClass\",\"value\":\"io.bf2.kafka.authorizer.GlobalAclAuthorizer\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.allowed-listeners\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.1\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.2\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.3\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.4\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.resource-operations\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.5\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.6\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.7\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.8\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.9\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.10\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.11\"},"
+                + "{\"op\":\"remove\",\"path\":\"/spec/kafka/config/strimzi.authorization.custom-authorizer.acl.12\"},"
+                + "{\"op\":\"add\",\"path\":\"/spec/kafka/config/strimzi.authorization.global-authorizer.acl.2\",\"value\":\"permission=allow;group=*;operations=all\"},"
+                + "{\"op\":\"add\",\"path\":\"/spec/kafka/config/strimzi.authorization.global-authorizer.acl.3\",\"value\":\"permission=allow;transactional_id=*;operations=all\"},"
+                + "{\"op\":\"add\",\"path\":\"/spec/kafka/config/strimzi.authorization.global-authorizer.acl.1\",\"value\":\"permission=allow;topic=*;operations=all\"},"
+                + "{\"op\":\"add\",\"path\":\"/spec/kafka/config/strimzi.authorization.global-authorizer.allowed-listeners\",\"value\":\"TLS-9093,SRE-9096\"}]",
+                patch.toString());
     }
 
     @Test

--- a/operator/src/test/java/org/bf2/operator/utils/ManagedKafkaUtils.java
+++ b/operator/src/test/java/org/bf2/operator/utils/ManagedKafkaUtils.java
@@ -7,6 +7,7 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafkaAuthenticationOAuthBuilde
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaEndpointBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
+import org.bf2.operator.resources.v1alpha1.ServiceAccountBuilder;
 
 public class ManagedKafkaUtils {
     private ManagedKafkaUtils() {
@@ -52,6 +53,13 @@ public class ManagedKafkaUtils {
                         .withStrimzi("0.23.0-2")
                     .endVersions()
                     .withOwners("userid-123")
+                    .withServiceAccounts(
+                        new ServiceAccountBuilder()
+                            .withName("canary")
+                            .withPrincipal("canary-123")
+                            .withPassword("canary-secret")
+                            .build()
+                    )
                     .build())
             .build();
         return mk;

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -133,10 +133,14 @@ spec:
       strimzi.authorization.custom-authorizer.acl.3: default=true;permission=allow;group=*;operations=all
       strimzi.authorization.custom-authorizer.acl.4: default=true;permission=allow;transactional_id=*;operations=all
       strimzi.authorization.custom-authorizer.resource-operations: '{ "cluster": [ "describe", "alter" ], "group": [ "all", "delete", "describe", "read" ], "topic": [ "all", "alter", "alter_configs", "create", "delete", "describe", "describe_configs", "read", "write" ], "transactional_id": [ "all", "describe", "write" ] }'
-      strimzi.authorization.custom-authorizer.acl.5: permission=allow;principal=userid-123;cluster=*;operations=describe,alter;apis=create_acls,describe_acls,delete_acls
-      strimzi.authorization.custom-authorizer.acl.6: permission=allow;principal=userid-123;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.7: permission=allow;principal=userid-123;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.8: permission=allow;principal=userid-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.5: permission=allow;principal=userid-123;cluster=*;operations=describe
+      strimzi.authorization.custom-authorizer.acl.6: permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls
+      strimzi.authorization.custom-authorizer.acl.7: permission=allow;principal=userid-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.8: permission=allow;principal=userid-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.9: permission=allow;principal=userid-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.10: permission=allow;principal=service-account-canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.11: permission=allow;principal=service-account-canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter
+      strimzi.authorization.custom-authorizer.acl.12: permission=allow;principal=service-account-canary-123;group=strimzi-canary-group;operations=describe,read
     storage: !<jbod>
       volumes:
       - !<persistent-claim>

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -131,10 +131,14 @@ spec:
       strimzi.authorization.custom-authorizer.acl.3: default=true;permission=allow;group=*;operations=all
       strimzi.authorization.custom-authorizer.acl.4: default=true;permission=allow;transactional_id=*;operations=all
       strimzi.authorization.custom-authorizer.resource-operations: '{ "cluster": [ "describe", "alter" ], "group": [ "all", "delete", "describe", "read" ], "topic": [ "all", "alter", "alter_configs", "create", "delete", "describe", "describe_configs", "read", "write" ], "transactional_id": [ "all", "describe", "write" ] }'
-      strimzi.authorization.custom-authorizer.acl.5: permission=allow;principal=userid-123;cluster=*;operations=describe,alter;apis=create_acls,describe_acls,delete_acls
-      strimzi.authorization.custom-authorizer.acl.6: permission=allow;principal=userid-123;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.7: permission=allow;principal=userid-123;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.8: permission=allow;principal=userid-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.5: permission=allow;principal=userid-123;cluster=*;operations=describe
+      strimzi.authorization.custom-authorizer.acl.6: permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls
+      strimzi.authorization.custom-authorizer.acl.7: permission=allow;principal=userid-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.8: permission=allow;principal=userid-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.9: permission=allow;principal=userid-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.10: permission=allow;principal=service-account-canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.11: permission=allow;principal=service-account-canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter
+      strimzi.authorization.custom-authorizer.acl.12: permission=allow;principal=service-account-canary-123;group=strimzi-canary-group;operations=describe,read
     storage: !<jbod>
       volumes:
       - !<persistent-claim>


### PR DESCRIPTION
* Allow all `describe` operations on `cluster` for owner(s). Eliminate denial logging for `LIST_GROUPS` API from Admin API
* Allow `alter` operations `create_acls` and `delete_acls` on `cluster` for owner(s)
* Update canary principal to match expected run-time `preferred_username`
* Allow `alter` API operation `alter_partition_reassignments` on `cluster` for canary
* Allow canary to `create`, `describe`, and `alter` own topic (`__strimzi_canary`)
* Allow canary to `describe` own consumer group (`strimzi-canary-group`)
* Add canary service account configuration for unit tests

Signed-off-by: Michael Edgar <medgar@redhat.com>