### PR TITLE
upgrading to quarkus operator sdk 2.0.3

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.fabric8.kubernetes.client.utils.Serialization;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -66,7 +65,7 @@ public class KafkaInstanceConfiguration {
     protected Canary canary = new Canary();
 
     public Map<String, String> toMap(boolean includeAll) {
-        ObjectMapper mapper = Serialization.jsonMapper();
+        ObjectMapper mapper = new ObjectMapper();
         if (!includeAll) {
             mapper = mapper.copy().setSerializationInclusion(Include.NON_NULL);
         }

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -6,7 +6,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
@@ -216,9 +215,6 @@ public class IngressControllerManagerTest {
 
     @AfterEach
     void cleanup() {
-        // clears the mock server state
-        // won't be needed after quarkus fixes issues with WithKubernetesTestServer
-        kubernetesServer.getMockServer().setDispatcher(new KubernetesCrudDispatcher());
         ingressControllerManager.getRouteMatchLabels().clear();
     }
 }

--- a/operator/src/test/java/org/bf2/operator/managers/StrimziManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/StrimziManagerTest.java
@@ -5,7 +5,6 @@ import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -20,7 +19,6 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatusBuilder;
 import org.bf2.operator.resources.v1alpha1.StrimziVersionStatus;
 import org.bf2.operator.resources.v1alpha1.VersionsBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,11 +61,6 @@ public class StrimziManagerTest {
         this.strimziManager.clearStrimziVersions();
 
         this.informerManager.createKafkaInformer();
-    }
-
-    @AfterEach
-    public void afterEach() {
-        this.server.getMockServer().setDispatcher(new KubernetesCrudDispatcher());
     }
 
     @Test

--- a/perf/src/main/java/org/bf2/performance/InstanceProfiler.java
+++ b/perf/src/main/java/org/bf2/performance/InstanceProfiler.java
@@ -255,9 +255,9 @@ public class InstanceProfiler {
         kafkaProvisioner = ManagedKafkaProvisioner.create(kafkaCluster);
 
         kafkaProvisioner.setup();
-        omb = new OMB(KubeClusterResource.connectToKubeCluster(PerformanceEnvironment.OMB_KUBECONFIG));
+        omb = new OMB(KubeClusterResource.connectToKubeCluster(PerformanceEnvironment.KAFKA_KUBECONFIG));
 
-        omb.install(kafkaProvisioner.getTlsConfig());
+        //omb.install(kafkaProvisioner.getTlsConfig());
 
         // TODO: if there is an existing result, make sure it's the same test setup
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,16 +56,16 @@
 
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <quarkus.platform.version>2.2.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.6.2.Final</quarkus.platform.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <strimzi.version>0.26.0</strimzi.version>
-        <fabric8.client.version>5.7.2</fabric8.client.version>
-        <quarkus.operator.extension>2.0.0.Beta5</quarkus.operator.extension>
+        <fabric8.client.version>5.10.2</fabric8.client.version>
+        <quarkus.operator.extension>2.0.3</quarkus.operator.extension>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <junit.platform.version>1.7.2</junit.platform.version>
-        <sundrio.version>0.40.1</sundrio.version>
-        <lombok.version>1.18.20</lombok.version>
+        <sundrio.version>0.50.1</sundrio.version>
+        <lombok.version>1.18.22</lombok.version>
         <jandex-plugin.version>1.0.7</jandex-plugin.version>
         <properties-plugin.version>1.0.0</properties-plugin.version>
         <impsort-plugin.version>1.6.0</impsort-plugin.version>

--- a/sync/src/test/java/org/bf2/sync/informer/CustomResourceEventHandlerTest.java
+++ b/sync/src/test/java/org/bf2/sync/informer/CustomResourceEventHandlerTest.java
@@ -1,0 +1,23 @@
+package org.bf2.sync.informer;
+
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.function.BiConsumer;
+
+public class CustomResourceEventHandlerTest {
+
+    @Test public void testAdd() {
+        BiConsumer<ManagedKafka, ManagedKafka> consumer = Mockito.mock(BiConsumer.class);
+
+        CustomResourceEventHandler<ManagedKafka> handler = new CustomResourceEventHandler<>(consumer);
+
+        ManagedKafka mk = new ManagedKafka();
+
+        handler.onAdd(mk);
+
+        Mockito.verify(consumer).accept(null, mk);
+    }
+
+}


### PR DESCRIPTION
This is the base amount of changes needed to upgrade across our main dependencies.  This isn't necessarily to be merged - this commit can be used for reproducing quarkus issues on a more up-to-date version and to see in general how easy the next upgrade will be.

Follow on changes can include:
- re-enable the health check as the informers will return a good value for isWatching
- remove finalizers
- remove unnecessary startup annotations (I can't seem to find the link to the quarkus issue to confirm that this has been resolved)