### PR TITLE
Fix upgrade test for managed kafka

### DIFF
--- a/systemtest/src/main/java/org/bf2/systemtest/framework/AssertUtils.java
+++ b/systemtest/src/main/java/org/bf2/systemtest/framework/AssertUtils.java
@@ -8,10 +8,6 @@ import org.bf2.operator.resources.v1alpha1.ManagedKafkaStatus;
 import org.bf2.systemtest.framework.resource.ManagedKafkaResourceType;
 import org.bf2.test.k8s.KubeClient;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,17 +48,5 @@ public class AssertUtils {
         assertNotNull(agentStatus.getRemaining(), yml);
         assertNotNull(agentStatus.getResizeInfo(), yml);
         assertNotNull(agentStatus.getNodeInfo(), yml);
-    }
-
-    public static void assertStrimziUpgraded(ManagedKafka mk, LocalDateTime dateBeforeStartUpgrade) {
-        ManagedKafkaResourceType.getKafkaPods(mk).forEach(kp -> {
-            LocalDateTime started = LocalDateTime.ofInstant(Instant.parse(kp.getStatus().getStartTime()), ZoneOffset.UTC);
-            assertTrue(dateBeforeStartUpgrade.isBefore(started));
-        });
-
-        ManagedKafkaResourceType.getZookeeperPods(mk).forEach(zp -> {
-            LocalDateTime started = LocalDateTime.ofInstant(Instant.parse(zp.getStatus().getStartTime()), ZoneOffset.UTC);
-            assertTrue(dateBeforeStartUpgrade.isBefore(started));
-        });
     }
 }

--- a/systemtest/src/test/java/org/bf2/systemtest/integration/UpgradeST.java
+++ b/systemtest/src/test/java/org/bf2/systemtest/integration/UpgradeST.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag(TestTags.UPGRADE)
 public class UpgradeST extends AbstractST {
@@ -78,7 +78,6 @@ public class UpgradeST extends AbstractST {
 
         AssertUtils.assertManagedKafka(mk);
 
-        LocalDateTime dateBeforeStartUpgrade = LocalDateTime.now(ZoneOffset.UTC);
         LOGGER.info("Upgrade to {}", latestStrimziVersion);
         mk = ManagedKafkaResourceType.getDefault(mkAppName, mkAppName, keycloak, latestStrimziVersion, kafkaVersion);
         mk = resourceManager.createResource(extensionContext, mk);
@@ -98,10 +97,10 @@ public class UpgradeST extends AbstractST {
                     TimeUnit.MINUTES.toMillis(10));
         }
 
-        ManagedKafka finalMk = mk;
         TestUtils.waitFor("MK is upgraded", TimeUnit.SECONDS.toMillis(20), TimeUnit.MINUTES.toMillis(10), () -> {
             try {
-                AssertUtils.assertStrimziUpgraded(finalMk, dateBeforeStartUpgrade);
+                assertEquals(latestStrimziVersion, ManagedKafkaResourceType.getOperation().inNamespace(mkAppName)
+                        .withName(mkAppName).get().getStatus().getVersions().getStrimzi());
                 return true;
             } catch (AssertionError err) {
                 return false;


### PR DESCRIPTION
Remove check for kafka and zookeeper pod roller during upgrade, it does not work when kafka image is not changed between strimzi versions. 