### PR TITLE
Bump kafka-admin-api image to 0.7.0

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -5,7 +5,7 @@ quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %x %s%
 # for quarkus 1.x compatibility
 quarkus.kubernetes.ports.http.host-port=8080
 
-image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.6.4
+image.admin-api=quay.io/mk-ci-cd/kafka-admin-api:0.7.0
 image.canary=quay.io/mk-ci-cd/strimzi-canary:0.2.0-220111183833
 image.canary-init=quay.io/mk-ci-cd/strimzi-canary:0.2.0-220111183833
 

--- a/operator/src/test/resources/expected/adminserver.yml
+++ b/operator/src/test/resources/expected/adminserver.yml
@@ -61,7 +61,7 @@ spec:
           value: "1000"
         - name: "KAFKA_ADMIN_OAUTH_ENABLED"
           value: "false"
-        image: "quay.io/mk-ci-cd/kafka-admin-api:0.6.4"
+        image: "quay.io/mk-ci-cd/kafka-admin-api:0.7.0"
         livenessProbe:
           httpGet:
             path: "/health/liveness"


### PR DESCRIPTION
Release notes:
https://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/releases/tag/0.7.0

Signed-off-by: Michael Edgar <medgar@redhat.com>