### PR TITLE
Added available Kafka versions in the ManagedKafkaAgent status

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/StrimziVersionStatus.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/StrimziVersionStatus.java
@@ -6,6 +6,8 @@ import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.List;
+
 /**
  * Define the status for installed Strimzi versions on the Kubernetes cluster
  * and if they are ready or not
@@ -22,6 +24,8 @@ public class StrimziVersionStatus {
     private String version;
     @NotNull
     private boolean ready;
+    @NotNull
+    private List<String> kafkaVersions;
 
     public String getVersion() {
         return version;
@@ -37,5 +41,13 @@ public class StrimziVersionStatus {
 
     public void setReady(boolean ready) {
         this.ready = ready;
+    }
+
+    public List<String> getKafkaVersions() {
+        return kafkaVersions;
+    }
+
+    public void setKafkaVersions(List<String> kafkaVersions) {
+        this.kafkaVersions = kafkaVersions;
     }
 }


### PR DESCRIPTION
This PR uses the `STRIMZI_KAFKA_IMAGES` env var from a Strimzi operator deployment in order to get the available Kafka versions for that operator and updating the corresponding ManagedKafkaAgent status.