### PR TITLE
Removing Canary Listeners

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -289,18 +289,6 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
 
         return Arrays.asList(
                         new GenericKafkaListenerBuilder()
-                                .withName("tls")
-                                .withPort(9093)
-                                .withType(KafkaListenerType.INTERNAL)
-                                .withTls(true)
-                                .withAuth(plainOverOauthAuthenticationListener)
-                                .withNetworkPolicyPeers(new NetworkPolicyPeerBuilder()
-                                        .withNewPodSelector()
-                                        .addToMatchLabels("app", AbstractCanary.canaryName(managedKafka))
-                                        .endPodSelector()
-                                        .build())
-                                .build(),
-                        new GenericKafkaListenerBuilder()
                                 .withName("external")
                                 .withPort(9094)
                                 .withType(externalListenerType)

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -21,33 +21,6 @@ spec:
     version: "2.6.0"
     replicas: 4
     listeners:
-    - name: "tls"
-      port: 9093
-      type: "internal"
-      tls: true
-      authentication: !<oauth>
-        clientId: "clientId"
-        clientSecret:
-          secretName: "test-mk-sso-secret"
-          key: "ssoClientSecret"
-        validIssuerUri: "https://validIssuerEndpointURI"
-        checkIssuer: true
-        jwksEndpointUri: "https://jwksEndpointURI"
-        userNameClaim: "userNameClaim"
-        fallbackUserNameClaim: "fallbackUserNameClaim"
-        checkAccessTokenType: true
-        accessTokenIsJwt: true
-        tlsTrustedCertificates:
-          - secretName: "test-mk-sso-cert"
-            certificate: "keycloak.crt"
-        enablePlain: true
-        tokenEndpointUri: "https://tokenEndpointURI"
-        enableOauthBearer: true
-        type: "oauth"
-      networkPolicyPeers:
-        - podSelector:
-            matchLabels:
-              app: "test-mk-canary"
     - name: "external"
       port: 9094
       type: "ingress"

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -21,33 +21,6 @@ spec:
     version: "2.6.0"
     replicas: 3
     listeners:
-    - name: "tls"
-      port: 9093
-      type: "internal"
-      tls: true
-      authentication: !<oauth>
-        clientId: "clientId"
-        clientSecret:
-          secretName: "test-mk-sso-secret"
-          key: "ssoClientSecret"
-        validIssuerUri: "https://validIssuerEndpointURI"
-        checkIssuer: true
-        jwksEndpointUri: "https://jwksEndpointURI"
-        userNameClaim: "userNameClaim"
-        fallbackUserNameClaim: "fallbackUserNameClaim"
-        checkAccessTokenType: true
-        accessTokenIsJwt: true
-        tlsTrustedCertificates:
-          - secretName: "test-mk-sso-cert"
-            certificate: "keycloak.crt"
-        enablePlain: true
-        tokenEndpointUri: "https://tokenEndpointURI"
-        enableOauthBearer: true
-        type: "oauth"
-      networkPolicyPeers:
-        - podSelector:
-            matchLabels:
-              app: "test-mk-canary"
     - name: "external"
       port: 9094
       type: "ingress"


### PR DESCRIPTION
The canary now uses the external service (same as a client) the canary's old listener is no longer used by anything. This PR is to remove the old listeners.[[MGDSTRM-7137](https://issues.redhat.com/browse/MGDSTRM-7137)]