### PR TITLE
Correct the handling of metric updates.

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
@@ -134,8 +134,7 @@ public class MetricsManager implements ResourceEventHandler<Kafka>{
     private Optional<GenericKafkaListener> getExternalListener(AtomicReference<Kafka> r) {
         return getKafkaClusterSpec(r)
                 .map(KafkaClusterSpec::getListeners)
-                .orElse(List.of())
-                .stream().filter(l -> AbstractKafkaCluster.EXTERNAL_LISTENER_NAME.equals(l.getName())).findFirst();
+                .flatMap(ll -> ll.stream().filter(l -> AbstractKafkaCluster.EXTERNAL_LISTENER_NAME.equals(l.getName())).findFirst());
     }
 
     private Optional<KafkaClusterSpec> getKafkaClusterSpec(AtomicReference<Kafka> k) {

--- a/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
@@ -22,7 +22,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;

--- a/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
@@ -2,23 +2,34 @@ package org.bf2.operator.managers;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.cache.Cache;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.search.Search;
 import io.quarkus.runtime.Startup;
 import io.strimzi.api.kafka.model.Kafka;
+import io.strimzi.api.kafka.model.KafkaClusterSpec;
+import io.strimzi.api.kafka.model.KafkaSpec;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
+import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration;
+import org.bf2.operator.operands.AbstractKafkaCluster;
 import org.bf2.operator.operands.KafkaCluster;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
-
-import static org.bf2.operator.operands.AbstractKafkaCluster.EXTERNAL_LISTENER_NAME;
 
 @Startup
 @ApplicationScoped
@@ -43,6 +54,8 @@ public class MetricsManager implements ResourceEventHandler<Kafka>{
     @Inject
     MeterRegistry meterRegistry;
 
+    private final Map<String, AtomicReference<Kafka>> kafkaMap = new ConcurrentHashMap<>();
+
     @PostConstruct
     public void postConstruct() {
         informerManager.registerKafkaInformerHandler(this);
@@ -50,40 +63,50 @@ public class MetricsManager implements ResourceEventHandler<Kafka>{
 
     @Override
     public void onAdd(Kafka kafka) {
-        createMetrics(kafka);
+        createOrUpdateMetrics(kafka);
     }
 
     @Override
     public void onUpdate(Kafka oldObj, Kafka newObj) {
-        createMetrics(newObj);
+        createOrUpdateMetrics(newObj);
     }
 
     @Override
     public void onDelete(Kafka obj, boolean deletedFinalStateUnknown) {
         Search.in(meterRegistry).tags(buildKafkaInstanceTags(obj)).meters().forEach(meterRegistry::remove);
-
+        kafkaMap.remove(Cache.metaNamespaceKeyFunc(obj));
     }
 
-    private void createMetrics(Kafka kafka) {
+    private void createOrUpdateMetrics(Kafka kafka) {
+        AtomicReference<Kafka> ref = kafkaMap.computeIfAbsent(Cache.metaNamespaceKeyFunc(kafka), (k) -> new AtomicReference<>(kafka));
+        // Note that meterRegistry.gauge() is a no-op if the gauge already exists.  To handle the update case we
+        // update the existing atomic reference that is already registered with the gauge to point at the new kafka object.
+        ref.set(kafka);
+
         Tags tags = buildKafkaInstanceTags(kafka);
-        meterRegistry.gauge(KAFKA_INSTANCE_SPEC_BROKERS_DESIRED_COUNT, tags, kafka, this::replicas);
-        meterRegistry.gauge(KAFKA_INSTANCE_PARTITION_LIMIT, tags, kafka, k -> kafkaConfigValue(k, KafkaCluster.MAX_PARTITIONS));
-        meterRegistry.gauge(KAFKA_INSTANCE_MAX_MESSAGE_SIZE_LIMIT, tags, kafka, k -> kafkaConfigValue(k, KafkaCluster.MESSAGE_MAX_BYTES));
 
-        if (kafka.getSpec() != null && kafka.getSpec().getKafka() != null) {
-            IntStream.range(0, kafka.getSpec().getKafka().getReplicas()).forEach(ordinal -> {
-                Tags brokerTags = Tags.concat(tags, Tags.of(Tag.of(TAG_LABEL_BROKER_ID, String.valueOf(ordinal))));
+        meterRegistry.gauge(KAFKA_INSTANCE_SPEC_BROKERS_DESIRED_COUNT, tags, ref, this::replicas);
+        meterRegistry.gauge(KAFKA_INSTANCE_PARTITION_LIMIT, tags, ref, k -> kafkaConfigValue(k, KafkaCluster.MAX_PARTITIONS));
+        meterRegistry.gauge(KAFKA_INSTANCE_MAX_MESSAGE_SIZE_LIMIT, tags, ref, k -> kafkaConfigValue(k, KafkaCluster.MESSAGE_MAX_BYTES));
 
-                if (kafka.getSpec().getKafka().getListeners() != null) {
-                    kafka.getSpec().getKafka().getListeners().stream().filter(l -> EXTERNAL_LISTENER_NAME.equals(l.getName())).forEach(l -> {
-                        String listenerName = String.format("%s-%d", l.getName().toUpperCase(Locale.ROOT), l.getPort()); // Note - kafka itself capitalises the listener name.
-                        Tags listenerTags = Tags.concat(brokerTags, Tags.of(Tag.of(TAG_LABEL_LISTENER, listenerName)));
-                        meterRegistry.gauge(KAFKA_INSTANCE_CONNECTION_LIMIT, listenerTags, l, this::maxConnections);
-                        meterRegistry.gauge(KAFKA_INSTANCE_CONNECTION_CREATION_RATE_LIMIT, listenerTags, l, this::maxConnectionCreationRate);
-                    });
-                }
-            });
-        }
+        Set<Meter> orphanMeters = new HashSet<>(Search.in(meterRegistry).tags(tags).tagKeys(TAG_LABEL_BROKER_ID).meters());
+
+        Optional<GenericKafkaListener> externalListener = getExternalListener(ref);
+        externalListener.ifPresent(genericKafkaListener -> IntStream.range(0, kafka.getSpec().getKafka().getReplicas()).forEach(ordinal -> {
+            String listenerName = String.format("%s-%d", genericKafkaListener.getName().toUpperCase(Locale.ROOT), genericKafkaListener.getPort()); // Note - kafka itself capitalises the listener name.
+            Tag brokerTag = Tag.of(TAG_LABEL_BROKER_ID, String.valueOf(ordinal));
+            Tag listenerTag = Tag.of(TAG_LABEL_LISTENER, listenerName);
+            Tags listenerTags = tags.and(brokerTag, listenerTag);
+
+            orphanMeters.removeIf(m -> m.getId().getTags().contains(brokerTag));
+
+            meterRegistry.gauge(KAFKA_INSTANCE_CONNECTION_LIMIT, listenerTags, ref,
+                    r -> getExternalListener(r).map(GenericKafkaListener::getConfiguration).map(GenericKafkaListenerConfiguration::getMaxConnections).map(Integer::doubleValue).orElse(Double.NaN));
+            meterRegistry.gauge(KAFKA_INSTANCE_CONNECTION_CREATION_RATE_LIMIT, listenerTags, ref,
+                    r -> getExternalListener(r).map(GenericKafkaListener::getConfiguration).map(GenericKafkaListenerConfiguration::getMaxConnectionCreationRate).map(Integer::doubleValue).orElse(Double.NaN));
+        }));
+
+        orphanMeters.forEach(meterRegistry::remove);
     }
 
     private Tags buildKafkaInstanceTags(Kafka obj) {
@@ -91,20 +114,34 @@ public class MetricsManager implements ResourceEventHandler<Kafka>{
         return Tags.of(Tag.of(TAG_LABEL_NAMESPACE, metadata.getNamespace()), Tag.of(TAG_LABEL_INSTANCE_NAME, metadata.getName()), OWNER);
     }
 
-    private Double replicas(Kafka k) {
-        return k.getSpec() == null || k.getSpec().getKafka() == null ? Double.NaN : k.getSpec().getKafka().getReplicas();
+    private Double replicas(AtomicReference<Kafka> r) {
+        return getKafkaClusterSpec(r)
+                .map(KafkaClusterSpec::getReplicas)
+                .map(Number::doubleValue)
+                .orElse(Double.NaN);
     }
 
-    private Double kafkaConfigValue(Kafka k, String configKey) {
-        return k.getSpec() == null || k.getSpec().getKafka() == null || k.getSpec().getKafka().getConfig() == null || k.getSpec().getKafka().getConfig().get(configKey) == null ? Double.NaN : ((Number) k.getSpec().getKafka().getConfig().get(configKey)).doubleValue();
+    private Double kafkaConfigValue(AtomicReference<Kafka> r, String configKey) {
+        Class<Number> number = Number.class;
+        return getKafkaConfig(r).map(m -> m.get(configKey)).filter(number::isInstance).map(number::cast).map(Number::doubleValue).orElse(Double.NaN);
     }
 
-    private Double maxConnections(GenericKafkaListener l) {
-        return l.getConfiguration() == null ? Double.MAX_VALUE : l.getConfiguration().getMaxConnections();
+    private Optional<Map<String, Object>> getKafkaConfig(AtomicReference<Kafka> k) {
+        return getKafkaClusterSpec(k)
+                .map(KafkaClusterSpec::getConfig);
     }
 
-    private Double maxConnectionCreationRate(GenericKafkaListener l) {
-        return l.getConfiguration() == null ? Double.MAX_VALUE : l.getConfiguration().getMaxConnectionCreationRate();
+    private Optional<GenericKafkaListener> getExternalListener(AtomicReference<Kafka> r) {
+        return getKafkaClusterSpec(r)
+                .map(KafkaClusterSpec::getListeners)
+                .orElse(List.of())
+                .stream().filter(l -> AbstractKafkaCluster.EXTERNAL_LISTENER_NAME.equals(l.getName())).findFirst();
+    }
+
+    private Optional<KafkaClusterSpec> getKafkaClusterSpec(AtomicReference<Kafka> k) {
+        return Optional.ofNullable(k.get())
+                .map(Kafka::getSpec)
+                .map(KafkaSpec::getKafka);
     }
 
 }


### PR DESCRIPTION
I noticed that sometimes after creating a managedkafka, the new metrics would show a NaN value, rather than the reflection of the kafka resource as expected.  It turns out there is a race. I misunderstood how `meterRegistry.gauge()` works, if the metric already exists (same name and tags), the method is a no-op.  This meant metric continued to return values from the initial kaka object and any updates were ignored.

  