### PR TITLE
Retrieval of Kafka, Canary, and Admin server images from annotations

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/StrimziManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/StrimziManager.java
@@ -137,11 +137,11 @@ public class StrimziManager {
     }
 
     private boolean isStrimziDeployment(Deployment deployment) {
-        return deployment.getMetadata().getName().startsWith("strimzi-cluster-operator");
+        return deployment.getMetadata().getName().startsWith(STRIMZI_CLUSTER_OPERATOR);
     }
 
     private void updateStatus() {
-        List<StrimziVersionStatus> versions = this.strimziVersions.values().stream().map(ComponentVersions::getStrimziVersion).collect(Collectors.toCollection(ArrayList::new));
+        List<StrimziVersionStatus> versions = this.strimziVersions.values().stream().map(ComponentVersions::getStrimziVersion).collect(Collectors.toList());
         // create the Kafka informer only when a Strimzi bundle is installed (aka at least one available version)
         if (!versions.isEmpty()) {
             informerManager.createKafkaInformer();
@@ -196,9 +196,9 @@ public class StrimziManager {
                 .getTemplate()
                 .getSpec()
                 .getContainers()
-                .get(0)
-                .getEnv()
                 .stream()
+                .filter(container -> container.getName().startsWith(STRIMZI_CLUSTER_OPERATOR))
+                .flatMap(container -> container.getEnv().stream())
                 .filter(ev -> ev.getName().equals(KAFKA_IMAGES_ENVVAR))
                 .map(EnvVar::getValue)
                 .filter(Objects::nonNull)


### PR DESCRIPTION
With this change, the fleetshard operator will support specifying canary, canary-init, admin-server, and Kafka images in annotations on the Strimzi deployment's pod template.

```yaml
managedkafka.bf2.org/kafka-images: |
  2.8.1=quay.io/mk-ci-cd/kafka-28@sha256:cd9d97704f5a729154f82acf06eabb25b9cff985423c9ffbccaefd35b6858953
  3.0.0=quay.io/mk-ci-cd/kafka-30@sha256:49b743b887318d2e5c74f99e864d6f646dabc000d9c093a500916bcee1a7cf10
managedkafka.bf2.org/related-images: |
  {
    "canary-init": "quay.io/mk-ci-cd/strimzi-canary@sha256:1ad0e8aaad71b5fc230ce12359d0fafeec2361948501234962346c0e4492d9d0",
    "canary": "quay.io/mk-ci-cd/strimzi-canary@sha256:1ad0e8aaad71b5fc230ce12359d0fafeec2361948501234962346c0e4492d9d0",
    "admin-server": "quay.io/mk-ci-cd/kafka-admin-api@sha256:f55f80fdfca47152d0991881998cdcc13082ff23819849a6394bbab266b61c5c"
  }
```
- When annotation `managedkafka.bf2.org/kafka-images` is present, it will be the preferred data source to determine the versions of Kafka supported by the deployment in `StrimziManager`. Otherwise, the `STRIMZI_KAFKA_IMAGES` env will be used.
- When the canary, canary-init, or admin server images are `null` in their respective ConfigMap keys, the pod template's `managedkafka.bf2.org/related-images` annotation will be checked (via `StrimziManager`) for an entry corresponding to the component. If not found, default to the image in configuration.



MGDSTRM-7931