### PR TITLE
updating to strimzi .26

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -14,8 +14,7 @@ import io.strimzi.api.kafka.model.GenericSecretSourceBuilder;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthentication;
 import io.strimzi.api.kafka.model.listener.KafkaListenerAuthenticationOAuthBuilder;
-import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListeners;
-import io.strimzi.api.kafka.model.listener.arraylistener.ArrayOrObjectKafkaListenersBuilder;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBootstrapBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfigurationBroker;
@@ -40,6 +39,7 @@ import org.jboss.logging.Logger;
 import javax.inject.Inject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -223,7 +223,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
         kafkaResourceClient.createOrUpdate(kafka);
     }
 
-    protected ArrayOrObjectKafkaListeners buildListeners(ManagedKafka managedKafka) {
+    protected List<GenericKafkaListener> buildListeners(ManagedKafka managedKafka) {
 
         KafkaListenerAuthentication plainOverOauthAuthenticationListener = null;
         KafkaListenerAuthentication oauthAuthenticationListener = null;
@@ -282,8 +282,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                 .withMaxConnections(totalMaxConnections)
                 .withMaxConnectionCreationRate(maxConnectionAttemptsPerSec);
 
-        return new ArrayOrObjectKafkaListenersBuilder()
-                .withGenericKafkaListeners(
+        return Arrays.asList(
                         new GenericKafkaListenerBuilder()
                                 .withName("tls")
                                 .withPort(9093)
@@ -312,7 +311,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                                 .withType(KafkaListenerType.INTERNAL)
                                 .withTls(false)
                                 .build()
-                ).build();
+                );
     }
 
     protected List<GenericKafkaListenerConfigurationBroker> buildBrokerOverrides(ManagedKafka managedKafka) {

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-        <strimzi.version>0.23.0</strimzi.version>
+        <strimzi.version>0.26.0</strimzi.version>
         <fabric8.client.version>5.7.2</fabric8.client.version>
         <quarkus.operator.extension>2.0.0.Beta5</quarkus.operator.extension>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>


### PR DESCRIPTION
the crd versioning did not change, but they did eliminate an intermediate list representation