### PR TITLE
using partitions to drive the selection of the number of brokers

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -230,7 +230,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
         kafkaResourceClient.createOrUpdate(kafka);
     }
 
-    protected List<GenericKafkaListener> buildListeners(ManagedKafka managedKafka) {
+    protected List<GenericKafkaListener> buildListeners(ManagedKafka managedKafka, int replicas) {
 
         KafkaListenerAuthentication plainOverOauthAuthenticationListener = null;
         KafkaListenerAuthentication oauthAuthenticationListener = null;
@@ -274,9 +274,9 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
         KafkaListenerType externalListenerType = kubernetesClient.isAdaptable(OpenShiftClient.class) ? KafkaListenerType.ROUTE : KafkaListenerType.INGRESS;
 
         // Limit client connections per listener
-        Integer totalMaxConnections = Objects.requireNonNullElse(managedKafka.getSpec().getCapacity().getTotalMaxConnections(), this.config.getKafka().getMaxConnections()) / this.config.getKafka().getReplicas();
+        Integer totalMaxConnections = Objects.requireNonNullElse(managedKafka.getSpec().getCapacity().getTotalMaxConnections(), this.config.getKafka().getMaxConnections()) / replicas;
         // Limit connection attempts per listener
-        Integer maxConnectionAttemptsPerSec = Objects.requireNonNullElse(managedKafka.getSpec().getCapacity().getMaxConnectionAttemptsPerSec(), this.config.getKafka().getConnectionAttemptsPerSec()) / this.config.getKafka().getReplicas();
+        Integer maxConnectionAttemptsPerSec = Objects.requireNonNullElse(managedKafka.getSpec().getCapacity().getMaxConnectionAttemptsPerSec(), this.config.getKafka().getConnectionAttemptsPerSec()) / replicas;
 
         GenericKafkaListenerConfigurationBuilder listenerConfigBuilder = new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
@@ -284,7 +284,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                         .withAnnotations(Map.of("haproxy.router.openshift.io/balance", "leastconn"))
                         .build()
                 )
-                .withBrokers(buildBrokerOverrides(managedKafka))
+                .withBrokers(buildBrokerOverrides(managedKafka, replicas))
                 .withBrokerCertChainAndKey(buildTlsCertAndKeySecretSource(managedKafka))
                 .withMaxConnections(totalMaxConnections)
                 .withMaxConnectionCreationRate(maxConnectionAttemptsPerSec);
@@ -318,9 +318,9 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                 );
     }
 
