### PR TITLE
Mount admin server TLS cert/key from volume secret

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractAdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractAdminServer.java
@@ -90,10 +90,6 @@ public abstract class AbstractAdminServer implements Operand<ManagedKafka> {
         return managedKafka.getMetadata().getName() + "-admin-server";
     }
 
-    public static String adminServerConfigVolumeName(ManagedKafka managedKafka) {
-        return managedKafka.getMetadata().getName() + "-config-volume";
-    }
-
     public static String adminServerNamespace(ManagedKafka managedKafka) {
         return managedKafka.getMetadata().getNamespace();
     }

--- a/operator/src/test/resources/expected/adminserver.yml
+++ b/operator/src/test/resources/expected/adminserver.yml
@@ -89,9 +89,9 @@ spec:
             cpu: "500m"
         volumeMounts:
           - mountPath: "/opt/kafka-admin-api/custom-config/"
-            name: "test-mk-config-volume"
+            name: "custom-config"
       volumes:
         - configMap:
             name: "test-mk-admin-server"
             optional: true
-          name: "test-mk-config-volume"
+          name: "custom-config"


### PR DESCRIPTION
Also remove unnecessary cluster name prefix from optional config volume

This is supported by the current admin server: https://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/blob/72741ba6e0ab787e1c3fa77c85f931e1843c2b55/kafka-admin/src/main/java/org/bf2/admin/http/server/AdminServer.java#L381-L403

Must be in place for the Quarkus-based admin server: https://quarkus.io/guides/http-reference#providing-a-certificate-and-key-file
