### PR TITLE
Release 0.22.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,7 +1,4 @@
 name: kas-fleetshard
 release:
-  # The values here will usually be stale on the main branch.  This is
-  # intentional -- they should only be updated by creating a PR to the
-  # release branch.
-  current-version: 0.8.0
-  next-version: 0.8.1-SNAPSHOT
+  current-version: 0.22.0
+  next-version: 0.23.0-SNAPSHOT


### PR DESCRIPTION
This PR also goes back to having the `main` POM versions be set to the next SNAPSHOT release (see #230), as set by `next-version` for each release.

@rareddy , @shawkins - we can also leave `next-version` set to `999-SNAPSHOT`, let me know your thoughts.

Signed-off-by: Michael Edgar <medgar@redhat.com>