### PR TITLE
Configure default sync properties for standalone deployment

### DIFF
--- a/sync/src/main/resources/application.properties
+++ b/sync/src/main/resources/application.properties
@@ -9,13 +9,14 @@ resync.interval=${resync-interval:60s}
 
 # prod defaults (not expected to change)
 secret.name=addon-kas-fleetshard-operator-parameters
-sso.enabled=true
+sso.enabled=false
+sso.filter.enabled=true
 secret.enabled=true
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %x %s%e%n
 quarkus.kubernetes.ports.http.host-port=8080
 
 # dev overrides
-%dev.sso.enabled=false
+%dev.sso.filter.enabled=false
 %dev.secret.enabled=false
 %dev.quarkus.log.category."org.bf2".level=DEBUG
 %dev.sync.mock-control-plane.simulate=true
@@ -23,7 +24,7 @@ quarkus.kubernetes.ports.http.host-port=8080
 %dev.quarkus.kubernetes.env.vars."sync.mock-control-plane.max"=${sync.mock-control-plane.max}
 
 # test overrides
-%test.sso.enabled=false
+%test.sso.filter.enabled=false
 %test.secret.enabled=false
 %test.sync.mock-control-plane.simulate=false
 %test.quarkus.log.category."org.bf2".level=DEBUG
@@ -35,7 +36,7 @@ control-plane/mp-rest/connectTimeout=5000
 control-plane/mp-rest/readTimeout=10000
 ## authentication properties, client-enabled and register-filter should be true to enable
 quarkus.oidc-client.client-enabled=${sso.enabled}
-quarkus.oidc-client-filter.register-filter=${sso.enabled}
+quarkus.oidc-client-filter.register-filter=${sso.filter.enabled}
 quarkus.oidc-client.auth-server-url=${sso.auth-server-url}
 quarkus.oidc-client.client-id=${sso.client-id}
 quarkus.oidc-client.credentials.secret=${sso.secret}
@@ -46,6 +47,7 @@ quarkus.kubernetes-config.secrets.enabled=true
 quarkus.kubernetes-config.secrets=${secret.name}
 ## must be disabled by default for dev/test - cannot use indirection; set in container via env
 quarkus.kubernetes-config.enabled=false
+quarkus.kubernetes-config.fail-on-missing-config=${sso.enabled}
 
 quarkus.kubernetes.secret-volumes.tls-config-volume.secret-name=sync-sso-tls-config
 quarkus.kubernetes.secret-volumes.tls-config-volume.optional=true


### PR DESCRIPTION
Allows sync to run (without crash-loops) in environments without external SSO or configuration secret being available.

With this change, the value of env `SSO_ENABLED` must be set to `true` to re-enable the functionality turned off by default.

Signed-off-by: Michael Edgar <medgar@redhat.com>