### PR TITLE
Add 'oc observe' script to place canary configmap

### DIFF
--- a/tools/apply_canary_configmap.sh
+++ b/tools/apply_canary_configmap.sh
@@ -18,9 +18,49 @@ metadata:
 data:
   sarama.log.enabled: "true"
   verbosity.log.level: "1"
+  go.debug: "netdns=go+9"
 ' | oc apply -n ${1} -f -
 
     for canary in $(oc -n ${1} get deploy -l app.kubernetes.io/component=canary -o name --no-headers); do
         oc -n ${1} rollout restart ${canary}
     done
+
+    while [[ $(oc get routes -l app.kubernetes.io/name=kafka -o=jsonpath='{.items[*].spec.host}' | wc -w) != 4 ]]; do
+        echo "Waiting 5s for availability of Kafka routes before creating nslookup pod..."
+        sleep 5
+    done
+    bootstrap_route=$(oc get routes -l app.kubernetes.io/name=kafka -o=jsonpath='{range .items[*]}{.spec.host}{"\n"}{end}' | grep -v broker)
+    echo $bootstrap_route
+
+    echo 'apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    created-by: oc-observe
+  name: nslookup
+spec:
+  containers:
+  - name: nslookup
+    image: quay.io/grdryn/ubi8-bind-utils
+    imagePullPolicy: Always
+    args:
+    - /usr/bin/bash
+    - -c
+    - |
+      echo "Start: $(date)"
+      echo "cat /etc/resolve.conf"
+      cat /etc/resolv.conf
+
+      # Run nslookup every 5 seconds for 30 mins
+      for i in {0..360}; do
+          date
+          nslookup -debug ${KAFKA_BOOTSTRAP_DOMAIN}
+          echo "========================="
+          sleep 5
+      done
+      echo "End: $(date)"
+    env:
+    - name: KAFKA_BOOTSTRAP_DOMAIN
+      value: #bootstrap_route
+  restartPolicy: Never' | sed -e "s/#bootstrap_route/${bootstrap_route}/" | oc apply -n ${1} -f -
 fi


### PR DESCRIPTION
Open to suggestions for the best place for this script.

Example output:
```
$ oc observe namespaces --type-env-var='OBSERVE_EVENT_TYPE' -l 'bf2.org/managedkafka-id' -- ./apply_canary_configmap.sh 
# 2021-12-02T15:31:04Z Added 3826734	./apply_canary_configmap.sh kafka-c6kecg03jvu8790blrv0 ""
configmap/canary-config created
deployment.apps/gryan-canary restarted
# 2021-12-02T15:31:09Z Updated 3826742	./apply_canary_configmap.sh kafka-c6kecg03jvu8790blrv0 ""
```