### PR TITLE
MGDSTRM-7845 removing the possibility of the service npe

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -538,6 +538,9 @@ public class IngressControllerManager {
         String serviceName = route.getSpec().getTo().getName();
         String namespace = route.getMetadata().getNamespace();
         Service svc = informerManager.getLocalService(namespace, serviceName);
+        if (svc == null) {
+            return "";
+        }
 
         Map<String, String> labels = svc.getSpec().getSelector();
         Stream<Pod> pods = brokerPodInformer.getList().stream()


### PR DESCRIPTION
We don't have to put a lot of effort into this because it's primarily due to the service watch issue.  It's still possible as a timing issue, but that would be exceedingly rare.  Since an empty string was already being returned, just added that here.