### PR TITLE
bugfix: compensate for the ext4 formatting overhead in storage calculations

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -710,10 +710,9 @@ public class KafkaCluster extends AbstractKafkaCluster {
      * Get the effective volume size considering extra padding and the existing size
      */
     private Quantity getAdjustedMaxDataRetentionSize(Kafka current, long storagePerBroker, long storagePadding) {
-        long bytes = storagePerBroker;
+        long bytes = storagePerBroker + storagePadding;
 
         // pad to give a margin before soft/hard limits kick in
-        bytes += storagePadding;
 
         // strimzi won't allow the size to be reduced so scrape the size if possible
         if (current != null) {

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -87,7 +87,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Provides same functionalities to get a Kafka resource from a ManagedKafka one
@@ -195,6 +194,10 @@ public class KafkaCluster extends AbstractKafkaCluster {
         int actualReplicas = getBrokerReplicas(managedKafka, current);
         int desiredReplicas = getBrokerReplicas(managedKafka, null);
 
+        long storagePerBroker = getPerBrokerBytes(managedKafka.getSpec().getCapacity().getMaxDataRetentionSize(), () -> this.configs.getConfig(managedKafka).getKafka().getVolumeSize(), actualReplicas);
+        long safetyMargin = calculateSafetyMargin(managedKafka, current);
+        long formatOverheadWithMargin = safetyMargin + calculateFormattingOverhead(managedKafka, storagePerBroker + safetyMargin, FormattedValueType.FORMATTED);
+
         KafkaInstanceConfiguration config = this.configs.getConfig(managedKafka);
         KafkaBuilder kafkaBuilder = builder
                 .editOrNewMetadata()
@@ -207,11 +210,11 @@ public class KafkaCluster extends AbstractKafkaCluster {
                 .editOrNewSpec()
                     .editOrNewKafka()
                         .withVersion(this.kafkaManager.currentKafkaVersion(managedKafka))
-                        .withConfig(buildKafkaConfig(managedKafka, current))
+                        .withConfig(buildKafkaConfig(managedKafka, current, storagePerBroker))
                         .withReplicas(actualReplicas)
                         .withResources(config.kafka.buildResources())
                         .withJvmOptions(buildKafkaJvmOptions(managedKafka))
-                        .withStorage(buildKafkaStorage(managedKafka, current))
+                        .withStorage(buildKafkaStorage(managedKafka, current, storagePerBroker, formatOverheadWithMargin))
                         .withListeners(buildListeners(managedKafka, actualReplicas))
                         .withRack(buildKafkaRack(managedKafka))
                         .withTemplate(buildKafkaTemplate(managedKafka))
@@ -532,7 +535,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         return specBuilder.build();
     }
 
-    private Map<String, Object> buildKafkaConfig(ManagedKafka managedKafka, Kafka current) {
+    private Map<String, Object> buildKafkaConfig(ManagedKafka managedKafka, Kafka current, long storagePerBroker) {
         Map<String, Object> config = new HashMap<>();
         KafkaInstanceConfiguration instanceConfig = this.configs.getConfig(managedKafka);
         int scalingAndReplicationFactor = instanceConfig.getKafka().getScalingAndReplicationFactor();
@@ -568,7 +571,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
 
         // configure quota plugin
         if (instanceConfig.getKafka().isEnableQuota()) {
-            addQuotaConfig(managedKafka, current, config);
+            addQuotaConfig(managedKafka, current, config, storagePerBroker);
         }
 
         // custom authorizer configuration
@@ -598,7 +601,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         return (String)kafka.getSpec().getKafka().getConfig().get(QUOTA_FETCH);
     }
 
-    private void addQuotaConfig(ManagedKafka managedKafka, Kafka current, Map<String, Object> config) {
+    private void addQuotaConfig(ManagedKafka managedKafka, Kafka current, Map<String, Object> config, long storageLimit) {
 
         config.put("client.quota.callback.class", IO_STRIMZI_KAFKA_QUOTA_STATIC_QUOTA_CALLBACK);
 
@@ -606,10 +609,6 @@ public class KafkaCluster extends AbstractKafkaCluster {
         config.put(QUOTA_PRODUCE, String.valueOf(getIngressBytes(managedKafka, current)));
         config.put(QUOTA_FETCH, String.valueOf(getEgressBytes(managedKafka, current)));
 
-        // Start throttling when disk is above requested size. Full stop when only storageMinMargin is free.
-        final long maxRetentionBytes = Quantity.getAmountInBytes(getAdjustedMaxDataRetentionSize(managedKafka, current)).longValue();
-        final long storagePaddingBytes = getStoragePadding(managedKafka, current);
-        long storageLimit = maxRetentionBytes - storagePaddingBytes;
         //It's unlikely that customers will notice producer throttling, so we set it to the same as the hard limit and let the hard limit win
         config.put("client.quota.callback.static.storage.soft", String.valueOf(storageLimit));
         config.put("client.quota.callback.static.storage.hard", String.valueOf(storageLimit));
@@ -626,10 +625,10 @@ public class KafkaCluster extends AbstractKafkaCluster {
         config.put("quota.window.size.seconds", "2");
     }
 
-    private Storage buildKafkaStorage(ManagedKafka managedKafka, Kafka current) {
+    private Storage buildKafkaStorage(ManagedKafka managedKafka, Kafka current, long storagePerBroker, long storagePadding) {
         PersistentClaimStorageBuilder builder = new PersistentClaimStorageBuilder()
                 .withId(JBOD_VOLUME_ID)
-                .withSize(getAdjustedMaxDataRetentionSize(managedKafka, current).getAmount())
+                .withSize(getAdjustedMaxDataRetentionSize(current, storagePerBroker, storagePadding).getAmount())
                 .withDeleteClaim(DELETE_CLAIM);
 
         Optional.ofNullable(current).map(Kafka::getSpec).map(KafkaSpec::getKafka).map(KafkaClusterSpec::getStorage)
@@ -666,38 +665,55 @@ public class KafkaCluster extends AbstractKafkaCluster {
     /**
      * Get per broker value
      */
-    private long getPerBrokerBytes(ManagedKafka managedKafka, Kafka current, Quantity quantity, Supplier<String> defaultValue) {
+    private long getPerBrokerBytes(Quantity quantity, Supplier<String> defaultValue, int replicas) {
         long bytes = Quantity.getAmountInBytes(Optional.ofNullable(quantity).orElseGet(() -> Quantity.parse(defaultValue.get()))).longValue();
-
-        return bytes / getBrokerReplicas(managedKafka, current);
+        return bytes / replicas;
     }
 
     private long getIngressBytes(ManagedKafka managedKafka, Kafka current) {
-        return getPerBrokerBytes(managedKafka, current, managedKafka.getSpec().getCapacity().getIngressPerSec(), () -> this.configs.getConfig(managedKafka).getKafka().getIngressPerSec());
+        int brokerReplicas = getBrokerReplicas(managedKafka, current);
+        return getPerBrokerBytes(managedKafka.getSpec().getCapacity().getIngressPerSec(), () -> this.configs.getConfig(managedKafka).getKafka().getIngressPerSec(), brokerReplicas);
     }
 
     private long getEgressBytes(ManagedKafka managedKafka, Kafka current) {
-        return getPerBrokerBytes(managedKafka, current, managedKafka.getSpec().getCapacity().getEgressPerSec(), () -> this.configs.getConfig(managedKafka).getKafka().getEgressPerSec());
+        int brokerReplicas = getBrokerReplicas(managedKafka, current);
+        return getPerBrokerBytes(managedKafka.getSpec().getCapacity().getEgressPerSec(), () -> this.configs.getConfig(managedKafka).getKafka().getEgressPerSec(), brokerReplicas);
     }
 
     /**
-     * Get extra storage padding given the effective IngressEgressThroughput limit and storageMinMargin
+     * Calculates extra storage safety margin given the effective IngressEgressThroughput limit and storageMinMargin
      */
-    private long getStoragePadding(ManagedKafka managedKafka, Kafka current) {
+    private long calculateSafetyMargin(ManagedKafka managedKafka, Kafka current) {
         KafkaInstanceConfiguration config = this.configs.getConfig(managedKafka);
         return Quantity.getAmountInBytes(config.getStorage().getMinMargin()).longValue()
                 + getIngressBytes(managedKafka, current) * config.getStorage().getCheckInterval()
                         * config.getStorage().getSafetyFactor();
     }
 
+    enum FormattedValueType {
+        FORMATTED, UNFORMATTED
+    }
+
+    /**
+     * Given either a formatted or unformatted size, calculate the formatting overhead using a heuristic.
+     */
+    protected long calculateFormattingOverhead(ManagedKafka managedKafka, long size, FormattedValueType formattedValueType) {
+        double formattingOverhead = this.configs.getConfig(managedKafka).getStorage().getFormattingOverhead();
+        if (formattedValueType == FormattedValueType.FORMATTED) {
+            return (long) (size * formattingOverhead);
+        } else {
+            return (long) (size - (size / (1 + formattingOverhead)));
+        }
+    }
+
     /**
      * Get the effective volume size considering extra padding and the existing size
      */
-    private Quantity getAdjustedMaxDataRetentionSize(ManagedKafka managedKafka, Kafka current) {
-        long bytes = getPerBrokerBytes(managedKafka, current, managedKafka.getSpec().getCapacity().getMaxDataRetentionSize(), () -> this.configs.getConfig(managedKafka).getKafka().getVolumeSize());
+    private Quantity getAdjustedMaxDataRetentionSize(Kafka current, long storagePerBroker, long storagePadding) {
+        long bytes = storagePerBroker;
 
         // pad to give a margin before soft/hard limits kick in
-        bytes += getStoragePadding(managedKafka, current);
+        bytes += storagePadding;
 
         // strimzi won't allow the size to be reduced so scrape the size if possible
         if (current != null) {
@@ -720,7 +736,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
     }
 
     public long unpadBrokerStorage(ManagedKafka managedKafka, Kafka current, long value) {
-        return value - getStoragePadding(managedKafka, current);
+        return value - calculateFormattingOverhead(managedKafka, value, FormattedValueType.UNFORMATTED) - calculateSafetyMargin(managedKafka, current);
     }
 
     /**
@@ -735,14 +751,14 @@ public class KafkaCluster extends AbstractKafkaCluster {
                 return 0L;
             }
             PersistentVolumeClaimStatus status = pvc.getStatus();
-            Quantity q = OperandUtils.getOrDefault(status.getCapacity(), "storage", (Quantity)null);
+            Quantity q = OperandUtils.getOrDefault(status.getCapacity(), "storage", (Quantity) null);
             if (q == null) {
                 return 0L;
             }
             long value = Quantity.getAmountInBytes(q).longValue();
             // round down to the nearest GB - the PVC request is automatically rounded up
-            return (long)Math.floor(((double)unpadBrokerStorage(managedKafka, current, value))/(1L<<30));
-        }).collect(Collectors.summingLong(Long::longValue));
+            return (long) Math.floor(((double) unpadBrokerStorage(managedKafka, current, value)) / (1L << 30));
+        }).mapToLong(Long::longValue).sum();
 
         Quantity capacity = managedKafka.getSpec().getCapacity().getMaxDataRetentionSize();
 

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -60,6 +60,10 @@ public class KafkaInstanceConfiguration {
         @JsonProperty("min-margin")
         protected Quantity minMargin;
 
+        @JsonProperty("formatting-overhead")
+        protected double formattingOverhead = 105d/100;
+
+
         public int getCheckInterval() {
             return checkInterval;
         }
@@ -83,6 +87,15 @@ public class KafkaInstanceConfiguration {
         public void setMinMargin(Quantity minMargin) {
             this.minMargin = minMargin;
         }
+
+        public double getFormattingOverhead() {
+            return formattingOverhead;
+        }
+
+        public void setFormattingOverhead(double formattingOverhead) {
+            this.formattingOverhead = formattingOverhead;
+        }
+
     }
 
     public static class Container {

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -61,7 +61,7 @@ public class KafkaInstanceConfiguration {
         protected Quantity minMargin;
 
         @JsonProperty("formatting-overhead")
-        protected double formattingOverhead = 105d/100;
+        protected double formattingOverhead;
 
 
         public int getCheckInterval() {

--- a/operator/src/main/resources/instances/managedkafka.properties
+++ b/operator/src/main/resources/instances/managedkafka.properties
@@ -22,3 +22,5 @@ canary.container-memory=64Mi
 storage.check-interval=30
 storage.safety-factor=2
 storage.min-margin=10Gi
+# Based on experimentation with ext4 volumes (the kubernetes default which is used by the service).
+storage.formatting-overhead=0.05

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -357,10 +357,10 @@ class KafkaClusterTest {
         ManagedKafka mk = dummyManagedKafka("id");
 
         long desiredUserStorage = Quantity.getAmountInBytes(Quantity.parse("1Gi")).longValue();
-        long formattingOverhead = kafkaCluster.calculateFormattingOverhead(mk, desiredUserStorage, KafkaCluster.FormattedValueType.FORMATTED);
+        long formattingOverhead = kafkaCluster.calculateFormatOverheadFromFormattedSize(mk, desiredUserStorage);
         long physicalStorage = desiredUserStorage + formattingOverhead;
         assertTrue(physicalStorage > desiredUserStorage);
-        long formattingOverheadFromPhysicalStorage = kafkaCluster.calculateFormattingOverhead(mk, physicalStorage, KafkaCluster.FormattedValueType.UNFORMATTED);
+        long formattingOverheadFromPhysicalStorage = kafkaCluster.calculateFormatOverheadFromUnformattedSize(mk, physicalStorage);
         assertEquals(formattingOverhead, formattingOverheadFromPhysicalStorage);
     }
 

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -52,6 +52,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.bf2.operator.utils.ManagedKafkaUtils.dummyManagedKafka;
 import static org.bf2.operator.utils.ManagedKafkaUtils.exampleManagedKafka;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -130,13 +131,13 @@ class KafkaClusterTest {
 
         Kafka reduced = kafkaCluster.kafkaFrom(exampleManagedKafka("40Gi"), kafka);
 
-        // should not change to a smaller size
-        diffToExpected(reduced, "/expected/strimzi.yml");
+        // storage should not change to a smaller size, but the lower limits should be enforced
+        diffToExpected(reduced, "/expected/strimzi.yml", "[{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.soft\",\"value\":\"14316557653\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.hard\",\"value\":\"14316557653\"}]");
 
         Kafka larger = kafkaCluster.kafkaFrom(exampleManagedKafka("80Gi"), kafka);
 
-        // should change to a larger size
-        diffToExpected(larger, "/expected/strimzi.yml", "[{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.soft\",\"value\":\"28633115306\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.hard\",\"value\":\"28633115306\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/storage/volumes/0/size\",\"value\":\"39412476546\"}]");
+        // storage should change to a larger size with the higher limits.
+        diffToExpected(larger, "/expected/strimzi.yml", "[{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.soft\",\"value\":\"28633115306\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/config/client.quota.callback.static.storage.hard\",\"value\":\"28633115306\"},{\"op\":\"replace\",\"path\":\"/spec/kafka/storage/volumes/0/size\",\"value\":\"41383100373\"}]");
     }
 
     @Test
@@ -342,13 +343,25 @@ class KafkaClusterTest {
     }
 
     @Test
-    void testStorageCalculations() throws IOException {
+    void testStorageCalculations() {
         ManagedKafka mk = exampleManagedKafka("40Gi");
         Kafka kafka = kafkaCluster.kafkaFrom(mk, null);
         long bytes = getBrokerStorageBytes(kafka);
-        assertEquals(25095918893L, bytes);
+        assertEquals(26350714837L, bytes);
 
-        assertEquals((40*1L<<30)-1, kafkaCluster.unpadBrokerStorage(mk, null, 25095918893L)*3);
+        assertEquals((40*1L<<30)-1, kafkaCluster.unpadBrokerStorage(mk, null,   bytes)*3);
+    }
+
+    @Test
+    void testFormattedStorageCalculations() {
+        ManagedKafka mk = dummyManagedKafka("id");
+
+        long desiredUserStorage = Quantity.getAmountInBytes(Quantity.parse("1Gi")).longValue();
+        long formattingOverhead = kafkaCluster.calculateFormattingOverhead(mk, desiredUserStorage, KafkaCluster.FormattedValueType.FORMATTED);
+        long physicalStorage = desiredUserStorage + formattingOverhead;
+        assertTrue(physicalStorage > desiredUserStorage);
+        long formattingOverheadFromPhysicalStorage = kafkaCluster.calculateFormattingOverhead(mk, physicalStorage, KafkaCluster.FormattedValueType.UNFORMATTED);
+        assertEquals(formattingOverhead, formattingOverheadFromPhysicalStorage);
     }
 
     private long getBrokerStorageBytes(Kafka kafka) {
@@ -419,7 +432,7 @@ class KafkaClusterTest {
         // there's no pvcs, should be 0
         assertEquals("0", kafkaCluster.calculateRetentionSize(mk).getAmount());
 
-        PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder().withNewStatus().addToCapacity("storage", Quantity.parse("344Gi")).endStatus().build();
+        PersistentVolumeClaim pvc = new PersistentVolumeClaimBuilder().withNewStatus().addToCapacity("storage", Quantity.parse("361Gi")).endStatus().build();
         Mockito.when(informerManager.getPvcsInNamespace(Mockito.anyString())).thenReturn(List.of(pvc, pvc, pvc));
 
         // should be the sum in Gi, less the padding

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -166,7 +166,7 @@ spec:
       volumes:
       - !<persistent-claim>
         type: "persistent-claim"
-        size: "21495807980"
+        size: "22570598379"
         class: "gp2"
         id: 0
         deleteClaim: true

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -159,7 +159,7 @@ spec:
       volumes:
       - !<persistent-claim>
         type: "persistent-claim"
-        size: "32254197720"
+        size: "33866907606"
         class: "gp2"
         id: 0
         deleteClaim: true


### PR DESCRIPTION
Previously the code assumed that the PV capacity's was the same same as the available space on the volume provisioned by OpenShift CSI.  This fails to account for the formatting overhead.

The service currently relies on the default `storageclass`, which uses a default `fsType`, which defaults to `ext4`. 

Actually calculating the exact formatting overhead for ext4 is non-trivial.  Instead we use a 5% heuristic which is shown to be sufficient for storage sizes of 16Ti and below (the ext4 maximum).  Note that volumes are formatted with the `reserved for root` disabled, so we don't need to consider that.

When this code is deployed, any existing kafka instances will have their storage increased by 5%.

There's more discussion on https://issues.redhat.com/browse/MGDSTRM-8072