### PR TITLE
disabling the managedkafka finalizer

### DIFF
--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
@@ -43,7 +43,7 @@ import java.util.List;
  * An alternative to this approach would be to have the ManagedKafkaControl make status
  * updates directly based upon the changes it sees in the ManagedKafka instances.
  */
-@Controller
+@Controller(finalizerName = Controller.NO_FINALIZER)
 public class ManagedKafkaAgentController implements ResourceController<ManagedKafkaAgent> {
 
     @Inject

--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-@Controller
+@Controller(finalizerName = Controller.NO_FINALIZER)
 public class ManagedKafkaController implements ResourceController<ManagedKafka> {
 
     @Inject

--- a/systemtest/src/test/java/org/bf2/systemtest/integration/SmokeST.java
+++ b/systemtest/src/test/java/org/bf2/systemtest/integration/SmokeST.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(TestTags.SMOKE)
 public class SmokeST extends AbstractST {
@@ -98,6 +99,8 @@ public class SmokeST extends AbstractST {
         ManagedKafkaStatus apiStatus = Serialization.jsonMapper()
                 .readValue(SyncApiClient.getManagedKafkaStatus(mk.getId(), syncEndpoint).body(), ManagedKafkaStatus.class);
         ManagedKafka managedKafka = ManagedKafkaResourceType.getOperation().inNamespace(mkAppName).withName(mkAppName).get();
+
+        assertTrue(managedKafka.getMetadata().getFinalizers() == null || managedKafka.getMetadata().getFinalizers().isEmpty());
 
         AssertUtils.assertManagedKafkaStatus(managedKafka, apiStatus);
 


### PR DESCRIPTION
another operator sdk upgrade followup.  we logged an issue a while ago for the sdk to support not adding a finalizer.  Since there is no action that we need to take at deletion time, we don't need the finalizer.  This makes it easy to clean up managekafka resources without the operator running.