### PR TITLE
Change default ACLs to describe only

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -43,9 +43,8 @@ managedkafka.kafka.acl.allowed-listeners=SRE-9096
 # - Default clusters to allow describe of all topics, consumer groups, and ACLs
 # - Globally deny cluster operations other than idempotent_write, describe_acls, create_acls, and delete_acls
 managedkafka.kafka.acl.global=\
-default=true;permission=allow;topic=*;operations=all \n\
-default=true;permission=allow;group=*;operations=all \n\
-default=true;permission=allow;transactional_id=*;operations=all \n\
+default=true;permission=allow;topic=*;operations=describe,describe_configs \n\
+default=true;permission=allow;group=*;operations=describe \n\
 default=true;permission=allow;cluster=*;operations=describe \n\
 permission=allow;cluster=*;operations=idempotent_write \n\
 permission=deny;cluster=*;operations-except=alter,describe,idempotent_write \n\

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -135,35 +135,34 @@ spec:
       connections.max.reauth.ms: 299000
       strimzi.authorization.custom-authorizer.allowed-listeners: SRE-9096
       strimzi.authorization.custom-authorizer.resource-operations: '{ "cluster": [ "describe", "alter" ], "group": [ "all", "delete", "describe", "read" ], "topic": [ "all", "alter", "alter_configs", "create", "delete", "describe", "describe_configs", "read", "write" ], "transactional_id": [ "all", "describe", "write" ] }'
-      strimzi.authorization.custom-authorizer.acl.001: default=true;permission=allow;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.002: default=true;permission=allow;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.003: default=true;permission=allow;transactional_id=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.004: default=true;permission=allow;cluster=*;operations=describe
-      strimzi.authorization.custom-authorizer.acl.005: permission=allow;cluster=*;operations=idempotent_write
-      strimzi.authorization.custom-authorizer.acl.006: permission=deny;cluster=*;operations-except=alter,describe,idempotent_write
-      strimzi.authorization.custom-authorizer.acl.007: permission=deny;cluster=*;operations=describe;apis-except=describe_acls
-      strimzi.authorization.custom-authorizer.acl.008: permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls
-      strimzi.authorization.custom-authorizer.acl.009: permission=deny;topic=__*;operations=all
-      strimzi.authorization.custom-authorizer.acl.010: permission=deny;group=strimzi-canary-group;operations=all
-      strimzi.authorization.custom-authorizer.acl.011: priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls
-      strimzi.authorization.custom-authorizer.acl.012: priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls
-      strimzi.authorization.custom-authorizer.acl.013: priority=1;permission=allow;principal=userid-123;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.014: priority=1;permission=allow;principal=userid-123;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.015: priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.016: priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
-      strimzi.authorization.custom-authorizer.acl.017: priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
-      strimzi.authorization.custom-authorizer.acl.018: priority=1;permission=allow;principal=canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter,alter_configs
-      strimzi.authorization.custom-authorizer.acl.019: priority=1;permission=allow;principal=canary-123;group=strimzi-canary-group;operations=describe,read
-      strimzi.authorization.custom-authorizer.acl.020: priority=2;permission=deny;principal=canary-123;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.021: priority=2;permission=deny;principal=canary-123;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.022: priority=2;permission=deny;principal=canary-123;transactional_id=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.023: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
-      strimzi.authorization.custom-authorizer.acl.024: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
-      strimzi.authorization.custom-authorizer.acl.025: priority=1;permission=allow;principal=service-account-canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter,alter_configs
-      strimzi.authorization.custom-authorizer.acl.026: priority=1;permission=allow;principal=service-account-canary-123;group=strimzi-canary-group;operations=describe,read
-      strimzi.authorization.custom-authorizer.acl.027: priority=2;permission=deny;principal=service-account-canary-123;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.028: priority=2;permission=deny;principal=service-account-canary-123;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.029: priority=2;permission=deny;principal=service-account-canary-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.001: default=true;permission=allow;topic=*;operations=describe,describe_configs
+      strimzi.authorization.custom-authorizer.acl.002: default=true;permission=allow;group=*;operations=describe
+      strimzi.authorization.custom-authorizer.acl.003: default=true;permission=allow;cluster=*;operations=describe
+      strimzi.authorization.custom-authorizer.acl.004: permission=allow;cluster=*;operations=idempotent_write
+      strimzi.authorization.custom-authorizer.acl.005: permission=deny;cluster=*;operations-except=alter,describe,idempotent_write
+      strimzi.authorization.custom-authorizer.acl.006: permission=deny;cluster=*;operations=describe;apis-except=describe_acls
+      strimzi.authorization.custom-authorizer.acl.007: permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls
+      strimzi.authorization.custom-authorizer.acl.008: permission=deny;topic=__*;operations=all
+      strimzi.authorization.custom-authorizer.acl.009: permission=deny;group=strimzi-canary-group;operations=all
+      strimzi.authorization.custom-authorizer.acl.010: priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls
+      strimzi.authorization.custom-authorizer.acl.011: priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls
+      strimzi.authorization.custom-authorizer.acl.012: priority=1;permission=allow;principal=userid-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.013: priority=1;permission=allow;principal=userid-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.014: priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.015: priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.016: priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.017: priority=1;permission=allow;principal=canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter,alter_configs
+      strimzi.authorization.custom-authorizer.acl.018: priority=1;permission=allow;principal=canary-123;group=strimzi-canary-group;operations=describe,read
+      strimzi.authorization.custom-authorizer.acl.019: priority=2;permission=deny;principal=canary-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.020: priority=2;permission=deny;principal=canary-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.021: priority=2;permission=deny;principal=canary-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.022: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.023: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.024: priority=1;permission=allow;principal=service-account-canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter,alter_configs
+      strimzi.authorization.custom-authorizer.acl.025: priority=1;permission=allow;principal=service-account-canary-123;group=strimzi-canary-group;operations=describe,read
+      strimzi.authorization.custom-authorizer.acl.026: priority=2;permission=deny;principal=service-account-canary-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.027: priority=2;permission=deny;principal=service-account-canary-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.028: priority=2;permission=deny;principal=service-account-canary-123;transactional_id=*;operations=all
     storage: !<jbod>
       volumes:
       - !<persistent-claim>

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -133,35 +133,34 @@ spec:
       connections.max.reauth.ms: 299000
       strimzi.authorization.custom-authorizer.allowed-listeners: SRE-9096
       strimzi.authorization.custom-authorizer.resource-operations: '{ "cluster": [ "describe", "alter" ], "group": [ "all", "delete", "describe", "read" ], "topic": [ "all", "alter", "alter_configs", "create", "delete", "describe", "describe_configs", "read", "write" ], "transactional_id": [ "all", "describe", "write" ] }'
