### PR TITLE
MGDSTRM-7464 switching the ingress sizing to be based on demand

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/InformerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/InformerManager.java
@@ -29,6 +29,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -170,6 +171,13 @@ public class InformerManager {
                 this.eventSource.onUpdate(k, k);
             });
         }
+    }
+
+    public List<Kafka> getKafkas() {
+        if (kafkaInformer != null) {
+            return kafkaInformer.getList();
+        }
+        return Collections.emptyList();
     }
 
     public void resyncManagedKafka() {

--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -401,7 +401,7 @@ public class IngressControllerManager {
             IngressController existing, int replicas, LabelSelector routeSelector, String topologyValue) {
 
         Optional<IngressController> optionalExisting = Optional.ofNullable(existing);
-        IngressControllerBuilder builder = optionalExisting.map(IngressControllerBuilder::new).orElse(new IngressControllerBuilder());
+        IngressControllerBuilder builder = optionalExisting.map(IngressControllerBuilder::new).orElseGet(IngressControllerBuilder::new);
         Integer existingReplicas = optionalExisting.map(IngressController::getSpec).map(IngressControllerSpec::getReplicas).orElse(null);
         int previousNodeCount = optionalExisting.map(IngressController::getMetadata)
                 .map(ObjectMeta::getAnnotations)

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -50,6 +50,8 @@ import java.util.function.Predicate;
 
 public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
 
+    public static final String EXTERNAL_LISTENER_NAME = "external";
+
     @Inject
     Logger log;
 
@@ -289,7 +291,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
 
         return Arrays.asList(
                         new GenericKafkaListenerBuilder()
-                                .withName("external")
+                                .withName(EXTERNAL_LISTENER_NAME)
                                 .withPort(9094)
                                 .withType(externalListenerType)
                                 .withTls(true)

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -22,9 +22,18 @@ drain.cleaner.webhook.label.value=strimzi-drain-cleaner.kb.io
 
 mock.factory.interval=15s
 
-#ingress controller resources
+#ingress controller resources - an alternative profile can create fewer/smaller
 ingresscontroller.request-cpu=1700m
-ingresscontroller.request-memory=300Mi
+ingresscontroller.request-memory=1.2Gi
+#ingresscontroller.default-replica-count=1
+#ingresscontroller.az-replica-count=0
+
+# depends upon the instance type.  It is roughly 300Mi for m5.2xlarge,
+# but we're not assuming that we will achieve that initially
+ingresscontroller.max-ingress-throughput=300Mi
+# this has yet to be completely verified, but is inferred from the
+# old sizing - this should go higher, but we should need more memory
+ingresscontroller.max-ingress-connections=75000
 
 # external configuration injection through configmap
 quarkus.kubernetes-config.enabled=true

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -29,8 +29,9 @@ ingresscontroller.request-memory=1.2Gi
 #ingresscontroller.az-replica-count=0
 
 # depends upon the instance type.  It is roughly 300Mi for m5.2xlarge,
-# but we're not assuming that we will achieve that initially
 ingresscontroller.max-ingress-throughput=300Mi
+# percentage of peak throughput you actually need to meet
+ingresscontroller.peak-throughput-percentage=40
 # this has yet to be completely verified, but is inferred from the
 # old sizing - this should go higher, but we should need more memory
 ingresscontroller.max-ingress-connections=75000

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
@@ -21,6 +22,7 @@ import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.strimzi.api.kafka.model.Kafka;
 import org.bf2.common.OperandUtils;
 import org.bf2.operator.operands.AbstractKafkaCluster;
+import org.bf2.operator.operands.KafkaCluster;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaRoute;
@@ -32,6 +34,7 @@ import org.mockito.Mockito;
 
 import javax.inject.Inject;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.LongSummaryStatistics;
@@ -56,6 +59,12 @@ public class IngressControllerManagerTest {
     @KubernetesTestServer
     KubernetesServer kubernetesServer;
 
+    @Inject
+    KafkaCluster kafkaCluster;
+
+    @Inject
+    InformerManager informerManager;
+
     @Test
     public void testIngressControllerCreationWithNoZones() {
         QuarkusMock.installMockForType(Mockito.mock(InformerManager.class), InformerManager.class);
@@ -69,17 +78,42 @@ public class IngressControllerManagerTest {
     }
 
     @Test
-    public void testIngressControllerCreationWith3Zones() {
+    public void testReplicaReduction() {
+        openShiftClient.resourceList((List)buildNodes(12)).createOrReplace();
 
-        IntStream.range(0, 3).forEach(i -> {
-            Node node = new NodeBuilder()
-                    .editOrNewMetadata()
-                        .withName("z"+i)
-                        .withLabels(Map.of(IngressControllerManager.WORKER_NODE_LABEL, "", IngressControllerManager.TOPOLOGY_KEY, "zone"+i))
-                    .endMetadata()
-                    .build();
-            openShiftClient.nodes().create(node);
+        IntStream.range(0, 6).forEach(i -> {
+            ManagedKafka mk = ManagedKafka.getDummyInstance(1);
+            mk.getMetadata().setName("ingressTest" + i);
+            mk.getSpec().getCapacity().setIngressPerSec(Quantity.parse("115Mi"));
+            Kafka kafka = this.kafkaCluster.kafkaFrom(mk, null);
+            openShiftClient.resource(kafka).createOrReplace();
         });
+        informerManager.createKafkaInformer();
+
+        ingressControllerManager.reconcileIngressControllers();
+        checkAzReplicaCount(4);
+
+        // remove the kafkas - we should keep the same number of replicas
+        openShiftClient.resources(Kafka.class).inAnyNamespace().delete();
+        ingressControllerManager.reconcileIngressControllers();
+        checkAzReplicaCount(4);
+
+        // delete 3 nodes
+        openShiftClient.resources(Node.class).delete();
+        buildNodes(6).stream().forEach(n -> openShiftClient.nodes().create(n));
+        ingressControllerManager.reconcileIngressControllers();
+        checkAzReplicaCount(2);
+    }
+
+    private void checkAzReplicaCount(int count) {
+        List<IngressController> ingressControllers = openShiftClient.operator().ingressControllers().inNamespace(IngressControllerManager.INGRESS_OPERATOR_NAMESPACE).list().getItems();
+        IngressController ic = ingressControllers.stream().filter(c -> !c.getMetadata().getName().equals("kas")).findFirst().get();
+        assertEquals(count, ic.getSpec().getReplicas());
+    }
+
+    @Test
+    public void testIngressControllerCreationWith3Zones() {
+        buildNodes(3).stream().forEach(n -> openShiftClient.nodes().create(n));
 
         ingressControllerManager.reconcileIngressControllers();
 
@@ -93,6 +127,21 @@ public class IngressControllerManagerTest {
             }
             return c.getSpec().getNodePlacement() != null;
         }));
+    }
+
+    @Test
+    public void testSummarize() {
+        ManagedKafka mk = ManagedKafka.getDummyInstance(1);
+        Kafka kafka = this.kafkaCluster.kafkaFrom(mk, null);
+        int replicas = kafka.getSpec().getKafka().getReplicas();
+        int instances = 4;
+
+        LongSummaryStatistics egress = IngressControllerManager.summarize(Collections.nCopies(instances, kafka),
+                KafkaCluster::getFetchQuota, () -> {throw new AssertionError();});
+        long singleEgress = Quantity.getAmountInBytes(mk.getSpec().getCapacity().getEgressPerSec()).longValue()
+                / replicas * replicas;
+        assertEquals(singleEgress, egress.getMax());
+        assertEquals(singleEgress * instances, egress.getSum());
     }
 
     @Test
@@ -115,7 +164,7 @@ public class IngressControllerManagerTest {
     }
 
     private List<Node> buildNodes(int nodeCount) {
-        List<Node> nodes = IntStream.range(0, nodeCount).mapToObj(i ->
+        return IntStream.range(0, nodeCount).mapToObj(i ->
             new NodeBuilder()
                     .editOrNewMetadata()
                         .withName("z"+i)
@@ -123,7 +172,6 @@ public class IngressControllerManagerTest {
                     .endMetadata()
                     .build()
         ).collect(Collectors.toList());
-        return nodes;
     }
 
     @Test


### PR DESCRIPTION
Replacement for #666 

also increasing the memory request - based upon the observation of memory usage in production.

This switches the ingress logic from being node based to being demand based. There are pluses and minuses for doing it this way. The best plus is that it's more based upon actual need - that becomes more relevant as we need a greater number of ingress replicas per managed kafka (when the ingress/egress goes up). The other benefit is that you don't need to hard code what is the potential maximum load per node, instead you characterize what each ingress replica can handle and determine how many you need.

There are also 2 new properties that simply allow you to override how many replicas you actually want - that should be useful to kas-install and instance profiling.

The minuses are:

- it's more complicated, but yet still has to make simplifying assumptions such as assuming that the demand will be equal in all zones
- it may not be worst case enough. Accounting for the case where an ingress replica ends up on the same node as a broker is currently modeled as half broker traffic is coming from the ingress replica that is next to it (approximately the case when there are 2 replicas per zone). As you add replicas though a smaller proportion of that brokers traffic is likely going though it's collocated replica.
- ~~it will more rapidly scale down the number of replicas than the node based strategy. Scaling down a replica may force clients to reconnect (does anyone know for sure what the behavior is?)~~ the logic will conservatively scale down only when you have 3 excess replicas or when nodes are scaled down.
- it may need a tighter reconciliation than 3 minutes (if we ever support changing the ingress/egress capacity on the fly)
- it does not guard against instances being created without quotas or with unrealistic values - those scenarios (instance profiling) would use the overrides
Any feedback is welcome.

Other thoughts:

- we can support a far greater number of connections per ingress replica, but we have not validated what the memory requirement will be.
- we'll eventually likely want to set the resource requirements differently for the broker and default replicas.