### PR TITLE
Use new prefix for broker plugins properties

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -388,6 +388,8 @@ public class KafkaInstanceConfiguration {
         protected String finalVersion = "0.0.0"; // Default, disables `acl-legacy` configurations
         @JsonProperty("authorizer-class")
         protected String authorizerClass = null;
+        @JsonProperty("broker-plugins-config-prefix")
+        protected String brokerPluginsConfigPrefix = null;
         @JsonProperty("config-prefix")
         protected String configPrefix = null;
         @JsonProperty("global")
@@ -457,10 +459,20 @@ public class KafkaInstanceConfiguration {
             this.authorizerClass = authorizerClass;
         }
 
+        public String getBrokerPluginsConfigPrefix() {
+            return brokerPluginsConfigPrefix;
+        }
+
+        public void setBrokerPluginsConfigPrefix(String brokerPluginsConfigPrefix) {
+            this.brokerPluginsConfigPrefix = brokerPluginsConfigPrefix;
+        }
+
+        @Deprecated
         public String getConfigPrefix() {
             return configPrefix;
         }
 
+        @Deprecated
         public void setConfigPrefix(String configPrefix) {
             this.configPrefix = configPrefix;
         }

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -390,6 +390,7 @@ public class KafkaInstanceConfiguration {
         protected String authorizerClass = null;
         @JsonProperty("broker-plugins-config-prefix")
         protected String brokerPluginsConfigPrefix = null;
+        @Deprecated
         @JsonProperty("config-prefix")
         protected String configPrefix = null;
         @JsonProperty("global")

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -81,6 +81,7 @@ managedkafka.upgrade.consuming-percentage-threshold=90
 # Static ACL static configuration for CustomAuthorizer
 managedkafka.kafka.acl.authorizer-class=io.bf2.kafka.authorizer.CustomAclAuthorizer
 managedkafka.kafka.acl.config-prefix=strimzi.authorization.custom-authorizer.
+managedkafka.kafka.acl.broker-plugins-config-prefix=kas.authorizer.
 managedkafka.kafka.acl.allowed-listeners=SRE-9096
 managedkafka.kafka.acl.logging.suppression-window.duration=PT300S
 managedkafka.kafka.acl.logging.suppression-window.eventCount=5000

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -167,6 +167,52 @@ spec:
       leader.imbalance.per.broker.percentage: 0
       strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.eventCount: 5000
       strimzi.authorization.custom-authorizer.partition-limit-enforced: false
+
+      kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
+      kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
+      kas.authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
+      kas.authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
+      kas.authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
+      kas.authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
+      kas.authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
+      kas.authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
+      kas.authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
+      kas.authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
+      kas.authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
+      kas.authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
+      kas.authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
+      kas.authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
+      kas.authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
+      kas.authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
+      kas.authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
+      kas.authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
+      kas.authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
+      kas.authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
+      kas.authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
+      kas.authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
+      kas.authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
+      kas.authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
+      kas.authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
+      kas.authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
+      kas.authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
+      kas.authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
+      kas.authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
+      kas.authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
+      kas.authorizer.acl.logging.suppressionWindow.duration: "PT300S"
+      kas.authorizer.acl.logging.suppressionWindow.eventCount: 5000
+      kas.authorizer.allowed-listeners: "SRE-9096"
+      kas.authorizer.resource-operations: "{ \"cluster\"\
+        : [ \"describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\"\
+        , \"read\" ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\"\
+        , \"delete\", \"describe\", \"describe_configs\", \"read\", \"write\" ], \"\
+        transactional_id\": [ \"all\", \"describe\", \"write\" ] }"
+      kas.policy.create-topic.partition-counter.private-topic-prefix: "__redhat_"
+      kas.policy.create-topic.partition-counter.schedule-interval-seconds: 15
+      kas.policy.create-topic.partition-counter.timeout-seconds: 10
+      kas.policy.create-topic.partition-limit-enforced: false
+      kas.policy.shared-admin.adminclient-listener.name: "controlplane-9090"
+      kas.policy.shared-admin.adminclient-listener.port: 9090
+      kas.policy.shared-admin.adminclient-listener.protocol: "SSL"
     storage:
       volumes:
       - type: "persistent-claim"
@@ -284,4 +330,3 @@ spec:
       requests:
         memory: "256Mi"
         cpu: "500m"
-

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -158,6 +158,52 @@ spec:
         transactional_id\": [ \"all\", \"describe\", \"write\" ] }"
       leader.imbalance.per.broker.percentage: 0
       strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.eventCount: 5000
+
+      kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
+      kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
+      kas.authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
+      kas.authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
+      kas.authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
+      kas.authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
+      kas.authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
+      kas.authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
+      kas.authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
+      kas.authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
+      kas.authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
+      kas.authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
+      kas.authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
+      kas.authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
+      kas.authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
+      kas.authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
+      kas.authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
+      kas.authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
+      kas.authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
+      kas.authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
+      kas.authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
+      kas.authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
+      kas.authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
+      kas.authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
+      kas.authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
+      kas.authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
+      kas.authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
+      kas.authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
+      kas.authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
+      kas.authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
+      kas.authorizer.acl.logging.suppressionWindow.duration: "PT300S"
+      kas.authorizer.acl.logging.suppressionWindow.eventCount: 5000
+      kas.authorizer.allowed-listeners: "SRE-9096"
+      kas.authorizer.resource-operations: "{ \"cluster\"\
+        : [ \"describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\"\
+        , \"read\" ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\"\
+        , \"delete\", \"describe\", \"describe_configs\", \"read\", \"write\" ], \"\
+        transactional_id\": [ \"all\", \"describe\", \"write\" ] }"
+      kas.policy.create-topic.partition-counter.private-topic-prefix: "__redhat_"
+      kas.policy.create-topic.partition-counter.schedule-interval-seconds: 15
+      kas.policy.create-topic.partition-counter.timeout-seconds: 10
+      kas.policy.create-topic.partition-limit-enforced: false
+      kas.policy.shared-admin.adminclient-listener.name: "controlplane-9090"
+      kas.policy.shared-admin.adminclient-listener.port: 9090
+      kas.policy.shared-admin.adminclient-listener.protocol: "SSL"
     storage:
       volumes:
       - type: "persistent-claim"

--- a/operator/src/test/resources/expected/scaling-one.yml
+++ b/operator/src/test/resources/expected/scaling-one.yml
@@ -69,3 +69,49 @@ strimzi.authorization.custom-authorizer.adminclient-listener.name: controlplane-
 strimzi.authorization.custom-authorizer.adminclient-listener.port: 9090
 strimzi.authorization.custom-authorizer.adminclient-listener.protocol: SSL
 strimzi.authorization.custom-authorizer.partition-limit-enforced: false
+
+kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
+kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
+kas.authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
+kas.authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
+kas.authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
+kas.authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
+kas.authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
+kas.authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
+kas.authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
+kas.authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
+kas.authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
+kas.authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
+kas.authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
+kas.authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
+kas.authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
+kas.authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
+kas.authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
+kas.authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
+kas.authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
+kas.authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
+kas.authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
+kas.authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
+kas.authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
+kas.authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
+kas.authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
+kas.authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
+kas.authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
+kas.authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
+kas.authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
+kas.authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
+kas.authorizer.acl.logging.suppressionWindow.duration: "PT300S"
+kas.authorizer.acl.logging.suppressionWindow.eventCount: 5000
+kas.authorizer.allowed-listeners: "SRE-9096"
+kas.authorizer.resource-operations: "{ \"cluster\": [ \"\
+  describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\", \"read\"\
+  \ ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\", \"delete\"\
+  , \"describe\", \"describe_configs\", \"read\", \"write\" ], \"transactional_id\"\
+  : [ \"all\", \"describe\", \"write\" ] }"
+kas.policy.create-topic.partition-counter.private-topic-prefix: __redhat_
+kas.policy.create-topic.partition-counter.schedule-interval-seconds: 15
+kas.policy.create-topic.partition-counter.timeout-seconds: 10
+kas.policy.create-topic.partition-limit-enforced: false
+kas.policy.shared-admin.adminclient-listener.name: controlplane-9090
+kas.policy.shared-admin.adminclient-listener.port: 9090
+kas.policy.shared-admin.adminclient-listener.protocol: SSL

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -160,6 +160,52 @@ spec:
       leader.imbalance.per.broker.percentage: 0
       strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.eventCount: 5000
       strimzi.authorization.custom-authorizer.partition-limit-enforced: false
+
+      kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
+      kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
+      kas.authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
+      kas.authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
+      kas.authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
+      kas.authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
+      kas.authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
+      kas.authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
+      kas.authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
+      kas.authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
+      kas.authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
+      kas.authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
+      kas.authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
+      kas.authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
+      kas.authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
+      kas.authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
+      kas.authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
+      kas.authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
+      kas.authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
+      kas.authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
+      kas.authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
+      kas.authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
+      kas.authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
+      kas.authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
+      kas.authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
+      kas.authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
+      kas.authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
+      kas.authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
+      kas.authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
+      kas.authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
+      kas.authorizer.acl.logging.suppressionWindow.duration: "PT300S"
+      kas.authorizer.acl.logging.suppressionWindow.eventCount: 5000
+      kas.authorizer.allowed-listeners: "SRE-9096"
+      kas.authorizer.resource-operations: "{ \"cluster\"\
+        : [ \"describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\"\
+        , \"read\" ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\"\
+        , \"delete\", \"describe\", \"describe_configs\", \"read\", \"write\" ], \"\
+        transactional_id\": [ \"all\", \"describe\", \"write\" ] }"
+      kas.policy.create-topic.partition-counter.private-topic-prefix: "__redhat_"
+      kas.policy.create-topic.partition-counter.schedule-interval-seconds: 15
+      kas.policy.create-topic.partition-counter.timeout-seconds: 10
+      kas.policy.create-topic.partition-limit-enforced: false
+      kas.policy.shared-admin.adminclient-listener.name: "controlplane-9090"
+      kas.policy.shared-admin.adminclient-listener.port: 9090
+      kas.policy.shared-admin.adminclient-listener.protocol: "SSL"
     storage:
       volumes:
       - type: "persistent-claim"
@@ -273,4 +319,3 @@ spec:
       requests:
         memory: "256Mi"
         cpu: "500m"
-        


### PR DESCRIPTION
In the broker plugins project, we're updating the config properties so that they don't have the strimzi prefix.

This change updates the config set by this operator so that both the old and new properties are set. Once the version of the operator using the new properties is rolled out, we can then remove the old properties from being set here again in another change.

Given that this is intended to be a temporary duplication, I tried to keep it as simple as possible, so that it will be simple to remove when we get to that stage also.