### PR TITLE
Added CRDs permissions

### DIFF
--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -4,6 +4,15 @@ metadata:
   name: kas-fleetshard-operator
 rules:
   - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      # the Strimzi bundle manager checks if Strimzi operator related CRDs are installed
+      - 'customresourcedefinitions'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - managedkafka.bf2.org
     resources:
       # operator main custom resources for getting Kafka instance to deploy, configuration and reporting back status


### PR DESCRIPTION
Re-add CRDs permissions because the Strimzi bundle manager needs that and not the Java Operator SDK anymore.