### PR TITLE
Alter adminserver deployment depending on ConfigMap property (Quarkus)

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/OperandOverrideManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/OperandOverrideManager.java
@@ -1,5 +1,8 @@
 package org.bf2.operator.managers;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -15,6 +18,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,9 +27,11 @@ import java.util.concurrent.ConcurrentHashMap;
 @ApplicationScoped
 public class OperandOverrideManager {
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class OperandOverride {
         public String image;
+
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new HashMap<>();
 
         public String getImage() {
             return image;
@@ -33,6 +39,16 @@ public class OperandOverrideManager {
 
         public void setImage(String image) {
             this.image = image;
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return this.additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String name, Object value) {
+            this.additionalProperties.put(name, value);
         }
     }
 
@@ -109,8 +125,12 @@ public class OperandOverrideManager {
         return Optional.ofNullable(getOverrides(strimzi).canary.init.image).orElse(canaryInitImage);
     }
 
+    public OperandOverride getAdminServerOverride(String strimzi) {
+        return getOverrides(strimzi).adminServer;
+    }
+
     public String getAdminServerImage(String strimzi) {
-        return Optional.ofNullable(getOverrides(strimzi).adminServer.image).orElse(adminApiImage);
+        return Optional.ofNullable(getAdminServerOverride(strimzi).image).orElse(adminApiImage);
     }
 
     void updateOverrides(ConfigMap obj) {

--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -260,26 +260,37 @@ public class AdminServer extends AbstractAdminServer {
     }
 
     protected List<Container> buildContainers(ManagedKafka managedKafka) {
+        Probe readinessProbe;
+        Probe livenessProbe;
+
+        if (isQuarkusBasedAdminServer(managedKafka)) {
+            readinessProbe = buildProbe("/health/ready", HTTP_PORT_TARGET);
+            livenessProbe = buildProbe("/health/live", HTTP_PORT_TARGET);
+        } else {
+            readinessProbe = buildProbe("/health/liveness", MANAGEMENT_PORT_TARGET);
+            livenessProbe = buildProbe("/health/liveness", MANAGEMENT_PORT_TARGET);
+        }
+
         Container container = new ContainerBuilder()
                 .withName("admin-server")
                 .withImage(overrideManager.getAdminServerImage(managedKafka.getSpec().getVersions().getStrimzi()))
                 .withEnv(buildEnvVar(managedKafka))
                 .withPorts(buildContainerPorts(managedKafka))
                 .withResources(buildResources())
-                .withReadinessProbe(buildProbe())
-                .withLivenessProbe(buildProbe())
+                .withReadinessProbe(readinessProbe)
+                .withLivenessProbe(livenessProbe)
                 .withVolumeMounts(buildVolumeMounts(managedKafka))
                 .build();
 
         return Collections.singletonList(container);
     }
 
-    private Probe buildProbe() {
+    private Probe buildProbe(String path, IntOrString portTarget) {
         return new ProbeBuilder()
                 .withHttpGet(
                         new HTTPGetActionBuilder()
-                        .withPath("/health/liveness")
-                        .withPort(MANAGEMENT_PORT_TARGET)
+                        .withPath(path)
+                        .withPort(portTarget)
                         .build()
                 )
                 .withTimeoutSeconds(5)
@@ -446,25 +457,51 @@ public class AdminServer extends AbstractAdminServer {
     }
 
     private List<ContainerPort> buildContainerPorts(ManagedKafka managedKafka) {
-        final String apiPortName;
-        final int apiContainerPort;
+        if (isQuarkusBasedAdminServer(managedKafka)) {
+            List<ContainerPort> ports = new ArrayList<>(3);
 
-        if (SecuritySecretManager.isKafkaExternalCertificateEnabled(managedKafka)) {
-            apiPortName = HTTPS_PORT_NAME;
-            apiContainerPort = HTTPS_PORT;
+            // HTTP port always exposed for health probes
+            ports.add(new ContainerPortBuilder()
+                    .withName(HTTP_PORT_NAME)
+                    .withContainerPort(HTTP_PORT)
+                    .build());
+
+            // HTTP "management" alias port exposed for metrics pod monitor. Remove when no longer needed.
+            ports.add(new ContainerPortBuilder()
+                    .withName(MANAGEMENT_PORT_NAME)
+                    .withContainerPort(HTTP_PORT)
+                    .build());
+
+            if (SecuritySecretManager.isKafkaExternalCertificateEnabled(managedKafka)) {
+                // HTTPS port exposed when the route/service will be configured for TLS
+                ports.add(new ContainerPortBuilder()
+                        .withName(HTTPS_PORT_NAME)
+                        .withContainerPort(HTTPS_PORT)
+                        .build());
+            }
+
+            return ports;
         } else {
-            apiPortName = HTTP_PORT_NAME;
-            apiContainerPort = HTTP_PORT;
-        }
+            final String apiPortName;
+            final int apiContainerPort;
 
-        return List.of(new ContainerPortBuilder()
-                           .withName(apiPortName)
-                           .withContainerPort(apiContainerPort)
-                           .build(),
-                       new ContainerPortBuilder()
-                           .withName(MANAGEMENT_PORT_NAME)
-                           .withContainerPort(MANAGEMENT_PORT)
-                           .build());
+            if (SecuritySecretManager.isKafkaExternalCertificateEnabled(managedKafka)) {
+                apiPortName = HTTPS_PORT_NAME;
+                apiContainerPort = HTTPS_PORT;
+            } else {
+                apiPortName = HTTP_PORT_NAME;
+                apiContainerPort = HTTP_PORT;
+            }
+
+            return List.of(new ContainerPortBuilder()
+                               .withName(apiPortName)
+                               .withContainerPort(apiContainerPort)
+                               .build(),
+                           new ContainerPortBuilder()
+                               .withName(MANAGEMENT_PORT_NAME)
+                               .withContainerPort(MANAGEMENT_PORT)
+                               .build());
+        }
     }
 
     private List<ServicePort> buildServicePorts(ManagedKafka managedKafka) {
@@ -525,5 +562,14 @@ public class AdminServer extends AbstractAdminServer {
         return openShiftClient.routes()
                 .inNamespace(adminServerNamespace(managedKafka))
                 .withName(adminServerName(managedKafka));
+    }
+
+    /**
+     * Temporary configuration check for transition to Quarkus-based admin server
+     */
+    boolean isQuarkusBasedAdminServer(ManagedKafka managedKafka) {
+        String strimziVersion = managedKafka.getSpec().getVersions().getStrimzi();
+        Object quarkusBased = overrideManager.getAdminServerOverride(strimziVersion).getAdditionalProperties().get("quarkus-based");
+        return Boolean.TRUE.equals(quarkusBased);
     }
 }

--- a/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
@@ -3,13 +3,20 @@ package org.bf2.operator.operands;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import org.bf2.operator.managers.OperandOverrideManager;
+import org.bf2.operator.managers.OperandOverrideManager.OperandOverride;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
+import org.bf2.operator.resources.v1alpha1.TlsKeyPair;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
 
 import javax.inject.Inject;
 
@@ -30,11 +37,11 @@ class AdminServerTest {
     @Inject
     AdminServer adminServer;
 
-    static ManagedKafka buildBasicManagedKafka() {
+    static ManagedKafka buildBasicManagedKafka(String name, String strimziVersion, TlsKeyPair tls) {
         return new ManagedKafkaBuilder()
                 .withNewMetadata()
                 .withNamespace("test")
-                .withName("test-mk")
+                .withName(name)
             .endMetadata()
             .withSpec(
                     new ManagedKafkaSpecBuilder()
@@ -42,25 +49,45 @@ class AdminServerTest {
                                 .withMaxPartitions(1000)
                                 .endCapacity()
                             .withNewEndpoint()
+                                .withTls(tls)
                                 .endEndpoint()
                             .withNewVersions()
                                 .withKafka("2.6.0")
+                                .withStrimzi(strimziVersion)
                                 .endVersions()
                             .build())
             .build();
     }
 
-    @Test
-    void createAdminServerDeployment() throws Exception {
-        ManagedKafka mk = buildBasicManagedKafka();
-        Deployment adminServerDeployment = adminServer.deploymentFrom(mk, null);
+    @ParameterizedTest
+    @CsvSource({
+        "test-mk-q,     1, true,  false, /expected/adminserver-quarkus.yml",
+        "test-mk-tls-q, 2, true,  true,  /expected/adminserver-tls-quarkus.yml",
+        "test-mk,       3, false, false, /expected/adminserver.yml",
+        "test-mk-tls,   4, false, true,  /expected/adminserver-tls.yml"
+    })
+    void createAdminServerDeployment(String name, String versionString, boolean quarkusBased, boolean tls, String expectedResource) throws Exception {
+        ManagedKafka mk = buildBasicManagedKafka(name, versionString, tls ? new TlsKeyPair() : null);
 
+        OperandOverride override = new OperandOverride();
+        override.setImage("quay.io/mk-ci-cd/kafka-admin-api:0.7.0");
+        override.setAdditionalProperty("quarkus-based", quarkusBased);
+
+        OperandOverrideManager overrideManager = Mockito.mock(OperandOverrideManager.class);
+        Mockito.when(overrideManager.getAdminServerOverride(versionString))
+            .thenReturn(override);
+        Mockito.when(overrideManager.getAdminServerImage(versionString))
+            .thenReturn(override.image);
+        QuarkusMock.installMockForType(overrideManager, OperandOverrideManager.class);
+
+        Deployment adminServerDeployment = adminServer.deploymentFrom(mk, null);
         server.getClient().apps().deployments().create(adminServerDeployment);
+
         assertNotNull(server.getClient().apps().deployments()
                 .inNamespace(adminServerDeployment.getMetadata().getNamespace())
                 .withName(adminServerDeployment.getMetadata().getName()).get());
-        KafkaClusterTest.diffToExpected(adminServerDeployment, "/expected/adminserver.yml");
 
+        KafkaClusterTest.diffToExpected(adminServerDeployment, expectedResource);
     }
 
     @Test

--- a/operator/src/test/resources/expected/adminserver-quarkus.yml
+++ b/operator/src/test/resources/expected/adminserver-quarkus.yml
@@ -1,0 +1,97 @@
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+    app: "test-mk-q-admin-server"
+    app.kubernetes.io/component: "adminserver"
+  name: "test-mk-q-admin-server"
+  namespace: "test"
+  ownerReferences:
+  - apiVersion: "managedkafka.bf2.org/v1alpha1"
+    kind: "ManagedKafka"
+    name: "test-mk-q"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+      app: "test-mk-q-admin-server"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+        app: "test-mk-q-admin-server"
+        app.kubernetes.io/component: "adminserver"
+      annotations:
+        managedkafka.bf2.org/secret-dependency-digest: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+    spec:
+      affinity:
+       podAffinity:
+         preferredDuringSchedulingIgnoredDuringExecution:
+         - podAffinityTerm:
+             labelSelector:
+               matchExpressions:
+               - key: "strimzi.io/name"
+                 operator: "In"
+                 values:
+                 - "test-mk-q-zookeeper"
+             topologyKey: "kubernetes.io/hostname"
+           weight: 100    
+      containers:
+      - env:
+        - name: "KAFKA_ADMIN_BOOTSTRAP_SERVERS"
+          value: "test-mk-q-kafka-bootstrap:9095"
+        - name: "KAFKA_ADMIN_BROKER_TLS_ENABLED"
+          value: "true"
+        - name: "KAFKA_ADMIN_BROKER_TRUSTED_CERT"
+          valueFrom:
+            secretKeyRef:
+              key: "ca.crt"
+              name: "test-mk-q-cluster-ca-cert"
+              optional: false
+        - name: "KAFKA_ADMIN_ACL_RESOURCE_OPERATIONS"
+          value: "{ \"cluster\": [ \"describe\", \"alter\" ], \"group\": [ \"all\"\
+            , \"delete\", \"describe\", \"read\" ], \"topic\": [ \"all\", \"alter\"\
+            , \"alter_configs\", \"create\", \"delete\", \"describe\", \"describe_configs\"\
+            , \"read\", \"write\" ], \"transactional_id\": [ \"all\", \"describe\"\
+            , \"write\" ] }"
+        - name: "KAFKA_ADMIN_NUM_PARTITIONS_MAX"
+          value: "1000"
+        - name: "KAFKA_ADMIN_OAUTH_ENABLED"
+          value: "false"
+        image: "quay.io/mk-ci-cd/kafka-admin-api:0.7.0"
+        livenessProbe:
+          httpGet:
+            path: "/health/live"
+            port: "http"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        name: "admin-server"
+        ports:
+          - containerPort: 8080
+            name: "http"
+          - containerPort: 8080
+            name: "management"
+        readinessProbe:
+          httpGet:
+            path: "/health/ready"
+            port: "http"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+          - mountPath: "/opt/kafka-admin-api/custom-config/"
+            name: "custom-config"
+      volumes:
+        - configMap:
+            name: "test-mk-q-admin-server"
+            optional: true
+          name: "custom-config"

--- a/operator/src/test/resources/expected/adminserver-tls-quarkus.yml
+++ b/operator/src/test/resources/expected/adminserver-tls-quarkus.yml
@@ -1,0 +1,111 @@
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+    app: "test-mk-tls-q-admin-server"
+    app.kubernetes.io/component: "adminserver"
+  name: "test-mk-tls-q-admin-server"
+  namespace: "test"
+  ownerReferences:
+  - apiVersion: "managedkafka.bf2.org/v1alpha1"
+    kind: "ManagedKafka"
+    name: "test-mk-tls-q"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+      app: "test-mk-tls-q-admin-server"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+        app: "test-mk-tls-q-admin-server"
+        app.kubernetes.io/component: "adminserver"
+      annotations:
+        managedkafka.bf2.org/secret-dependency-digest: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+    spec:
+      affinity:
+       podAffinity:
+         preferredDuringSchedulingIgnoredDuringExecution:
+         - podAffinityTerm:
+             labelSelector:
+               matchExpressions:
+               - key: "strimzi.io/name"
+                 operator: "In"
+                 values:
+                 - "test-mk-tls-q-zookeeper"
+             topologyKey: "kubernetes.io/hostname"
+           weight: 100    
+      containers:
+      - env:
+        - name: "KAFKA_ADMIN_BOOTSTRAP_SERVERS"
+          value: "test-mk-tls-q-kafka-bootstrap:9095"
+        - name: "KAFKA_ADMIN_BROKER_TLS_ENABLED"
+          value: "true"
+        - name: "KAFKA_ADMIN_BROKER_TRUSTED_CERT"
+          valueFrom:
+            secretKeyRef:
+              key: "ca.crt"
+              name: "test-mk-tls-q-cluster-ca-cert"
+              optional: false
+        - name: "KAFKA_ADMIN_ACL_RESOURCE_OPERATIONS"
+          value: "{ \"cluster\": [ \"describe\", \"alter\" ], \"group\": [ \"all\"\
+            , \"delete\", \"describe\", \"read\" ], \"topic\": [ \"all\", \"alter\"\
+            , \"alter_configs\", \"create\", \"delete\", \"describe\", \"describe_configs\"\
+            , \"read\", \"write\" ], \"transactional_id\": [ \"all\", \"describe\"\
+            , \"write\" ] }"
+        - name: "KAFKA_ADMIN_NUM_PARTITIONS_MAX"
+          value: "1000"
+        - name: "KAFKA_ADMIN_TLS_CERT"
+          value: "/opt/kafka-admin-api/tls-config/tls.crt"
+        - name: "KAFKA_ADMIN_TLS_KEY"
+          value: "/opt/kafka-admin-api/tls-config/tls.key"
+        - name: "KAFKA_ADMIN_TLS_VERSION"
+          value: "TLSv1.3,TLSv1.2"
+        - name: "KAFKA_ADMIN_OAUTH_ENABLED"
+          value: "false"
+        image: "quay.io/mk-ci-cd/kafka-admin-api:0.7.0"
+        livenessProbe:
+          httpGet:
+            path: "/health/live"
+            port: "http"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        name: "admin-server"
+        ports:
+          - containerPort: 8080
+            name: "http"
+          - containerPort: 8080
+            name: "management"
+          - containerPort: 8443
+            name: "https"
+        readinessProbe:
+          httpGet:
+            path: "/health/ready"
+            port: "http"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+          - mountPath: "/opt/kafka-admin-api/custom-config/"
+            name: "custom-config"
+          - mountPath: "/opt/kafka-admin-api/tls-config/"
+            name: "tls-config"
+            readOnly: true
+      volumes:
+        - configMap:
+            name: "test-mk-tls-q-admin-server"
+            optional: true
+          name: "custom-config"
+        - secret:
+            secretName: "test-mk-tls-q-tls-secret"
+          name: "tls-config"

--- a/operator/src/test/resources/expected/adminserver-tls.yml
+++ b/operator/src/test/resources/expected/adminserver-tls.yml
@@ -1,0 +1,109 @@
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+    app: "test-mk-tls-admin-server"
+    app.kubernetes.io/component: "adminserver"
+  name: "test-mk-tls-admin-server"
+  namespace: "test"
+  ownerReferences:
+  - apiVersion: "managedkafka.bf2.org/v1alpha1"
+    kind: "ManagedKafka"
+    name: "test-mk-tls"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+      app: "test-mk-tls-admin-server"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+        app: "test-mk-tls-admin-server"
+        app.kubernetes.io/component: "adminserver"
+      annotations:
+        managedkafka.bf2.org/secret-dependency-digest: "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+    spec:
+      affinity:
+       podAffinity:
+         preferredDuringSchedulingIgnoredDuringExecution:
+         - podAffinityTerm:
+             labelSelector:
+               matchExpressions:
+               - key: "strimzi.io/name"
+                 operator: "In"
+                 values:
+                 - "test-mk-tls-zookeeper"
+             topologyKey: "kubernetes.io/hostname"
+           weight: 100    
+      containers:
+      - env:
+        - name: "KAFKA_ADMIN_BOOTSTRAP_SERVERS"
+          value: "test-mk-tls-kafka-bootstrap:9095"
+        - name: "KAFKA_ADMIN_BROKER_TLS_ENABLED"
+          value: "true"
+        - name: "KAFKA_ADMIN_BROKER_TRUSTED_CERT"
+          valueFrom:
+            secretKeyRef:
+              key: "ca.crt"
+              name: "test-mk-tls-cluster-ca-cert"
+              optional: false
+        - name: "KAFKA_ADMIN_ACL_RESOURCE_OPERATIONS"
+          value: "{ \"cluster\": [ \"describe\", \"alter\" ], \"group\": [ \"all\"\
+            , \"delete\", \"describe\", \"read\" ], \"topic\": [ \"all\", \"alter\"\
+            , \"alter_configs\", \"create\", \"delete\", \"describe\", \"describe_configs\"\
+            , \"read\", \"write\" ], \"transactional_id\": [ \"all\", \"describe\"\
+            , \"write\" ] }"
+        - name: "KAFKA_ADMIN_NUM_PARTITIONS_MAX"
+          value: "1000"
+        - name: "KAFKA_ADMIN_TLS_CERT"
+          value: "/opt/kafka-admin-api/tls-config/tls.crt"
+        - name: "KAFKA_ADMIN_TLS_KEY"
+          value: "/opt/kafka-admin-api/tls-config/tls.key"
+        - name: "KAFKA_ADMIN_TLS_VERSION"
+          value: "TLSv1.3,TLSv1.2"
+        - name: "KAFKA_ADMIN_OAUTH_ENABLED"
+          value: "false"
+        image: "quay.io/mk-ci-cd/kafka-admin-api:0.7.0"
+        livenessProbe:
+          httpGet:
+            path: "/health/liveness"
+            port: "management"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        name: "admin-server"
+        ports:
+          - containerPort: 8443
+            name: "https"
+          - containerPort: 9990
+            name: "management"
+        readinessProbe:
+          httpGet:
+            path: "/health/liveness"
+            port: "management"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+          - mountPath: "/opt/kafka-admin-api/custom-config/"
+            name: "custom-config"
+          - mountPath: "/opt/kafka-admin-api/tls-config/"
+            name: "tls-config"
+            readOnly: true
+      volumes:
+        - configMap:
+            name: "test-mk-tls-admin-server"
+            optional: true
+          name: "custom-config"
+        - secret:
+            secretName: "test-mk-tls-tls-secret"
+          name: "tls-config"


### PR DESCRIPTION
Configure admin server health probes and exposed ports depending on whether property is present in ConfigMap with image reference. Obsolete code branches to be removed once new admin server is deployed to production.

Signed-off-by: Michael Edgar <medgar@redhat.com>