### PR TITLE
Revert "disabling the managedkafka finalizer (#516)"

### DIFF
--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
@@ -43,7 +43,7 @@ import java.util.List;
  * An alternative to this approach would be to have the ManagedKafkaControl make status
  * updates directly based upon the changes it sees in the ManagedKafka instances.
  */
-@Controller(finalizerName = Controller.NO_FINALIZER)
+@Controller
 public class ManagedKafkaAgentController implements ResourceController<ManagedKafkaAgent> {
 
     @Inject

--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-@Controller(finalizerName = Controller.NO_FINALIZER)
+@Controller
 public class ManagedKafkaController implements ResourceController<ManagedKafka> {
 
     @Inject

--- a/systemtest/src/test/java/org/bf2/systemtest/integration/SmokeST.java
+++ b/systemtest/src/test/java/org/bf2/systemtest/integration/SmokeST.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag(TestTags.SMOKE)
 public class SmokeST extends AbstractST {
@@ -99,8 +98,6 @@ public class SmokeST extends AbstractST {
         ManagedKafkaStatus apiStatus = Serialization.jsonMapper()
                 .readValue(SyncApiClient.getManagedKafkaStatus(mk.getId(), syncEndpoint).body(), ManagedKafkaStatus.class);
         ManagedKafka managedKafka = ManagedKafkaResourceType.getOperation().inNamespace(mkAppName).withName(mkAppName).get();
-
-        assertTrue(managedKafka.getMetadata().getFinalizers() == null || managedKafka.getMetadata().getFinalizers().isEmpty());
 
         AssertUtils.assertManagedKafkaStatus(managedKafka, apiStatus);
 


### PR DESCRIPTION
This reverts commit 65edcc0b82747c98668181f5db50178b582747bc.

@shawkins - FYI, this seems to trigger a bug where fleetshard sees a large increase of modification events.