### PR TITLE
[MGDSTRM-8959] Delay KafkaInstance reconcile until master secret created

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ServiceAccount.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ServiceAccount.java
@@ -2,6 +2,7 @@ package org.bf2.operator.resources.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import javax.validation.constraints.NotNull;
@@ -15,6 +16,7 @@ import javax.validation.constraints.NotNull;
         editableEnabled = false
 )
 @ToString
+@EqualsAndHashCode
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ServiceAccount {
 

--- a/common/src/main/java/org/bf2/common/OperandUtils.java
+++ b/common/src/main/java/org/bf2/common/OperandUtils.java
@@ -63,6 +63,10 @@ public class OperandUtils {
         return result;
     }
 
+    public static String masterSecretName(ManagedKafka managedKafka) {
+        return managedKafka.getMetadata().getName() + "-" + MASTER_SECRET_NAME;
+    }
+
     /**
      * Similar to the fabric8 createOrReplace operation, but assumes replacement is the dominant operation
      *

--- a/operator/src/main/java/org/bf2/operator/managers/SecuritySecretManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/SecuritySecretManager.java
@@ -131,6 +131,10 @@ public class SecuritySecretManager {
         }
     }
 
+    public boolean masterSecretExists(ManagedKafka managedKafka) {
+        return cachedOrRemoteSecret(managedKafka, OperandUtils.masterSecretName(managedKafka)) != null;
+    }
+
     public boolean secretKeysExist(ManagedKafka managedKafka, Map<String, List<String>> secretKeys) {
         for (Map.Entry<String, List<String>> entry : secretKeys.entrySet()) {
             String secretName = entry.getKey();

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstance.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstance.java
@@ -2,9 +2,11 @@ package org.bf2.operator.operands;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.bf2.operator.managers.ImagePullSecretManager;
+import org.bf2.operator.managers.SecuritySecretManager;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Reason;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
+import org.jboss.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -24,6 +26,8 @@ import java.util.stream.Collectors;
 public class KafkaInstance implements Operand<ManagedKafka> {
 
     @Inject
+    Logger log;
+    @Inject
     AbstractKafkaCluster kafkaCluster;
     @Inject
     Canary canary;
@@ -31,6 +35,8 @@ public class KafkaInstance implements Operand<ManagedKafka> {
     AdminServer adminServer;
     @Inject
     ImagePullSecretManager imagePullSecretManager;
+    @Inject
+    SecuritySecretManager securitySecretManager;
 
     private final Deque<Operand<ManagedKafka>> operands = new ArrayDeque<>();
 
@@ -43,7 +49,11 @@ public class KafkaInstance implements Operand<ManagedKafka> {
     public void createOrUpdate(ManagedKafka managedKafka) {
         imagePullSecretManager.propagateSecrets(managedKafka);
 
-        operands.forEach(o -> o.createOrUpdate(managedKafka));
+        if (securitySecretManager.masterSecretExists(managedKafka)) {
+            operands.forEach(o -> o.createOrUpdate(managedKafka));
+        } else {
+            log.infof("Master secret not yet created, skipping create/update processing");
+        }
     }
 
     @Override

--- a/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
+++ b/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
@@ -1,5 +1,7 @@
 package org.bf2.sync;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -7,6 +9,8 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.zjsonpatch.JsonDiff;
 import io.micrometer.core.annotation.Counted;
 import io.micrometer.core.annotation.Timed;
 import io.quarkus.scheduler.Scheduled;
@@ -173,15 +177,42 @@ public class ManagedKafkaSync {
             return false;
         }
         if (secretManager.isMasterSecretChanged(remote, existing)) {
+            log.debugf("Remote master secret data changed");
             return true;
         }
+
         ManagedKafka remoteCopy = secretManager.removeSecretsFromManagedKafka(remote);
+
+        if (!remoteCopy.getSpec().equals(existing.getSpec())) {
+            logChange("Remote spec changed: %s", remoteCopy.getSpec(), existing.getSpec());
+            return true;
+        }
+
+        if (!Objects.equals(existing.getMetadata().getLabels(), remoteCopy.getMetadata().getLabels())) {
+            logChange("Remote labels changed: %s", remoteCopy.getMetadata().getLabels(), existing.getMetadata().getLabels());
+            return true;
+        }
+
         // will always be non-null due to the id/placement requirements
         Map<String, String> annotations = new HashMap<>(existing.getMetadata().getAnnotations());
         annotations.keySet().removeAll(DATA_PLANE_ANNOTATIONS);
-        return !remoteCopy.getSpec().equals(existing.getSpec())
-                || !Objects.equals(existing.getMetadata().getLabels(), remoteCopy.getMetadata().getLabels())
-                || !Objects.equals(annotations, remoteCopy.getMetadata().getAnnotations());
+
+        if (!Objects.equals(annotations, remoteCopy.getMetadata().getAnnotations())) {
+            logChange("Remote annotations changed: %s", remoteCopy.getMetadata().getAnnotations(), annotations);
+            return true;
+        }
+
+        return false;
+    }
+
+    void logChange(String format, Object remote, Object local) {
+        if (log.isDebugEnabled()) {
+            ObjectMapper objectMapper = Serialization.yamlMapper();
+            JsonNode localJson = objectMapper.convertValue(local, JsonNode.class);
+            JsonNode remoteJson = objectMapper.convertValue(remote, JsonNode.class);
+            JsonNode patch = JsonDiff.asJson(localJson, remoteJson);
+            log.debugf(format, patch.toPrettyString());
+        }
     }
 
     /**

--- a/sync/src/main/java/org/bf2/sync/SecretManager.java
+++ b/sync/src/main/java/org/bf2/sync/SecretManager.java
@@ -42,10 +42,6 @@ public class SecretManager {
     @Inject
     InformerManager informerManager;
 
-    public static String masterSecretName(ManagedKafka managedKafka) {
-        return managedKafka.getMetadata().getName() + "-master-secret";
-    }
-
     public static String kafkaClusterNamespace(ManagedKafka managedKafka) {
         return managedKafka.getMetadata().getNamespace();
     }
@@ -67,7 +63,7 @@ public class SecretManager {
     }
 
     public Secret buildSecret(ManagedKafka managedKafka) {
-        Secret secret = buildSecret(masterSecretName(managedKafka),
+        Secret secret = buildSecret(OperandUtils.masterSecretName(managedKafka),
                             "Opaque",
                              managedKafka,
                              buildSecretData(managedKafka));
@@ -80,7 +76,7 @@ public class SecretManager {
     }
 
     private Secret buildSecret(String name, String type, ManagedKafka managedKafka, Map<String, String> dataSource) {
-        Secret current = cachedSecret(managedKafka, masterSecretName(managedKafka));
+        Secret current = cachedSecret(managedKafka, OperandUtils.masterSecretName(managedKafka));
         SecretBuilder builder = current != null ? new SecretBuilder(current) : new SecretBuilder();
 
         Map<String, String> data = dataSource.entrySet()
@@ -124,7 +120,7 @@ public class SecretManager {
     }
 
     public ManagedKafka removeSecretsFromManagedKafka(ManagedKafka managedKafka) {
-        final String masterSecretName = masterSecretName(managedKafka);
+        final String masterSecretName = OperandUtils.masterSecretName(managedKafka);
         final ManagedKafkaSpecBuilder replacement = new ManagedKafkaSpecBuilder(managedKafka.getSpec());
 
         if (isKafkaExternalCertificateEnabled(managedKafka)) {


### PR DESCRIPTION
Also adds some debug logging in sync around the changes received from the control plane.

Signed-off-by: Michael Edgar <medgar@redhat.com>