### PR TITLE
 bump to log4j 2.16.0.

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -51,16 +51,6 @@
         <dependency>
             <groupId>io.strimzi</groupId>
             <artifactId>api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>log4j-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,14 @@
                     <!-- Quarkus logging system requiring it for avoiding multiple bindings problem: https://quarkus.io/guides/logging#logging-adapters -->
                     <exclusion>
                         <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-slf4j-impl</artifactId>
                     </exclusion>
                 </exclusions>


### PR DESCRIPTION
Addresses: https://access.redhat.com/security/cve/CVE-2021-4104