### PR TITLE
Set rate-limit annotations on Admin Server OpenShift Route

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -467,6 +467,15 @@ public class KafkaInstanceConfiguration {
         @JsonProperty("container-cpu")
         protected String containerCpu = ADMIN_SERVER_CONTAINER_CPU;
 
+        @JsonProperty("rate-limit-enabled")
+        protected boolean rateLimitEnabled = true;
+
+        @JsonProperty("rate-limit-concurrent-tcp")
+        protected int rateLimitConcurrentTcp = 20;
+
+        @JsonProperty("rate-limit-requests-per-sec")
+        protected int rateLimitRequestsPerSec = 40;
+
         public boolean isColocateWithZookeeper() {
             return colocateWithZookeeper;
         }
@@ -497,6 +506,30 @@ public class KafkaInstanceConfiguration {
 
         public void setContainerCpu(String containerCpu) {
             this.containerCpu = containerCpu;
+        }
+
+        public boolean isRateLimitEnabled() {
+            return rateLimitEnabled;
+        }
+
+        public void setRateLimitEnabled(boolean rateLimitEnabled) {
+            this.rateLimitEnabled = rateLimitEnabled;
+        }
+
+        public int getRateLimitConcurrentTcp() {
+            return rateLimitConcurrentTcp;
+        }
+
+        public void setRateLimitConcurrentTcp(int rateLimitConcurrentTcp) {
+            this.rateLimitConcurrentTcp = rateLimitConcurrentTcp;
+        }
+
+        public int getRateLimitRequestsPerSec() {
+            return rateLimitRequestsPerSec;
+        }
+
+        public void setRateLimitRequestsPerSec(int rateLimitRequestsPerSec) {
+            this.rateLimitRequestsPerSec = rateLimitRequestsPerSec;
         }
     }
 


### PR DESCRIPTION
As an alternate approach to #595 

- Limit concurrent TCP connections per-IP to 20
- Limit requests/sec per-IP to 40

Signed-off-by: Michael Edgar <medgar@redhat.com>