### PR TITLE
Expose request error metrics to Prometheus

### DIFF
--- a/operator/src/main/resources/kafka-metrics.yaml
+++ b/operator/src/main/resources/kafka-metrics.yaml
@@ -7,6 +7,13 @@ metadata:
 data:
   jmx-exporter-config: |
     lowercaseOutputName: true
+    #
+    # Note that whitespace is important in the rule pattern - there
+    # needs to be a space after each comma.
+    #
+    # Bad: 'kafka.server<type=(.+),listener=(.+),networkProcessor=(.+)><>(.+):'
+    # Good: 'kafka.server<type=(.+), listener=(.+), networkProcessor=(.+)><>(.+):'
+    #
     rules:
       - labels:
           clientID: $3
@@ -208,6 +215,12 @@ data:
         labels:
           listener: "$1"
           networkProcessor: "$2"
+      - pattern: kafka.network<type=RequestMetrics, name=ErrorsPerSec, request=(.+), error=(.+)><>Count
+        name: kafka_network_request_errors_total
+        type: COUNTER
+        labels:
+          request: "$1"
+          error: "$2"
       - pattern: kafka.server<type=socket-server-metrics><>broker-connection-accept-rate
         name: kafka_server_socket_broker_connection_accept_rate
         type: GAUGE


### PR DESCRIPTION
Every request will have an "error", even if that's NONE, so the total number of "errors" will always be increasing. We can use these metrics to measure how many problematic errors we encounter as a percentage of the total number, and react if it gets too high.