### PR TITLE
Add profile to optionally attach Kubernetes resources to project

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -55,11 +55,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-scheduler</artifactId>
-        </dependency>  
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes-config</artifactId>
-        </dependency>              
+        </dependency>
         <!-- test -->
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -144,6 +144,45 @@
             <properties>
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>
+        </profile>
+        <profile>
+            <id>attach-kubernetes-resources</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/kubernetes/kubernetes.yml</file>
+                                            <type>yml</type>
+                                            <classifier>kubernetes</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${project.build.directory}/kubernetes/managedkafkaagents.managedkafka.bf2.org-v1.yml</file>
+                                            <type>yml</type>
+                                            <classifier>crd-managedkafkaagents</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${project.build.directory}/kubernetes/managedkafkas.managedkafka.bf2.org-v1.yml</file>
+                                            <type>yml</type>
+                                            <classifier>crd-managedkafkas</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <jandex-plugin.version>1.0.7</jandex-plugin.version>
         <properties-plugin.version>1.0.0</properties-plugin.version>
         <impsort-plugin.version>1.6.0</impsort-plugin.version>
+        <buildhelper-plugin.version>3.2.0</buildhelper-plugin.version>
         <format.skip>false</format.skip>
         <findbugs.annotations.version>3.0.0</findbugs.annotations.version>
     </properties>
@@ -274,6 +275,11 @@
                     <configuration>
                         <showWarnings>${maven.compiler.showWarnings}</showWarnings>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${buildhelper-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/sync/pom.xml
+++ b/sync/pom.xml
@@ -152,5 +152,34 @@
                 <quarkus.package.type>native</quarkus.package.type>
             </properties>
         </profile>
+        <profile>
+            <id>attach-kubernetes-resources</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/kubernetes/kubernetes.yml</file>
+                                            <type>yml</type>
+                                            <classifier>kubernetes</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Gives option to attach generated Kubernetes resources to the project for downstream consumption (e.g. as input to an OLM bundle generation process).

Signed-off-by: Michael Edgar <medgar@redhat.com>