### PR TITLE
Disabling heath checks based on informers watching

### DIFF
--- a/operator/src/main/java/org/bf2/operator/health/LivenessHealthCheck.java
+++ b/operator/src/main/java/org/bf2/operator/health/LivenessHealthCheck.java
@@ -17,9 +17,15 @@ public class LivenessHealthCheck implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
+
+        // Temporary disabling health check based on Informers watching due to a fabric8 bug fixed in 5.8.0 version
+        // https://github.com/fabric8io/kubernetes-client/pull/3485
+        /*
         if (this.resourceInformerFactory.allInformersWatching()) {
             return HealthCheckResponse.up("Informers are watching");
         }
         return HealthCheckResponse.down("Informers are not watching");
+        */
+        return HealthCheckResponse.up("Operator up and running");
     }
 }

--- a/sync/src/main/java/org/bf2/sync/health/LivenessHealthCheck.java
+++ b/sync/src/main/java/org/bf2/sync/health/LivenessHealthCheck.java
@@ -17,9 +17,14 @@ public class LivenessHealthCheck implements HealthCheck {
 
     @Override
     public HealthCheckResponse call() {
+        // Temporary disabling health check based on Informers watching due to a fabric8 bug fixed in 5.8.0 version
+        // https://github.com/fabric8io/kubernetes-client/pull/3485
+        /*
         if (this.resourceInformerFactory.allInformersWatching()) {
             return HealthCheckResponse.up("Informers are watching");
         }
         return HealthCheckResponse.down("Informers are not watching");
+        */
+        return HealthCheckResponse.up("Synchronizer up and running");
     }
 }


### PR DESCRIPTION
Due to a bug in fabric8, it's possible that the informer is considered not watching (while the underneath watcher is working fine) but our health check returns it's down and Kubernetes restarts the operator after the probe failing three times.
This PR temporary disables the health check based on informers watching by returning it's always UP until fabric8 5.8.0 with this fix (https://github.com/fabric8io/kubernetes-client/pull/3485) will be released and operator will use it.