### PR TITLE
disabling startup events for unit tests

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -119,3 +119,5 @@ managedkafka.kafka.max-connections=3000
 managedkafka.kafka.container-cpu=4500m
 managedkafka.kafka.container-memory=19Gi
 managedkafka.kafka.jvm-xms=6442450944
+
+quarkus.arc.test.disable-application-lifecycle-observers=true

--- a/sync/src/main/resources/application.properties
+++ b/sync/src/main/resources/application.properties
@@ -56,3 +56,5 @@ quarkus.kubernetes.resources.requests.memory=128Mi
 quarkus.kubernetes.resources.requests.cpu=100m
 quarkus.kubernetes.resources.limits.memory=256Mi
 quarkus.kubernetes.resources.limits.cpu=500m
+
+quarkus.arc.test.disable-application-lifecycle-observers=true


### PR DESCRIPTION
this was an upstream feature we requested a while ago, but helps even
more now that we have so many beans marked as Startup