### PR TITLE
Adding test for annotation

### DIFF
--- a/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
+++ b/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
@@ -230,10 +230,9 @@ public class ManagedKafkaSync {
                     ManagedKafkaSpec spec = remoteCopy.getSpec();
                     ObjectMeta meta = remoteCopy.getMetadata();
                     client.edit(local.getMetadata().getNamespace(), local.getMetadata().getName(), mk -> {
-                            secretManager.calculateMasterSecretDigest(mk, masterSecret);
                             mk.getMetadata().setLabels(meta.getLabels());
                             mk.getMetadata().setAnnotations(meta.getAnnotations());
-                            mk.setMetadata(meta);
+                            secretManager.calculateMasterSecretDigest(mk, masterSecret);
                             mk.setSpec(spec);
                             return mk;
                         });

--- a/sync/src/main/java/org/bf2/sync/SecretManager.java
+++ b/sync/src/main/java/org/bf2/sync/SecretManager.java
@@ -34,7 +34,7 @@ public class SecretManager {
     private static final String OAUTH_SSO_CLIENT_SECRET = "oauth.ssoClientSecret";
     private static final String CANARY_SASL_PRINCIPAL = "canary.sasl.principal";
     private static final String CANARY_SASL_PASSWORD = "canary.sasl.password";
-    private static final String ANNOTATION_MASTER_SECRET_DIGEST = "managedkafka.bf2.org/master-secret-digest";
+    static final String ANNOTATION_MASTER_SECRET_DIGEST = "managedkafka.bf2.org/master-secret-digest";
 
     @Inject
     KubernetesClient kubernetesClient;

--- a/sync/src/test/java/org/bf2/sync/PollerTest.java
+++ b/sync/src/test/java/org/bf2/sync/PollerTest.java
@@ -84,6 +84,7 @@ public class PollerTest {
         managedKafkaSync.syncKafkaClusters();
         items = lookup.getLocalManagedKafkas();
         assertEquals(1, items.size());
+        assertTrue(items.get(0).getAnnotation(SecretManager.ANNOTATION_MASTER_SECRET_DIGEST).isPresent());
 
         // make sure the remote tracking is there and not marked as deleted
         assertFalse(controlPlane.getDesiredState(ControlPlane.managedKafkaKey(managedKafka)).getSpec().isDeleted());


### PR DESCRIPTION
Small fix to the secret manager to update secret-digest and tests for the annotation of the `master-secret`
