### PR TITLE
Expose new quota plugin jmx metrics

### DIFF
--- a/operator/src/main/resources/kafka-metrics.yaml
+++ b/operator/src/main/resources/kafka-metrics.yaml
@@ -253,6 +253,17 @@ data:
       - pattern: kafka.server<type=Fetch, quota.type=FETCH><>throttle-time
         name: kafka_server_fetch_throttle_time
         type: GAUGE
-      - pattern : io.strimzi.kafka.quotas<type=(.+), name=(.+)><>Value
-        name: kafka_broker_quota_$2
+      - pattern: kafka.server<type=Request, quota.type=REQUEST><>request-rate
+        name: kafka_server_request_request_rate
+        type: GAUGE
+      - pattern: kafka.server<type=Request, quota.type=REQUEST><>throttle-time
+        name: kafka_server_request_throttle_time
+        type: GAUGE
+      - pattern : io.strimzi.kafka.quotas<type=StorageChecker, name=(.+)><>Value
+        name: kafka_broker_quota_$1
+        type: GAUGE
+      - pattern : io.strimzi.kafka.quotas<type=StaticQuotaCallback, name=(.+)><>Value
+        name: kafka_broker_client_quota_limit
+        labels:
+          quota_type: "$1"
         type: GAUGE


### PR DESCRIPTION
Changes to expose the new quota metrics made available by https://github.com/strimzi/kafka-quotas-plugin/pull/22 as prometheus metrics.

* `kafka_broker_quota_hardlimit` gives the quota storage hard-limit
* `kafka_broker_client_quota_limit{quota_type="(Produce|Fetch|Request)}` exposes the producer, fetch and request limits.

I also took the opportunity to the kafka_server_request_request_rate/kafka_server_request_throttle_time, as there omission 
seemed to be a gap.

Changes are backwardly compatible with the old plugin and existing alert rules etc.
