### PR TITLE
Add optional secret volume to sync to configure SSO trusted certificate

### DIFF
--- a/sync/src/main/resources/application.properties
+++ b/sync/src/main/resources/application.properties
@@ -47,6 +47,10 @@ quarkus.kubernetes-config.secrets=${secret.name}
 ## must be disabled by default for dev/test - cannot use indirection; set in container via env
 quarkus.kubernetes-config.enabled=false
 
+quarkus.kubernetes.secret-volumes.tls-config-volume.secret-name=sync-sso-tls-config
+quarkus.kubernetes.secret-volumes.tls-config-volume.optional=true
+quarkus.kubernetes.mounts.tls-config-volume.path=/config-sso-tls
+
 quarkus.kubernetes.config-map-volumes.logging-config-volume.config-map-name=sync-logging-config-override
 quarkus.kubernetes.config-map-volumes.logging-config-volume.optional=true
 quarkus.kubernetes.mounts.logging-config-volume.path=/config


### PR DESCRIPTION
This enables a trust-store to be configured for sync via `QUARKUS_OIDC_CLIENT_TLS_TRUST_STORE_FILE` when the SSO endpoint is using a self-signed certificate.

Aligns with configuration added to kas-installer: 
- deployment: https://github.com/bf2fc6cc711aee1a0c2a/kas-installer/pull/137/files#diff-86076e20d1de9f5e7490bac65425dba4870a59f1807c39f5191c7a817607d56b
- secret set-up: https://github.com/bf2fc6cc711aee1a0c2a/kas-installer/pull/137/files#diff-c65f056d795f37b5f7b8532ffd97a486c31d8e7485c1c940b735675e60bda89e