### PR TITLE
Moving Canary sasl password to  secret

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/SecuritySecretManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/SecuritySecretManager.java
@@ -7,6 +7,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import io.strimzi.api.kafka.model.KafkaResources;
 import org.bf2.common.OperandUtils;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.operator.resources.v1alpha1.ServiceAccount;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -25,6 +26,8 @@ import java.util.stream.Collectors;
 public class SecuritySecretManager {
 
     public static final String ANNOTATION_SECRET_DEP_DIGEST = "managedkafka.bf2.org/secret-dependency-digest";
+    public static final String SASL_PRINCIPAL ="sasl.principal";
+    public static final String SASL_PASSWORD ="sasl.password";
 
     @Inject
     KubernetesClient kubernetesClient;
@@ -38,6 +41,10 @@ public class SecuritySecretManager {
 
     public static boolean isKafkaExternalCertificateEnabled(ManagedKafka managedKafka) {
         return managedKafka.getSpec().getEndpoint().getTls() != null;
+    }
+
+    public static boolean isCanaryServiceAccountPresent(ManagedKafka managedKafka){
+        return managedKafka.getServiceAccount(ServiceAccount.ServiceAccountName.Canary).isPresent();
     }
 
     public static String kafkaTlsSecretName(ManagedKafka managedKafka) {
@@ -58,6 +65,9 @@ public class SecuritySecretManager {
 
     public static String strimziClusterCaCertSecret(ManagedKafka managedKafka) {
         return KafkaResources.clusterCaCertificateSecretName(managedKafka.getMetadata().getName());
+    }
+    public static String canarySaslSecretName(ManagedKafka managedKafka){
+        return managedKafka.getMetadata().getName() + "-canary-sasl-secret";
     }
 
     public boolean isDeleted(ManagedKafka managedKafka) {
@@ -103,6 +113,15 @@ public class SecuritySecretManager {
             }
             if (currentSsoTlsSecret != null) {
                 secretResource(managedKafka, ssoTlsSecretName(managedKafka)).delete();
+            }
+        }
+        Secret currentCanarySaslSecret = cachedSecret(managedKafka, canarySaslSecretName(managedKafka));
+        if(isCanaryServiceAccountPresent(managedKafka)){
+            Secret canarySaslSecret = canarySaslSecretFrom(managedKafka, currentCanarySaslSecret);
+            createOrUpdate(canarySaslSecret);
+        } else {
+            if (currentCanarySaslSecret != null){
+                secretResource(managedKafka,canarySaslSecretName(managedKafka)).delete();
             }
         }
     }
@@ -214,6 +233,16 @@ public class SecuritySecretManager {
                                current,
                                Map.of("keycloak.crt", managedKafka.getSpec().getOauth().getTlsTrustedCertificate()));
     }
+
+    private static Secret canarySaslSecretFrom(ManagedKafka managedKafka, Secret current){
+        return buildSecretFrom(canarySaslSecretName(managedKafka),
+                "Opaque",
+                managedKafka,
+                current,
+                Map.of(SASL_PRINCIPAL, managedKafka.getServiceAccount(ServiceAccount.ServiceAccountName.Canary).get().getPrincipal(),
+                        SASL_PASSWORD, managedKafka.getServiceAccount(ServiceAccount.ServiceAccountName.Canary).get().getPassword()));
+    }
+
 
     private static String encode(String value) {
         return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Currently, sasl password and principal are visible in Canary Deployment objects, which isn't ideal. Hence, we are moving sasl credentials to a secret for Canary. [MGDSTRM-6667]. This is a continuation to the PR (closed) https://github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard/pull/650.