-    protected List<GenericKafkaListenerConfigurationBroker> buildBrokerOverrides(ManagedKafka managedKafka) {
-        List<GenericKafkaListenerConfigurationBroker> brokerOverrides = new ArrayList<>(this.config.getKafka().getReplicas());
-        for (int i = 0; i < this.config.getKafka().getReplicas(); i++) {
+    protected List<GenericKafkaListenerConfigurationBroker> buildBrokerOverrides(ManagedKafka managedKafka, int replicas) {
+        List<GenericKafkaListenerConfigurationBroker> brokerOverrides = new ArrayList<>(replicas);
+        for (int i = 0; i < replicas; i++) {
             brokerOverrides.add(
                     new GenericKafkaListenerConfigurationBrokerBuilder()
                             .withHost(String.format("broker-%d-%s", i, managedKafka.getSpec().getEndpoint().getBootstrapServerHost()))
@@ -396,5 +396,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
     public Quantity calculateRetentionSize(ManagedKafka managedKafka) {
         return managedKafka.getSpec().getCapacity().getMaxDataRetentionSize();
     }
+
+    public abstract int getReplicas(ManagedKafka managedKafka);
 
 }

--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -92,6 +92,9 @@ public class Canary extends AbstractCanary {
     @Inject
     protected OperandOverrideManager overrideManager;
 
+    @Inject
+    protected AbstractKafkaCluster kafkaCluster;
+
     @Override
     public Deployment deploymentFrom(ManagedKafka managedKafka, Deployment current) {
         String canaryName = canaryName(managedKafka);
@@ -283,7 +286,7 @@ public class Canary extends AbstractCanary {
         String bootstrap = getBootstrapURL(managedKafka);
         envVars.add(new EnvVarBuilder().withName("KAFKA_BOOTSTRAP_SERVERS").withValue(bootstrap).build());
         envVars.add(new EnvVarBuilder().withName("RECONCILE_INTERVAL_MS").withValue("5000").build());
-        envVars.add(new EnvVarBuilder().withName("EXPECTED_CLUSTER_SIZE").withValue(String.valueOf(this.config.getKafka().getReplicas())).build());
+        envVars.add(new EnvVarBuilder().withName("EXPECTED_CLUSTER_SIZE").withValue(String.valueOf(kafkaCluster.getReplicas(managedKafka))).build());
         String kafkaVersion = managedKafka.getSpec().getVersions().getKafka();
         // takes the current Kafka version if the canary already exists. During Kafka upgrades it doesn't have to change, as any other clients.
         if (current != null) {

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -89,7 +89,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -115,6 +114,11 @@ public class KafkaCluster extends AbstractKafkaCluster {
     private static final String KAFKA_EXPORTER_LOG_LEVEL = "logLevel";
 
     private static final String DIGEST = "org.bf2.operator/digest";
+    /* tracks the number of brokers desired as inferred from the capacity
+     * it may differ from the actual number of brokers on the kafka resource
+     * and will later need a reconciliation process
+     */
+    private static final String REPLICAS = "org.bf2.operator/desired-broker-replicas";
     private static final String IO_STRIMZI_KAFKA_QUOTA_STATIC_QUOTA_CALLBACK = "io.strimzi.kafka.quotas.StaticQuotaCallback";
 
     private static final String SERVICE_ACCOUNT_KEY = "managedkafka.kafka.acl.service-accounts.%s";
@@ -197,22 +201,26 @@ public class KafkaCluster extends AbstractKafkaCluster {
     public Kafka kafkaFrom(ManagedKafka managedKafka, Kafka current) {
         KafkaBuilder builder = current != null ? new KafkaBuilder(current) : new KafkaBuilder();
 
+        int actualReplicas = getBrokerReplicas(managedKafka, current);
+        int desiredReplicas = getBrokerReplicas(managedKafka, null);
+
         KafkaBuilder kafkaBuilder = builder
                 .editOrNewMetadata()
                     .withName(kafkaClusterName(managedKafka))
                     .withNamespace(kafkaClusterNamespace(managedKafka))
                     .withLabels(buildKafkaLabels(managedKafka))
                     .withAnnotations(buildKafkaAnnotations(managedKafka, current))
+                    .addToAnnotations(REPLICAS, String.valueOf(desiredReplicas))
                 .endMetadata()
                 .editOrNewSpec()
                     .editOrNewKafka()
                         .withVersion(this.kafkaManager.currentKafkaVersion(managedKafka))
                         .withConfig(buildKafkaConfig(managedKafka, current))
-                        .withReplicas(this.config.getKafka().getReplicas())
+                        .withReplicas(actualReplicas)
                         .withResources(buildKafkaResources(managedKafka))
                         .withJvmOptions(buildKafkaJvmOptions(managedKafka))
                         .withStorage(buildKafkaStorage(managedKafka, current))
-                        .withListeners(buildListeners(managedKafka))
+                        .withListeners(buildListeners(managedKafka, actualReplicas))
                         .withRack(buildKafkaRack(managedKafka))
                         .withTemplate(buildKafkaTemplate(managedKafka))
                         .withMetricsConfig(buildKafkaMetricsConfig(managedKafka))
@@ -240,6 +248,29 @@ public class KafkaCluster extends AbstractKafkaCluster {
         OperandUtils.setAsOwner(managedKafka, kafka);
 
         return kafka;
+    }
+
+    @Override
+    public int getReplicas(ManagedKafka managedKafka) {
+        return getBrokerReplicas(managedKafka, cachedKafka(managedKafka));
+    }
+
+    public int getBrokerReplicas(ManagedKafka managedKafka, Kafka current) {
+        Integer maxPartitions = managedKafka.getSpec().getCapacity().getMaxPartitions();
+        int scalingAndReplicationFactor = 3;
+        int desiredReplicas = scalingAndReplicationFactor;
+        if (maxPartitions != null) {
+            double physicalCapacity = config.getKafka().getPartitionCapacity();
+            desiredReplicas = (int) Math.ceil(maxPartitions * scalingAndReplicationFactor / physicalCapacity);
+            // round to only even multiples
+            desiredReplicas = (int) (Math.ceil(desiredReplicas / (double)scalingAndReplicationFactor) * scalingAndReplicationFactor);
+        }
+
+        if (current != null) {
+            int existingReplicas = current.getSpec().getKafka().getReplicas();
+            desiredReplicas = existingReplicas;
+        }
+        return desiredReplicas;
     }
 
     /**
@@ -584,13 +615,13 @@ public class KafkaCluster extends AbstractKafkaCluster {
         config.put("client.quota.callback.class", IO_STRIMZI_KAFKA_QUOTA_STATIC_QUOTA_CALLBACK);
 
         // Throttle at Ingress/Egress MB/sec per broker
-        config.put(QUOTA_PRODUCE, String.valueOf(getIngressBytes(managedKafka)));
-        config.put(QUOTA_FETCH, String.valueOf(getEgressBytes(managedKafka)));
+        config.put(QUOTA_PRODUCE, String.valueOf(getIngressBytes(managedKafka, current)));
+        config.put(QUOTA_FETCH, String.valueOf(getEgressBytes(managedKafka, current)));
 
         // Start throttling when disk is above requested size. Full stop when only storageMinMargin is free.
         Quantity maxDataRetentionSize = getAdjustedMaxDataRetentionSize(managedKafka, current);
         long hardStorageLimit = Quantity.getAmountInBytes(maxDataRetentionSize).longValue() - Quantity.getAmountInBytes(storageMinMargin).longValue();
-        long softStorageLimit = Quantity.getAmountInBytes(maxDataRetentionSize).longValue() - getStoragePadding(managedKafka);
+        long softStorageLimit = Quantity.getAmountInBytes(maxDataRetentionSize).longValue() - getStoragePadding(managedKafka, current);
         config.put("client.quota.callback.static.storage.soft", String.valueOf(softStorageLimit));
         config.put("client.quota.callback.static.storage.hard", String.valueOf(hardStorageLimit));
 
@@ -645,36 +676,35 @@ public class KafkaCluster extends AbstractKafkaCluster {
     /**
      * Get per broker value
      */
-    private long getPerBrokerBytes(ManagedKafka managedKafka, Function<ManagedKafka, Quantity> capacityValue, Supplier<String> defaultValue) {
-        Quantity quantity = capacityValue.apply(managedKafka);
-        long bytes = Quantity.getAmountInBytes(Objects.requireNonNullElse(quantity, new Quantity(defaultValue.get()))).longValue();
+    private long getPerBrokerBytes(ManagedKafka managedKafka, Kafka current, Quantity quantity, Supplier<String> defaultValue) {
+        long bytes = Quantity.getAmountInBytes(Optional.ofNullable(quantity).orElseGet(() -> Quantity.parse(defaultValue.get()))).longValue();
 
-        return bytes / this.config.getKafka().getReplicas();
+        return bytes / getBrokerReplicas(managedKafka, current);
     }
 
-    private long getIngressBytes(ManagedKafka managedKafka) {
-        return getPerBrokerBytes(managedKafka, m -> m.getSpec().getCapacity().getIngressPerSec(), () -> config.getKafka().getIngressPerSec());
+    private long getIngressBytes(ManagedKafka managedKafka, Kafka current) {
+        return getPerBrokerBytes(managedKafka, current, managedKafka.getSpec().getCapacity().getIngressPerSec(), () -> config.getKafka().getIngressPerSec());
     }
 
-    private long getEgressBytes(ManagedKafka managedKafka) {
-        return getPerBrokerBytes(managedKafka, m -> m.getSpec().getCapacity().getEgressPerSec(), () -> config.getKafka().getEgressPerSec());
+    private long getEgressBytes(ManagedKafka managedKafka, Kafka current) {
+        return getPerBrokerBytes(managedKafka, current, managedKafka.getSpec().getCapacity().getEgressPerSec(), () -> config.getKafka().getEgressPerSec());
     }
 
     /**
      * Get extra storage padding given the effective IngressEgressThroughput limit and storageMinMargin
      */
-    private long getStoragePadding(ManagedKafka managedKafka) {
-        return Quantity.getAmountInBytes(storageMinMargin).longValue() + getIngressBytes(managedKafka) * storageCheckInterval * storageSafetyFactor;
+    private long getStoragePadding(ManagedKafka managedKafka, Kafka current) {
+        return Quantity.getAmountInBytes(storageMinMargin).longValue() + getIngressBytes(managedKafka, current) * storageCheckInterval * storageSafetyFactor;
     }
 
     /**
      * Get the effective volume size considering extra padding and the existing size
      */
     private Quantity getAdjustedMaxDataRetentionSize(ManagedKafka managedKafka, Kafka current) {
-        long bytes = getPerBrokerBytes(managedKafka, m -> m.getSpec().getCapacity().getMaxDataRetentionSize(), () -> this.config.getKafka().getVolumeSize());
+        long bytes = getPerBrokerBytes(managedKafka, current, managedKafka.getSpec().getCapacity().getMaxDataRetentionSize(), () -> this.config.getKafka().getVolumeSize());
 
         // pad to give a margin before soft/hard limits kick in
-        bytes += getStoragePadding(managedKafka);
+        bytes += getStoragePadding(managedKafka, current);
 
         // strimzi won't allow the size to be reduced so scrape the size if possible
         if (current != null) {
@@ -696,8 +726,8 @@ public class KafkaCluster extends AbstractKafkaCluster {
         return new Quantity(String.valueOf(bytes));
     }
 
-    public long unpadBrokerStorage(ManagedKafka managedKafka, long value) {
-        return value - getStoragePadding(managedKafka);
+    public long unpadBrokerStorage(ManagedKafka managedKafka, Kafka current, long value) {
+        return value - getStoragePadding(managedKafka, current);
     }
 
     /**
@@ -706,6 +736,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
      */
     @Override
     public Quantity calculateRetentionSize(ManagedKafka managedKafka) {
+        Kafka current = cachedKafka(managedKafka);
         long storageInGbs = informerManager.getPvcsInNamespace(managedKafka.getMetadata().getNamespace()).stream().map(pvc -> {
             if (pvc.getStatus() == null) {
                 return 0L;
@@ -717,7 +748,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
             }
             long value = Quantity.getAmountInBytes(q).longValue();
             // round down to the nearest GB - the PVC request is automatically rounded up
-            return (long)Math.floor(((double)unpadBrokerStorage(managedKafka, value))/(1L<<30));
+            return (long)Math.floor(((double)unpadBrokerStorage(managedKafka, current, value))/(1L<<30));
         }).collect(Collectors.summingLong(Long::longValue));
 
         Quantity capacity = managedKafka.getSpec().getCapacity().getMaxDataRetentionSize();
@@ -725,7 +756,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         // try to correct for the overall rounding
         if (storageInGbs > 0 && (capacity == null
                 || ("Gi".equals(capacity.getFormat()) && (Quantity.getAmountInBytes(capacity).longValue() / (1L << 30))
-                        % config.getKafka().getReplicas() != 0))) {
+                        % getBrokerReplicas(managedKafka, current) != 0))) {
             storageInGbs++;
         }
 

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -256,6 +256,9 @@ public class KafkaCluster extends AbstractKafkaCluster {
     }
 
     public int getBrokerReplicas(ManagedKafka managedKafka, Kafka current) {
+        if (current != null) {
+            return current.getSpec().getKafka().getReplicas();
+        }
         Integer maxPartitions = managedKafka.getSpec().getCapacity().getMaxPartitions();
         int scalingAndReplicationFactor = 3;
         int desiredReplicas = scalingAndReplicationFactor;
@@ -266,10 +269,6 @@ public class KafkaCluster extends AbstractKafkaCluster {
             desiredReplicas = (int) (Math.ceil(desiredReplicas / (double)scalingAndReplicationFactor) * scalingAndReplicationFactor);
         }
 
-        if (current != null) {
-            int existingReplicas = current.getSpec().getKafka().getReplicas();
-            desiredReplicas = existingReplicas;
-        }
         return desiredReplicas;
     }
 

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -80,12 +80,12 @@ public class KafkaInstanceConfiguration {
         protected int connectionAttemptsPerSec = DEFAULT_CONNECTION_ATTEMPTS_PER_SEC;
         @JsonProperty("max-connections")
         protected int maxConnections = DEFAULT_MAX_CONNECTIONS;
+        @JsonProperty("partition-capacity")
+        protected int partitionCapacity;
         @JsonProperty("ingress-per-sec")
         protected String ingressPerSec = DEFAULT_INGRESS_PER_SEC;
         @JsonProperty("egress-per-sec")
         protected String egressPerSec = DEFAULT_EGRESS_PER_SEC;
-        @JsonProperty("replicas")
-        protected int replicas = KAFKA_BROKERS;
         @JsonProperty("storage-class")
         protected String storageClass = KAFKA_STORAGE_CLASS;
         @JsonProperty("container-memory")
@@ -112,14 +112,6 @@ public class KafkaInstanceConfiguration {
         protected long maximumSessionLifetimeDefault;
         @JsonProperty("message-max-bytes")
         protected int messageMaxBytes = MESSAGE_MAX_BYTES;
-
-        public int getReplicas() {
-            return replicas;
-        }
-
-        public void setReplicas(int replicas) {
-            this.replicas = replicas;
-        }
 
         public String getStorageClass() {
             return storageClass;
@@ -260,6 +252,14 @@ public class KafkaInstanceConfiguration {
 
         public void setMessageMaxBytes(int maxMessageBytes) {
             this.messageMaxBytes = maxMessageBytes;
+        }
+
+        public int getPartitionCapacity() {
+            return partitionCapacity;
+        }
+
+        public void setPartitionCapacity(int partitionCapacity) {
+            this.partitionCapacity = partitionCapacity;
         }
     }
 

--- a/operator/src/main/java/org/bf2/operator/operands/dev/DevelopmentKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/dev/DevelopmentKafkaCluster.java
@@ -60,6 +60,8 @@ public class DevelopmentKafkaCluster extends AbstractKafkaCluster {
 
         KafkaBuilder builder = current != null ? new KafkaBuilder(current) : new KafkaBuilder();
 
+        int replicas = getReplicas(managedKafka);
+
         Kafka kafka = builder
                 .editOrNewMetadata()
                     .withName(kafkaClusterName(managedKafka))
@@ -69,8 +71,8 @@ public class DevelopmentKafkaCluster extends AbstractKafkaCluster {
                 .editOrNewSpec()
                     .editOrNewKafka()
                         .withVersion(managedKafka.getSpec().getVersions().getKafka())
-                        .withReplicas(this.config.getKafka().getReplicas())
-                        .withListeners(buildListeners(managedKafka))
+                        .withReplicas(replicas)
+                        .withListeners(buildListeners(managedKafka, replicas))
                         .withStorage(buildStorage())
                         .withConfig(buildKafkaConfig(managedKafka))
                         .withTemplate(getKafkaTemplate(managedKafka))
@@ -127,5 +129,10 @@ public class DevelopmentKafkaCluster extends AbstractKafkaCluster {
                     .withImagePullSecrets(imagePullSecretManager.getOperatorImagePullSecrets(managedKafka))
                 .endPod()
             .build();
+    }
+
+    @Override
+    public int getReplicas(ManagedKafka managedKafka) {
+        return 3;
     }
 }

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -126,14 +126,27 @@ topic=*;operations=describe;level=DEBUG \n\
 priority=1;topic=${managedkafka.canary.topic};operations=describe,read,write;level=DEBUG \n\
 group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG
 
+# default value for spec capacity - should be removed or replaced with a hard capacity
+managedkafka.kafka.max-connections=3000
+
+# topology settings
 managedkafka.kafka.colocate-with-zookeeper=true
 managedkafka.adminserver.colocate-with-zookeeper=true
 managedkafka.kafkaexporter.colocate-with-zookeeper=true
 managedkafka.canary.colocate-with-zookeeper=true
-managedkafka.kafka.max-connections=3000
+
+# sizing settings specific to OpenShift 4.8 on m5.2xlarge, and the topology settings
 managedkafka.kafka.container-cpu=4500m
 managedkafka.kafka.container-memory=19Gi
 managedkafka.kafka.jvm-xms=6442450944
+
+# absolute capacity specific to the above
+
+# this is meant as a pre-replication per broker value
+#
+# the spec capacity value is understood to be
+# X fully replicated partitions typically with replication factor 3
+managedkafka.kafka.partition-capacity=1500
 
 quarkus.arc.test.disable-application-lifecycle-observers=true
 

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -164,9 +164,6 @@ public class IngressControllerManagerTest {
 
         long ingress = 50000000;
         assertEquals(5, ingressControllerManager.numReplicasForAllZones(nodes, 370000));
-        for (int i = 0; i < 60; i++) {
-            System.out.println(i + " " + ingressControllerManager.numReplicasForZone("zone0", nodes, new LongSummaryStatistics(1, 0, ingress, ingress*i), new LongSummaryStatistics(1, 0, ingress*2, ingress*i*2), 0));
-        }
         assertEquals(4, ingressControllerManager.numReplicasForZone("zone0", nodes, new LongSummaryStatistics(1, 0, ingress, ingress*60), new LongSummaryStatistics(1, 0, ingress*2, ingress*120), 0));
     }
 

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -138,7 +138,6 @@ class KafkaClusterTest {
             KafkaInstanceConfiguration clone = objectMapper.readValue(objectMapper.writeValueAsString(config), KafkaInstanceConfiguration.class);
 
             clone.getKafka().setConnectionAttemptsPerSec(300);
-            clone.getKafka().setReplicas(4);
             clone.getKafka().setContainerMemory("2Gi");
             clone.getKafka().setJvmXx("foo bar, foo2 bar2");
 
@@ -153,6 +152,7 @@ class KafkaClusterTest {
             kafkaCluster.setKafkaConfiguration(clone);
 
             ManagedKafka mk = exampleManagedKafka("60Gi");
+            mk.getSpec().getCapacity().setMaxPartitions(2*clone.getKafka().getPartitionCapacity());
 
             Kafka kafka = kafkaCluster.kafkaFrom(mk, null);
 
@@ -168,7 +168,6 @@ class KafkaClusterTest {
         ObjectMapper objectMapper = new ObjectMapper();
         KafkaInstanceConfiguration clone = objectMapper.readValue(objectMapper.writeValueAsString(config), KafkaInstanceConfiguration.class);
         clone.getKafka().setConnectionAttemptsPerSec(300);
-        clone.getKafka().setReplicas(4);
         clone.getKafka().setContainerMemory("2Gi");
         clone.getKafka().setJvmXx("foo bar, foo2 bar2");
 
@@ -177,7 +176,6 @@ class KafkaClusterTest {
         clone.getZookeeper().setJvmXx("zkfoo zkbar, zkfoo2 zkbar2");
 
         Map<String, String> propertyMap = clone.toMap(false);
-        assertEquals("4", propertyMap.get("managedkafka.kafka.replicas"));
         assertEquals("2Gi", propertyMap.get("managedkafka.kafka.container-memory"));
         assertEquals("foo bar, foo2 bar2", propertyMap.get("managedkafka.kafka.jvm-xx"));
 
@@ -253,7 +251,7 @@ class KafkaClusterTest {
         long bytes = getBrokerStorageBytes(kafka);
         assertEquals(25095918893L, bytes);
 
-        assertEquals((40*1L<<30)-1, kafkaCluster.unpadBrokerStorage(mk, 25095918893L)*3);
+        assertEquals((40*1L<<30)-1, kafkaCluster.unpadBrokerStorage(mk, null, 25095918893L)*3);
     }
 
     private long getBrokerStorageBytes(Kafka kafka) {

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -1,7 +1,8 @@
 ---
 kind: "Kafka"
 metadata:
-  annotations: {}
+  annotations:
+    org.bf2.operator/desired-broker-replicas: "6"
   labels:
     app.kubernetes.io/managed-by: "kas-fleetshard-operator"
     ingressType: "sharded"
@@ -19,7 +20,7 @@ metadata:
 spec:
   kafka:
     version: "2.6.0"
-    replicas: 4
+    replicas: 6
     listeners:
     - name: "external"
       port: 9094
@@ -45,8 +46,8 @@ spec:
         enableOauthBearer: true
         type: "oauth"
       configuration:
-        maxConnections: 750
-        maxConnectionCreationRate: 75
+        maxConnections: 500
+        maxConnectionCreationRate: 50
         bootstrap:
           host: "xxx.yyy.zzz"
           annotations:
@@ -60,6 +61,10 @@ spec:
           host: "broker-2-xxx.yyy.zzz"
         - broker: 3
           host: "broker-3-xxx.yyy.zzz"
+        - broker: 4
+          host: "broker-4-xxx.yyy.zzz"
+        - broker: 5
+          host: "broker-5-xxx.yyy.zzz"
     - name: "oauth"
       port: 9095
       type: "internal"
@@ -103,16 +108,16 @@ spec:
       offsets.topic.replication.factor: 3
       quota.window.size.seconds: "2"
       transaction.state.log.min.isr: 2
-      client.quota.callback.static.storage.soft: "16106127360"
+      client.quota.callback.static.storage.soft: "10737418240"
       quota.window.num: "30"
       message.max.bytes: 1048588
-      client.quota.callback.static.fetch: "1048576"
-      client.quota.callback.static.storage.hard: "16137584640"
+      client.quota.callback.static.fetch: "699050"
+      client.quota.callback.static.storage.hard: "10758389740"
       client.quota.callback.static.storage.check-interval: "30"
       client.quota.callback.static.excluded.principal.name.list: "canary-123"
       default.replication.factor: 3
       inter.broker.protocol.version: "2.6"
-      client.quota.callback.static.produce: "524288"
+      client.quota.callback.static.produce: "349525"
       leader.imbalance.per.broker.percentage: 0
       connections.max.reauth.ms: 299000
       create.topic.policy.class.name: io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy
@@ -154,7 +159,7 @@ spec:
       volumes:
       - !<persistent-claim>
         type: "persistent-claim"
-        size: "26875002880"
+        size: "21495807980"
         class: "gp2"
         id: 0
         deleteClaim: true

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -1,7 +1,8 @@
 ---
 kind: "Kafka"
 metadata:
-  annotations: {}
+  annotations:
+    org.bf2.operator/desired-broker-replicas: "3"
   labels:
     app.kubernetes.io/managed-by: "kas-fleetshard-operator"
     ingressType: "sharded"

--- a/perf/src/main/java/org/bf2/performance/AdopterProfile.java
+++ b/perf/src/main/java/org/bf2/performance/AdopterProfile.java
@@ -10,20 +10,19 @@ public class AdopterProfile {
 
     public static final KafkaInstanceConfiguration VALUE_PROD = buildProfile(
             STANDARD_ZOOKEEPER_CONTAINER_SIZE, STANDARD_ZOOKEEPER_VM_SIZE, STANDARD_ZOOKEEPER_CPU,
-            "8Gi", "3G", "3000m", 3);
+            "8Gi", "3G", "3000m");
 
     public static final KafkaInstanceConfiguration SMALL_VALUE_PROD = buildProfile(
             "1Gi", "500M", "500m",
-            "1Gi", "500M", "1000m", 3);
+            "1Gi", "500M", "1000m");
 
     public static final KafkaInstanceConfiguration TYPE_KICKER = buildProfile(
             "2Gi", "1G", "500m",
-            "2Gi", "1G", "500m", 3);
+            "2Gi", "1G", "500m");
 
     public static KafkaInstanceConfiguration buildProfile(String zookeeperContainerMemory, String zookeeperJavaMemory,
-            String zookeeperCpu, String kafkaContainerMemory, String kafkaJavaMemory, String kafkaCpu, int numOfBrokers) {
+            String zookeeperCpu, String kafkaContainerMemory, String kafkaJavaMemory, String kafkaCpu) {
         KafkaInstanceConfiguration config = new KafkaInstanceConfiguration();
-        config.getKafka().setReplicas(numOfBrokers);
         config.getKafka().setMaxConnections(Integer.MAX_VALUE);
         config.getKafka().setConnectionAttemptsPerSec(Integer.MAX_VALUE);
         config.getKafka().setOneInstancePerNode(true);

--- a/perf/src/test/java/org/bf2/performance/ManagedKafkaValueProdMinimumTest.java
+++ b/perf/src/test/java/org/bf2/performance/ManagedKafkaValueProdMinimumTest.java
@@ -97,7 +97,7 @@ public class ManagedKafkaValueProdMinimumTest extends TestBase {
 
         LOGGER.info("Test config: {}", key);
         KafkaInstanceConfiguration profile = AdopterProfile.buildProfile(
-                zkContainerMemory, zkJavaMemory, "1000m", kafkaContainerMemory, kafkaJavaMemory, kfCpu, 3
+                zkContainerMemory, zkJavaMemory, "1000m", kafkaContainerMemory, kafkaJavaMemory, kfCpu
         );
 
         String bootstrapHosts = kafkaProvisioner.deployCluster("cluster1", capacity, profile).waitUntilReady();


### PR DESCRIPTION
This switches the fleetshard operator to using the partition count to drive the broker selection.

This requires adding a physical partition capacity value to the configuration to use as a reference.  I removed the old replicas value from the config, but it may be a good idea to add that back as an override to simply testing as noted in the ManagedKafkaProvisioner.

To support a single broker a subsequent pr will externalize the scalingAndReplicaionFactor - at worst it could be separate properties.

My understanding is that changing the broker count after the fact is not something that we don't want to do yet.  So similar to the consideration of not reducing volume sizes, to get the replica count we have to use both the managedkafka and the kafka, which makes these changes seem a bit messy.

This pr is not yet accounting for the physical limits of the other dimensions - we are assuming that the initial values will be supported based upon whatever the partition count is.  If/when we add that we'll also need to update the ManagedKafka status / status capacity when there is a discrepancy.

This does highlight the inter-relatedness of all the values - you cannot for example later increase the physical support for partitions and hope to see a reduction in the number of physical units - the physical support for each dimension (ingress/egress, connections) must similarly increase.  Related to this if we change the number of brokers the total storage must either stay the same or increase - so if we are satisfying something with 1 physical unit, and need that to be 2 physical units for whatever reason, we'll have double the storage of the ManagedKafka capacity value.