### PR TITLE
strimzi#canary#166 - mount config file to allow logging to be enabled at runtime

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -57,7 +57,7 @@ That is changes are applied at runtime, without the need to restart the canary.
 
 If you wish to change the logging configuration, you should create a ConfigMap named `canary-config` in the namespace of the Kafka instance where the canary is running.
 The ConfigMap must contain key `canary-config.json` containing a stringified JSON object providing the keys `verbosityLogLevel` and/or `saramaLogEnabled`.
-Kubernetes  configmap filesystem projection takes about 1 minute and the canary itself looks for changes every 30 seconds.
+Kubernetes configmap filesystem projection takes about 1 minute, and the canary itself looks for changes every 30 seconds.
 You may need to wait this long for the changes to be applied.
 
 * For `verbosityLogLevel` the *integer* values allowed are `0` (INFO), `1` (DEBUG) and `2` (TRACE).  If not provided the system defaults to `0`.
@@ -67,10 +67,10 @@ The following example command enables both canary logging at trace and sarama lo
 
 ```bash
 kubectl create configmap -n my-kafka-cluster-namespace canary-config \
-                          --from-file=canary-config.json='{saramaLogEnabled: true, verbosityLogLevel: 2}'
+                          --from-literal=canary-config.json='{"saramaLogEnabled": true, "verbosityLogLevel": 2}'
 ```
 
-To revert logging back to default, simply delete the configmap.
+To revert logging back to default, simply delete the configmap. You may need to wait again for the changes to be applied.
 
 ```bash
 kubectl delete configmap -n my-kafka-cluster-namespace canary-config

--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -60,7 +60,7 @@ public class Canary extends AbstractCanary {
     private static final String METRICS_PORT_NAME = "metrics";
     private static final IntOrString METRICS_PORT_TARGET = new IntOrString(METRICS_PORT_NAME);
     private static final String CANARY_CONFIG_CONFIGMAP_NAME = "canary-config";
-    private static final String CANARY_CONFIG_VOLUME_NAME = "canary-config-volume";
+    private static final String CANARY_CONFIG_VOLUME_NAME = "config-volume";
     private static final Path CANARY_DYNAMIC_CONFIG_JSON = Path.of("/opt/etc", "canary-config.json");
 
     @ConfigProperty(name = "managedkafka.canary.producer-latency-buckets")
@@ -185,7 +185,7 @@ public class Canary extends AbstractCanary {
                 new VolumeBuilder()
                         .withName(canaryTlsVolumeName(managedKafka))
                         .editOrNewSecret()
-                            .withSecretName(SecuritySecretManager.strimziClusterCaCertSecret(managedKafka))
+                        .withSecretName(SecuritySecretManager.strimziClusterCaCertSecret(managedKafka))
                         .endSecret()
                         .build(),
                 new VolumeBuilder()

--- a/operator/src/test/resources/expected/canary.yml
+++ b/operator/src/test/resources/expected/canary.yml
@@ -134,12 +134,12 @@ spec:
         - mountPath: "/tmp/tls-ca-cert"
           name: "test-mk-tls-ca-cert"
         - mountPath: "/opt/etc"
-          name: "canary-config-volume"
+          name: "config-volume"
       volumes:
       - name: "test-mk-tls-ca-cert"
         secret:
           secretName: "test-mk-cluster-ca-cert"
-      - name: "canary-config-volume"
+      - name: "config-volume"
         configMap:
           name: "canary-config"
           optional: true


### PR DESCRIPTION
Provides the ability to control the logging level of the canary at runtime, without canary restart.

This change is backwardly compatible.  Older versions of the canary would ignore the `canary-config.json` even if it were created. 

The ability to configure `SARAMA_LOG_ENABLED`/`VERBOSITY_LOG_LEVEL` is retained, ensuring that the existing method to control logging level (which requires canary restart) is maintained too.

The intent is to remove the old way of controlling logging via environment variables after one release.