### PR TITLE
Added some improvements to the osd-provision script

### DIFF
--- a/perf/scripts/osd-provision.sh
+++ b/perf/scripts/osd-provision.sh
@@ -246,6 +246,7 @@ function print_vars() {
     echo "OUTPUT: ${OUTPUT}"
     echo "CLUSTER_JSON: ${CLUSTER_JSON}"
     if [[ -z "${TOKEN}" ]]; then 
+        echo "Using '${TOKEN_FILE}' token file"
         TOKEN=$(cat ${TOKEN_FILE})
     fi
     echo "TOKEN: ${TOKEN}"
@@ -566,7 +567,7 @@ if [[ "${OPERATION}" == "create" ]]; then
             exit 1
         fi
     else
-        RESPONSE=`$OCM post /api/clusters_mgmt/v1/clusters --body="${CLUSTER_JSON}" 2>&1`
+        RESPONSE=$($OCM post /api/clusters_mgmt/v1/clusters --body="${CLUSTER_JSON}" 2>&1)
         if [[ $? -ne 0 ]]; then
             ERROR_MESSAGE=$(echo $RESPONSE | jq -r .details[].Error_Key)
             if [[ "$ERROR_MESSAGE" != "DuplicateClusterName" ]]; then


### PR DESCRIPTION
In order to use the mas-ci jenkins, we would like to introduce some of the changes we needed to run our performance and fault test pipelines. Those changes are:
- Include the install logging when the cluster finishes in error status
- Avoid script failure when the osd is already installed (DuplicatedClusterName error handling) using `--allow-existing-cluster` option
- Allow to set the token without storing it in a file
- Improve the grep filters when listing the clusters by name using `ocm list cluster --parameter search="name = '<name>'" --no-headers`
