### PR TITLE
set scope to provided for io.sundr:builder-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
                 <groupId>io.sundr</groupId>
                 <artifactId>builder-annotations</artifactId>
                 <version>${sundrio.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This jar isn't needed as part of the runtime.

Signed-off-by: Vanessa Busch <vbusch@redhat.com>