### PR TITLE
Demote "No Strimzi versions found in PackageManifest" to warning

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/StrimziBundleManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/StrimziBundleManager.java
@@ -34,6 +34,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -215,6 +216,11 @@ public class StrimziBundleManager {
                         .map(annotations -> annotations.get("strimziVersions"))
                         .orElse(null);
 
+        if (strimziVersionsJson == null) {
+            log.warnf("No Strimzi versions found in PackageManifest %s/%s yet.",
+                    packageManifest.getMetadata().getNamespace(), packageManifest.getMetadata().getName());
+            return Collections.emptyList();
+        }
         List<String> strimziVersions = new ArrayList<>();
         try {
             strimziVersions = Serialization.jsonMapper().readValue(strimziVersionsJson, List.class);


### PR DESCRIPTION
The appearance of the IAE is misleading.  As this isn't an error condition, demote to warning.