### PR TITLE
Use `pull_request_target` event for PR labeler job

### DIFF
--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
Fixes #671 

See: 
- https://github.com/actions/labeler#create-workflow
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

Signed-off-by: Michael Edgar <medgar@redhat.com>