### PR TITLE
Add scheme to `adminServerURI` in ManagedKafka status

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -538,8 +538,10 @@ public class AdminServer extends AbstractAdminServer {
 
     @Override
     public String uri(ManagedKafka managedKafka) {
-        Route route = cachedRoute(managedKafka);
+        return getRouteURI(cachedRoute(managedKafka));
+    }
 
+    String getRouteURI(Route route) {
         if (route != null) {
             RouteSpec spec = route.getSpec();
             StringBuilder uri = new StringBuilder();

--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.api.model.RouteSpec;
 import io.fabric8.openshift.api.model.TLSConfig;
 import io.fabric8.openshift.api.model.TLSConfigBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -236,7 +237,7 @@ public class AdminServer extends AbstractAdminServer {
                     .withLabels(buildRouteLabels())
                     .withAnnotations(buildRouteAnnotations(config))
                 .endMetadata()
-                .editOrNewSpec()
+                .withNewSpec()
                     .withNewTo()
                         .withKind("Service")
                         .withName(adminServerName)
@@ -538,7 +539,17 @@ public class AdminServer extends AbstractAdminServer {
     @Override
     public String uri(ManagedKafka managedKafka) {
         Route route = cachedRoute(managedKafka);
-        return route != null ? route.getSpec().getHost() : null;
+
+        if (route != null) {
+            RouteSpec spec = route.getSpec();
+            StringBuilder uri = new StringBuilder();
+            uri.append(spec.getTls() != null ? "https://" : "http://");
+            uri.append(spec.getHost());
+
+            return uri.toString();
+        }
+
+        return null;
     }
 
     private Route cachedRoute(ManagedKafka managedKafka) {

--- a/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
@@ -2,6 +2,8 @@ package org.bf2.operator.operands;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -88,6 +90,28 @@ class AdminServerTest {
                 .withName(adminServerDeployment.getMetadata().getName()).get());
 
         KafkaClusterTest.diffToExpected(adminServerDeployment, expectedResource);
+    }
+
+    @Test
+    void routeUriPlain() throws Exception {
+        Route route = new RouteBuilder().withNewSpec()
+                .withHost("test.net")
+            .endSpec()
+            .build();
+
+        assertEquals("http://test.net", adminServer.getRouteURI(route));
+    }
+
+    @Test
+    void routeUriTls() throws Exception {
+        Route route = new RouteBuilder().withNewSpec()
+                .withHost("test.net")
+                .withNewTls()
+                .endTls()
+            .endSpec()
+            .build();
+
+        assertEquals("https://test.net", adminServer.getRouteURI(route));
     }
 
     @Test


### PR DESCRIPTION
Include URI scheme (http/https) reported in the `adminServerURI` of the MK status.

MGDSTRM-7766