### PR TITLE
MGDSTRM-8409 cut down on modifications to the ingresscontroller

### DIFF
--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -13,6 +13,7 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.api.model.RouteTargetReferenceBuilder;
 import io.fabric8.openshift.api.model.operator.v1.IngressController;
+import io.fabric8.openshift.api.model.operator.v1.IngressControllerBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusMock;
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTestResource(KubernetesServerTestResource.class)
@@ -75,6 +77,15 @@ public class IngressControllerManagerTest {
         assertEquals(1, ingressControllers.size(), "Expected only one IngressController");
         assertEquals("kas", ingressControllers.get(0).getMetadata().getName(), "Expected the IngressController to be named kas");
         assertEquals(0, ingressControllers.get(0).getSpec().getReplicas(), "Expected 0 replicas because there are 0 nodes");
+
+        // check the patch logic
+        IngressController ic = ingressControllers.get(0);
+        assertFalse(ingressControllerManager.shouldPatchIngressController(ic, ic));
+        assertTrue(ingressControllerManager.shouldPatchIngressController(ic,
+                new IngressControllerBuilder(ic).editMetadata()
+                        .withLabels(Collections.emptyMap())
+                        .endMetadata()
+                        .build()));
     }
 
     @Test


### PR DESCRIPTION
Prior to issuing a patch we'll use the diff logic to determine if the patch is even needed.  Simply having fields added in existing state is just a side effect of the ingress controller operator - with the worst case is that the application of our patch then causes another update, which can repeat for quite a while.

So we need to see something removed or modified to submit the patch.  

I only see two updates being clustered by the operator in my local testing, so I didn't bother adding a time delay like with the ingress replicas.

This strategy could be employed for any dependent resource that we are attempting to patch that is modified by their respective controller / operator.