### PR TITLE
Configure TLS for oauth-9095 listener (Admin API 0.4.0)

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -237,7 +237,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                                 .withName("oauth")
                                 .withPort(9095)
                                 .withType(KafkaListenerType.INTERNAL)
-                                .withTls(false)
+                                .withTls(true)
                                 .withAuth(oauthAuthenticationListener)
                                 .build(),
                         new GenericKafkaListenerBuilder()

--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -304,6 +304,8 @@ public class AdminServer extends AbstractAdminServer {
         List<EnvVar> envVars = new ArrayList<>();
 
         addEnvVar(envVars, "KAFKA_ADMIN_BOOTSTRAP_SERVERS", managedKafka.getMetadata().getName() + "-kafka-bootstrap:9095");
+        addEnvVar(envVars, "KAFKA_ADMIN_BROKER_TLS_ENABLED", "true");
+        addEnvVarSecret(envVars, "KAFKA_ADMIN_BROKER_TRUSTED_CERT", SecuritySecretManager.strimziClusterCaCertSecret(managedKafka), "ca.crt");
 
         if (this.config.getKafka().getAcl().isCustomAclAuthorizerEnabled(managedKafka.getSpec().getOwners())) {
             addEnvVar(envVars, "KAFKA_ADMIN_ACL_RESOURCE_OPERATIONS", this.config.getKafka().getAcl().getResourceOperations());

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -5,7 +5,7 @@ strimzi.bundle.interval=60s
 quarkus.log.category."io.fabric8.kubernetes.client.informers.cache.ReflectorWatcher".level=WARNING
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %x %s%e%n
 
-image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.3.0
+image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.4.0
 image.canary=quay.io/mk-ci-cd/strimzi-canary:0.0.7
 
 # unique label required to identify the DrainCleaner's validating webhook

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -82,7 +82,7 @@ spec:
     - name: "oauth"
       port: 9095
       type: "internal"
-      tls: false
+      tls: true
       authentication: !<oauth>
         clientId: "clientId"
         clientSecret:

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -80,7 +80,7 @@ spec:
     - name: "oauth"
       port: 9095
       type: "internal"
-      tls: false
+      tls: true
       authentication: !<oauth>
         clientId: "clientId"
         clientSecret:


### PR DESCRIPTION
Tested using Admin API version from PR bf2fc6cc711aee1a0c2a/kafka-admin-api#125. Requires release 0.4.0 before merging.

Signed-off-by: Michael Edgar <medgar@redhat.com>