### PR TITLE
Adding Network Policy for canary and admin server

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -268,11 +268,11 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
         KafkaListenerType externalListenerType = kubernetesClient.isAdaptable(OpenShiftClient.class) ? KafkaListenerType.ROUTE : KafkaListenerType.INGRESS;
 
         // Limit client connections per listener
-        Integer totalMaxConnections = Objects.requireNonNullElse(managedKafka.getSpec().getCapacity().getTotalMaxConnections(), this.config.getKafka().getMaxConnections())/this.config.getKafka().getReplicas();
+        Integer totalMaxConnections = Objects.requireNonNullElse(managedKafka.getSpec().getCapacity().getTotalMaxConnections(), this.config.getKafka().getMaxConnections()) / this.config.getKafka().getReplicas();
         // Limit connection attempts per listener
-        Integer maxConnectionAttemptsPerSec = Objects.requireNonNullElse(managedKafka.getSpec().getCapacity().getMaxConnectionAttemptsPerSec(), this.config.getKafka().getConnectionAttemptsPerSec())/this.config.getKafka().getReplicas();
+        Integer maxConnectionAttemptsPerSec = Objects.requireNonNullElse(managedKafka.getSpec().getCapacity().getMaxConnectionAttemptsPerSec(), this.config.getKafka().getConnectionAttemptsPerSec()) / this.config.getKafka().getReplicas();
 
-        GenericKafkaListenerConfigurationBuilder listenerConfigBuilder =  new GenericKafkaListenerConfigurationBuilder()
+        GenericKafkaListenerConfigurationBuilder listenerConfigBuilder = new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
                         .withHost(managedKafka.getSpec().getEndpoint().getBootstrapServerHost())
                         .withAnnotations(Map.of("haproxy.router.openshift.io/balance", "leastconn"))
@@ -290,9 +290,12 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                                 .withPort(9093)
                                 .withType(KafkaListenerType.INTERNAL)
                                 .withTls(true)
-                                .withAuth(plainOverOauthAuthenticationListener).withNetworkPolicyPeers(new io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder()
-                                    .withNewPodSelector().addToMatchLabels("app", AbstractCanary.canaryName(managedKafka))
-                                    .endPodSelector().build())
+                                .withAuth(plainOverOauthAuthenticationListener)
+                                .withNetworkPolicyPeers(new NetworkPolicyPeerBuilder()
+                                        .withNewPodSelector()
+                                        .addToMatchLabels("app", AbstractCanary.canaryName(managedKafka))
+                                        .endPodSelector()
+                                        .build())
                                 .build(),
                         new GenericKafkaListenerBuilder()
                                 .withName("external")
@@ -307,9 +310,11 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                                 .withPort(9095)
                                 .withType(KafkaListenerType.INTERNAL)
                                 .withTls(true)
-                                .withAuth(oauthAuthenticationListener).withNetworkPolicyPeers(new io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder()
-                                    .withNewPodSelector().addToMatchLabels("app", AbstractAdminServer.adminServerName(managedKafka))
-                                    .endPodSelector().build())
+                                .withAuth(oauthAuthenticationListener)
+                                .withNetworkPolicyPeers(new NetworkPolicyPeerBuilder()
+                                        .withNewPodSelector()
+                                        .addToMatchLabels("app", AbstractAdminServer.adminServerName(managedKafka))
+                                        .endPodSelector().build())
                                 .build(),
                         new GenericKafkaListenerBuilder()
                                 .withName("sre")

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -44,6 +44,10 @@ spec:
         tokenEndpointUri: "https://tokenEndpointURI"
         enableOauthBearer: true
         type: "oauth"
+      networkPolicyPeers:
+        - podSelector:
+            matchLabels:
+              app: "test-mk-canary"
     - name: "external"
       port: 9094
       type: "ingress"
@@ -104,6 +108,10 @@ spec:
           certificate: "keycloak.crt"
         enableOauthBearer: true
         type: "oauth"
+      networkPolicyPeers:
+        - podSelector:
+            matchLabels:
+              app: "test-mk-admin-server"
     - name: "sre"
       port: 9096
       type: "internal"

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -44,6 +44,10 @@ spec:
         tokenEndpointUri: "https://tokenEndpointURI"
         enableOauthBearer: true
         type: "oauth"
+      networkPolicyPeers:
+        - podSelector:
+            matchLabels:
+              app: "test-mk-canary"
     - name: "external"
       port: 9094
       type: "ingress"
@@ -102,6 +106,10 @@ spec:
           certificate: "keycloak.crt"
         enableOauthBearer: true
         type: "oauth"
+      networkPolicyPeers:
+        - podSelector:
+            matchLabels:
+              app: "test-mk-admin-server"
     - name: "sre"
       port: 9096
       type: "internal"


### PR DESCRIPTION
This is to add a network policy with pod selector matching labels on canary and admin API server (the label "app") in order to restrict the listener to these components. 