### PR TITLE
Add missing ACL entries for canary's `preferred_username`

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -70,7 +70,14 @@ priority=1;permission=allow;principal=%1$s;topic=${managedkafka.canary.topic};op
 priority=1;permission=allow;principal=%1$s;group=${managedkafka.canary.group};operations=describe,read \n\
 priority=2;permission=deny;principal=%1$s;topic=*;operations=all \n\
 priority=2;permission=deny;principal=%1$s;group=*;operations=all \n\
-priority=2;permission=deny;principal=%1$s;transactional_id=*;operations=all
+priority=2;permission=deny;principal=%1$s;transactional_id=*;operations=all \n\
+priority=1;permission=allow;principal=service-account-%1$s;cluster=*;operations=describe;apis=list_partition_reassignments \n\
+priority=1;permission=allow;principal=service-account-%1$s;cluster=*;operations=alter;apis=alter_partition_reassignments \n\
+priority=1;permission=allow;principal=service-account-%1$s;topic=${managedkafka.canary.topic};operations=create,describe,read,write,alter \n\
+priority=1;permission=allow;principal=service-account-%1$s;group=${managedkafka.canary.group};operations=describe,read \n\
+priority=2;permission=deny;principal=service-account-%1$s;topic=*;operations=all \n\
+priority=2;permission=deny;principal=service-account-%1$s;group=*;operations=all \n\
+priority=2;permission=deny;principal=service-account-%1$s;transactional_id=*;operations=all
 
 # Used for validation in Admin API and custom Kafka Authorizer
 managedkafka.kafka.acl.resource-operations={ "cluster": [ "describe", "alter" ], "group": [ "all", "delete", "describe", "read" ], "topic": [ "all", "alter", "alter_configs", "create", "delete", "describe", "describe_configs", "read", "write" ], "transactional_id": [ "all", "describe", "write" ] }

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -155,6 +155,13 @@ spec:
       strimzi.authorization.custom-authorizer.acl.020: priority=2;permission=deny;principal=canary-123;topic=*;operations=all
       strimzi.authorization.custom-authorizer.acl.021: priority=2;permission=deny;principal=canary-123;group=*;operations=all
       strimzi.authorization.custom-authorizer.acl.022: priority=2;permission=deny;principal=canary-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.023: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.024: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.025: priority=1;permission=allow;principal=service-account-canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter
+      strimzi.authorization.custom-authorizer.acl.026: priority=1;permission=allow;principal=service-account-canary-123;group=strimzi-canary-group;operations=describe,read
+      strimzi.authorization.custom-authorizer.acl.027: priority=2;permission=deny;principal=service-account-canary-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.028: priority=2;permission=deny;principal=service-account-canary-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.029: priority=2;permission=deny;principal=service-account-canary-123;transactional_id=*;operations=all
     storage: !<jbod>
       volumes:
       - !<persistent-claim>

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -153,6 +153,13 @@ spec:
       strimzi.authorization.custom-authorizer.acl.020: priority=2;permission=deny;principal=canary-123;topic=*;operations=all
       strimzi.authorization.custom-authorizer.acl.021: priority=2;permission=deny;principal=canary-123;group=*;operations=all
       strimzi.authorization.custom-authorizer.acl.022: priority=2;permission=deny;principal=canary-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.023: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.024: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.025: priority=1;permission=allow;principal=service-account-canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter
+      strimzi.authorization.custom-authorizer.acl.026: priority=1;permission=allow;principal=service-account-canary-123;group=strimzi-canary-group;operations=describe,read
+      strimzi.authorization.custom-authorizer.acl.027: priority=2;permission=deny;principal=service-account-canary-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.028: priority=2;permission=deny;principal=service-account-canary-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.029: priority=2;permission=deny;principal=service-account-canary-123;transactional_id=*;operations=all
     storage: !<jbod>
       volumes:
       - !<persistent-claim>


### PR DESCRIPTION
Required prior to additional `fallbackUserNameClaim` being present in ManagedKafka CR from fleet manager.

Signed-off-by: Michael Edgar <medgar@redhat.com>