### PR TITLE
Remove operator deployment `serviceAccountName`, add sync role comments

### DIFF
--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -198,7 +198,6 @@ spec:
       labels:
         app: kas-fleetshard-operator
     spec:
-      serviceAccountName: kas-fleetshard-operator
       containers:
         - name: kas-fleetshard-operator
           image: ##IMAGE##

--- a/sync/src/main/kubernetes/kubernetes.yml
+++ b/sync/src/main/kubernetes/kubernetes.yml
@@ -8,6 +8,7 @@ rules:
   - apiGroups:
       - managedkafka.bf2.org
     resources:
+      # sync resources for getting Kafka instance to deploy, configuration and reporting back status
       - managedkafkas
       - managedkafkas/status
       - managedkafkaagents
@@ -23,6 +24,7 @@ rules:
   - apiGroups:
       - ""
     resources:
+      # sync has to create namespaces for Kafka instances to deploy
       - namespaces
     verbs:
       - get


### PR DESCRIPTION
`operator-sdk` issues warning that `serviceAccountName` in deployment is not valid. The generated Deployment will contain only a `serviceAccount` with this change.

Signed-off-by: Michael Edgar <medgar@redhat.com>