### PR TITLE
CVE-2021-44228 Log4Shell: Bump log4j to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,11 @@
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
         <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
-        <log4j2.version>2.13.3</log4j2.version>
     </properties>
 
     <dependencies>
@@ -33,17 +32,14 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Strimzi 0.23 brings a dependency on Apache Log4j.  Override it in dependencyManagement to pull in the version with the CVE fix.