-      strimzi.authorization.custom-authorizer.acl.001: default=true;permission=allow;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.002: default=true;permission=allow;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.003: default=true;permission=allow;transactional_id=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.004: default=true;permission=allow;cluster=*;operations=describe
-      strimzi.authorization.custom-authorizer.acl.005: permission=allow;cluster=*;operations=idempotent_write
-      strimzi.authorization.custom-authorizer.acl.006: permission=deny;cluster=*;operations-except=alter,describe,idempotent_write
-      strimzi.authorization.custom-authorizer.acl.007: permission=deny;cluster=*;operations=describe;apis-except=describe_acls
-      strimzi.authorization.custom-authorizer.acl.008: permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls
-      strimzi.authorization.custom-authorizer.acl.009: permission=deny;topic=__*;operations=all
-      strimzi.authorization.custom-authorizer.acl.010: permission=deny;group=strimzi-canary-group;operations=all
-      strimzi.authorization.custom-authorizer.acl.011: priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls
-      strimzi.authorization.custom-authorizer.acl.012: priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls
-      strimzi.authorization.custom-authorizer.acl.013: priority=1;permission=allow;principal=userid-123;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.014: priority=1;permission=allow;principal=userid-123;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.015: priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.016: priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
-      strimzi.authorization.custom-authorizer.acl.017: priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
-      strimzi.authorization.custom-authorizer.acl.018: priority=1;permission=allow;principal=canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter,alter_configs
-      strimzi.authorization.custom-authorizer.acl.019: priority=1;permission=allow;principal=canary-123;group=strimzi-canary-group;operations=describe,read
-      strimzi.authorization.custom-authorizer.acl.020: priority=2;permission=deny;principal=canary-123;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.021: priority=2;permission=deny;principal=canary-123;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.022: priority=2;permission=deny;principal=canary-123;transactional_id=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.023: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
-      strimzi.authorization.custom-authorizer.acl.024: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
-      strimzi.authorization.custom-authorizer.acl.025: priority=1;permission=allow;principal=service-account-canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter,alter_configs
-      strimzi.authorization.custom-authorizer.acl.026: priority=1;permission=allow;principal=service-account-canary-123;group=strimzi-canary-group;operations=describe,read
-      strimzi.authorization.custom-authorizer.acl.027: priority=2;permission=deny;principal=service-account-canary-123;topic=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.028: priority=2;permission=deny;principal=service-account-canary-123;group=*;operations=all
-      strimzi.authorization.custom-authorizer.acl.029: priority=2;permission=deny;principal=service-account-canary-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.001: default=true;permission=allow;topic=*;operations=describe,describe_configs
+      strimzi.authorization.custom-authorizer.acl.002: default=true;permission=allow;group=*;operations=describe
+      strimzi.authorization.custom-authorizer.acl.003: default=true;permission=allow;cluster=*;operations=describe
+      strimzi.authorization.custom-authorizer.acl.004: permission=allow;cluster=*;operations=idempotent_write
+      strimzi.authorization.custom-authorizer.acl.005: permission=deny;cluster=*;operations-except=alter,describe,idempotent_write
+      strimzi.authorization.custom-authorizer.acl.006: permission=deny;cluster=*;operations=describe;apis-except=describe_acls
+      strimzi.authorization.custom-authorizer.acl.007: permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls
+      strimzi.authorization.custom-authorizer.acl.008: permission=deny;topic=__*;operations=all
+      strimzi.authorization.custom-authorizer.acl.009: permission=deny;group=strimzi-canary-group;operations=all
+      strimzi.authorization.custom-authorizer.acl.010: priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls
+      strimzi.authorization.custom-authorizer.acl.011: priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls
+      strimzi.authorization.custom-authorizer.acl.012: priority=1;permission=allow;principal=userid-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.013: priority=1;permission=allow;principal=userid-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.014: priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.015: priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.016: priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.017: priority=1;permission=allow;principal=canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter,alter_configs
+      strimzi.authorization.custom-authorizer.acl.018: priority=1;permission=allow;principal=canary-123;group=strimzi-canary-group;operations=describe,read
+      strimzi.authorization.custom-authorizer.acl.019: priority=2;permission=deny;principal=canary-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.020: priority=2;permission=deny;principal=canary-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.021: priority=2;permission=deny;principal=canary-123;transactional_id=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.022: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=describe;apis=list_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.023: priority=1;permission=allow;principal=service-account-canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments
+      strimzi.authorization.custom-authorizer.acl.024: priority=1;permission=allow;principal=service-account-canary-123;topic=__strimzi_canary;operations=create,describe,read,write,alter,alter_configs
+      strimzi.authorization.custom-authorizer.acl.025: priority=1;permission=allow;principal=service-account-canary-123;group=strimzi-canary-group;operations=describe,read
+      strimzi.authorization.custom-authorizer.acl.026: priority=2;permission=deny;principal=service-account-canary-123;topic=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.027: priority=2;permission=deny;principal=service-account-canary-123;group=*;operations=all
+      strimzi.authorization.custom-authorizer.acl.028: priority=2;permission=deny;principal=service-account-canary-123;transactional_id=*;operations=all
     storage: !<jbod>
       volumes:
       - !<persistent-claim>


### PR DESCRIPTION
Replace `permission=allow;topic=*;operations=all` 
  with `permission=allow;topic=*;operations=describe,describe_configs`

Replace `permission=allow;group=*;operations=all`
with `permission=allow;group=*;operations=describe`

Remove `permission=allow;transactional_id=*;operations=all`

Signed-off-by: Michael Edgar <medgar@redhat.com>