### PR TITLE
Fixed error when no quota is available and wanted to reuse an already installed cluster

### DIFF
--- a/perf/scripts/osd-provision.sh
+++ b/perf/scripts/osd-provision.sh
@@ -598,18 +598,16 @@ if [[ "${OPERATION}" == "create" ]]; then
             exit 1
         fi
     else
-        RESPONSE=$($OCM post /api/clusters_mgmt/v1/clusters --body="${CLUSTER_JSON}" 2>&1)
-        if [[ $? -ne 0 ]]; then
-            ERROR_MESSAGE=$(echo $RESPONSE | jq -r .details[].Error_Key)
-            if [[ "$ERROR_MESSAGE" != "DuplicateClusterName" ]]; then
+        CLUSTER_EXIST=$($OCM list cluster --parameter search="name = '${CLUSTER_NAME}'" --no-headers | awk '{print $2}')
+        if [[ -z "${CLUSTER_EXIST}" ]]; then
+            $OCM post /api/clusters_mgmt/v1/clusters --body="${CLUSTER_JSON}"
+            if [[ $? -ne 0 ]]; then
                 echo "Something went wrong when creating the cluster. Exit!!!!"
-                echo $RESPONSE | jq .
                 exit 1
-            else
-                echo "'${CLUSTER_NAME}' cluster already exists"
             fi
+        else
+            echo "'${CLUSTER_NAME}' cluster already exists"
         fi
-        echo $RESPONSE | jq .
     fi
 
     if [[ "${WAIT}" == "true" ]]; then


### PR DESCRIPTION
Fixing this issue https://issues.redhat.com/browse/MGDSTRM-8836

When we want to use an already created cluster for developing purposes, we get an error every time there is no quota available to create a new one because it is trying to do that. 

Checking first if it already exists is better than trying and wait for the error.