### PR TITLE
Configure the soft and hard limits at customer's provisioned capacity.

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -607,14 +607,15 @@ public class KafkaCluster extends AbstractKafkaCluster {
         config.put(QUOTA_FETCH, String.valueOf(getEgressBytes(managedKafka, current)));
 
         // Start throttling when disk is above requested size. Full stop when only storageMinMargin is free.
-        Quantity maxDataRetentionSize = getAdjustedMaxDataRetentionSize(managedKafka, current);
-        KafkaInstanceConfiguration instanceConfig = this.configs.getConfig(managedKafka);
-        long hardStorageLimit = Quantity.getAmountInBytes(maxDataRetentionSize).longValue() - Quantity.getAmountInBytes(instanceConfig.getStorage().getMinMargin()).longValue();
-        long softStorageLimit = Quantity.getAmountInBytes(maxDataRetentionSize).longValue() - getStoragePadding(managedKafka, current);
-        config.put("client.quota.callback.static.storage.soft", String.valueOf(softStorageLimit));
-        config.put("client.quota.callback.static.storage.hard", String.valueOf(hardStorageLimit));
+        final long maxRetentionBytes = Quantity.getAmountInBytes(getAdjustedMaxDataRetentionSize(managedKafka, current)).longValue();
+        final long storagePaddingBytes = getStoragePadding(managedKafka, current);
+        long storageLimit = maxRetentionBytes - storagePaddingBytes;
+        //For RHOASK its unlikely that customers will notice producer throttling, so we set it to the same as the hard limit and let the hard limit win
+        config.put("client.quota.callback.static.storage.soft", String.valueOf(storageLimit));
+        config.put("client.quota.callback.static.storage.hard", String.valueOf(storageLimit));
 
         // Check storage every storageCheckInterval seconds
+        KafkaInstanceConfiguration instanceConfig = this.configs.getConfig(managedKafka);
         config.put("client.quota.callback.static.storage.check-interval", String.valueOf(instanceConfig.getStorage().getCheckInterval()));
 
         // Configure the quota plugin so that the canary is not subjected to the quota checks.

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 import static org.bf2.operator.utils.ManagedKafkaUtils.exampleManagedKafka;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTestResource(KubernetesServerTestResource.class)
 @QuarkusTest
@@ -131,7 +132,96 @@ class KafkaClusterTest {
         Kafka larger = kafkaCluster.kafkaFrom(exampleManagedKafka("80Gi"), kafka);
 
         // should change to a larger size
-        diffToExpected(larger, "/expected/strimzi.yml", "[{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.soft\",\"value\":\"28633115306\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.hard\",\"value\":\"28675058306\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/storage/volumes/0/size\",\"value\":\"39412476546\"}]");
+        diffToExpected(larger, "/expected/strimzi.yml", "[{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.soft\",\"value\":\"28633115306\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.hard\",\"value\":\"28633115306\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/storage/volumes/0/size\",\"value\":\"39412476546\"}]");
+    }
+
+    @Test
+    void hardLimitShouldBeAtCustomerStorage() throws IOException {
+        //Given
+        alternativeConfig(clone -> {
+            clone.getKafka().setOneInstancePerNode(false);
+            clone.getKafka().setColocateWithZookeeper(false);
+            clone.getKafka().setEnableQuota(true);
+            clone.getExporter().setColocateWithZookeeper(false);
+        });
+        final ManagedKafka managedKafka = exampleManagedKafka("2Ti");
+
+        //When
+        Kafka kafka = kafkaCluster.kafkaFrom(managedKafka, null);
+
+        //Then
+        final Map<String, Object> config = kafka.getSpec().getKafka().getConfig();
+        final long brokerCapacity = getBrokerCapacity(managedKafka, kafka);
+
+        assertLimitAt("client.quota.callback.static.storage.hard", config, brokerCapacity);
+    }
+
+    @Test
+    void hardLimitShouldBeWithinPvcStorage() throws IOException {
+        //Given
+        alternativeConfig(clone -> {
+            clone.getKafka().setOneInstancePerNode(false);
+            clone.getKafka().setColocateWithZookeeper(false);
+            clone.getKafka().setEnableQuota(true);
+            clone.getExporter().setColocateWithZookeeper(false);
+        });
+        final ManagedKafka managedKafka = exampleManagedKafka("2Ti");
+
+        //When
+        Kafka kafka = kafkaCluster.kafkaFrom(managedKafka, null);
+
+        //Then
+        final Map<String, Object> config = kafka.getSpec().getKafka().getConfig();
+        final long volumeSizeInBytes = getVolumeSizeInBytes(kafka);
+
+        assertLimitUnder("client.quota.callback.static.storage.hard", config, volumeSizeInBytes);
+    }
+
+    @Test
+    void softLimitShouldBeEqualToHardLimit() throws IOException {
+        //Given
+        alternativeConfig(clone -> {
+            clone.getKafka().setOneInstancePerNode(false);
+            clone.getKafka().setColocateWithZookeeper(false);
+            clone.getKafka().setEnableQuota(true);
+            clone.getExporter().setColocateWithZookeeper(false);
+        });
+        final ManagedKafka managedKafka = exampleManagedKafka("2Ti");
+
+        //When
+        Kafka kafka = kafkaCluster.kafkaFrom(managedKafka, null);
+
+        //Then
+        final Map<String, Object> config = kafka.getSpec().getKafka().getConfig();
+        final long volumeSizeInBytes = getVolumeSizeInBytes(kafka);
+
+        final long actualSoftLimit = assertLimitUnder("client.quota.callback.static.storage.soft", config, volumeSizeInBytes);
+        final long actualHardLimit = assertLimitUnder("client.quota.callback.static.storage.hard", config, volumeSizeInBytes);
+        assertEquals(actualSoftLimit, actualHardLimit);
+    }
+
+    private long getVolumeSizeInBytes(Kafka kafka) {
+        final JbodStorage storage = (JbodStorage) kafka.getSpec().getKafka().getStorage();
+        final PersistentClaimStorage pvc = (PersistentClaimStorage) storage.getVolumes().get(0);
+        return Long.parseLong(pvc.getSize());
+    }
+
+    private long getBrokerCapacity(ManagedKafka managedKafka, Kafka kafka) {
+        final Quantity maxDataRetentionSize = managedKafka.getSpec().getCapacity().getMaxDataRetentionSize();
+        final long clusterCapacity = Quantity.getAmountInBytes(maxDataRetentionSize).longValue();
+        final int replicas = kafka.getSpec().getKafka().getReplicas();
+        return clusterCapacity / replicas;
+    }
+
+    private long assertLimitUnder(String key, Map<String, Object> config, long expected) {
+        final long actualLimit = Long.parseLong(String.valueOf(config.get(key)));
+        assertTrue(actualLimit < expected, "expected (" + key + ") " + actualLimit + " to be smaller than " + expected);
+        return actualLimit;
+    }
+
+    private void assertLimitAt(String key, Map<String, Object> config, long expected) {
+        final long actualLimit = Long.parseLong(String.valueOf(config.get(key)));
+        assertEquals(actualLimit, expected, "expected (" + key + ") " + actualLimit + " to be smaller than " + expected);
     }
 
     @Test
@@ -213,10 +303,10 @@ class KafkaClusterTest {
 
     static JsonNode diffToExpected(Object kafka, String expected, String diff) throws IOException, JsonProcessingException, JsonMappingException {
         ObjectMapper objectMapper = Serialization.yamlMapper();
-        JsonNode file1 = objectMapper.readTree(KafkaClusterTest.class.getResourceAsStream(expected));
+        JsonNode expectedJson = objectMapper.readTree(KafkaClusterTest.class.getResourceAsStream(expected));
         String yaml = Serialization.asYaml(kafka);
-        JsonNode file2 = objectMapper.readTree(yaml);
-        JsonNode patch = JsonDiff.asJson(file1, file2);
+        JsonNode actualJson = objectMapper.readTree(yaml);
+        JsonNode patch = JsonDiff.asJson(expectedJson, actualJson);
         assertEquals(diff, patch.toString(), yaml);
         return patch;
     }

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -112,7 +112,7 @@ spec:
       quota.window.num: "30"
       message.max.bytes: 1048588
       client.quota.callback.static.fetch: "699050"
-      client.quota.callback.static.storage.hard: "10758389740"
+      client.quota.callback.static.storage.hard: "10737418240"
       client.quota.callback.static.storage.check-interval: "30"
       client.quota.callback.static.excluded.principal.name.list: "canary-123"
       default.replication.factor: 3

--- a/operator/src/test/resources/expected/scaling-one.yml
+++ b/operator/src/test/resources/expected/scaling-one.yml
@@ -51,7 +51,7 @@ strimzi.authorization.custom-authorizer.acl.logging.002: "topic=*;apis=list_offs
 strimzi.authorization.custom-authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
 strimzi.authorization.custom-authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
 strimzi.authorization.custom-authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
-client.quota.callback.static.storage.hard: "64550338560"
+client.quota.callback.static.storage.hard: "64424509440"
 strimzi.authorization.custom-authorizer.resource-operations: "{ \"cluster\": [ \"\
   describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\", \"read\"\
   \ ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\", \"delete\"\

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -106,7 +106,7 @@ spec:
       quota.window.num: "30"
       message.max.bytes: 1048588
       client.quota.callback.static.fetch: "1398101"
-      client.quota.callback.static.storage.hard: "21516779480"
+      client.quota.callback.static.storage.hard: "21474836480"
       client.quota.callback.static.storage.check-interval: "30"
       client.quota.callback.static.excluded.principal.name.list: "canary-123"
       default.replication.factor: 3


### PR DESCRIPTION
We don't believe customers will notice producer throttling in time to act, a safety factor of 2 there would have been a little over 1 min of throttling before the hard limit. Moving to a factor of 5 would give them 2m 30s or so to react.
The hard limit is what really protects the broker anyway, so we just simplify the documentation and monitoring story to the hard limit.

There is an outstanding question should the hard limit be at or slightly beyond the provisioned storage?

https://issues.redhat.com/browse/MGDSTRM-8110