### PR TITLE
copying only the labels and annotations

### DIFF
--- a/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
+++ b/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
@@ -221,7 +221,8 @@ public class ManagedKafkaSync {
                     ManagedKafkaSpec spec = remote.getSpec();
                     ObjectMeta meta = remote.getMetadata();
                     client.edit(local.getMetadata().getNamespace(), local.getMetadata().getName(), mk -> {
-                            mk.setMetadata(meta);
+                            mk.getMetadata().setLabels(meta.getLabels());
+                            mk.getMetadata().setAnnotations(meta.getAnnotations());
                             mk.setSpec(spec);
                             return mk;
                         });


### PR DESCRIPTION
The operator sdk will not process events if the finalizer is removed (which seems like an sdk bug, which will no longer apply to us after https://github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard/pull/708/commits/e7f77ab96da923d068ef4e12edeee585dd1c6403)

So changing the metadata copying to be just labels and annotations.

Also this could have been avoided with fabric8 apply support - however even basic server side apply support is not coming until 6.0.