### PR TITLE
MGDSTRM-9050: expose generic mechanism for injecting additional broker configuration from the operand override

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -32,7 +32,7 @@ environment variable.  It also provides an additional configuration item to the 
         kas.policy.topic-config.topic-config-policy-enforced: true
 ```
 
-This can used to override items of configuration.
+This can be used to override items of configuration.
 
 # Logging / Metrics
 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -4,6 +4,38 @@ OLM deployment
 
 Refining operands
 
+# Operand Override
+
+When a kafka instance is being provisioned, fleetshard looks for a configmap named after the requested
+version of strimzi to provide a source of additional configuration.  The configmap must have the label
+`app=strimzi` and must have a name starts with the prefix `strimzi-cluster-operator`.  The config
+map must have a data-item `fleetshard_operands.yaml`.
+
+If such a configmap exists, it may provide:
+
+1. alternative operand image.
+1. environment variables (supported by canary and admin operand).
+1. additional kafka broker configuration options (supported by the kafka operand).
+
+For instance, here's an example override the canary operand image, and passing an additional
+environment variable.  It also provides an additional configuration item to the broker.
+
+```yaml
+ fleetshard_operands.yaml: |
+    canary:
+      image: quay.io/k_wall/strimzi-canary:0.5.0-122333444455555
+      env:
+      - name: FOO
+        value "true"
+    kafka:
+      brokerConfig:
+        kas.policy.topic-config.topic-config-policy-enforced: true
+```
+
+This can used to override items of configuration.
+
+# Logging / Metrics
+
 ## Configure fleetshard operator and synchronizer logging
 
 If you wish to change the logging behavior of a component at runtime, you should create a configmap with an application.properties file in the operator namespace named *component*_logging_config_override.  The application.properties file should contain logging properties of the form quarkus.log.category.*something*.level.
@@ -203,4 +235,6 @@ the resource.  The operator won't overwrite the changes until the digest of the 
 annotation on the target configmap.
 
 Note that after overridding the metric configuration it is currently necessary to roll the kafka or zookeeper pods to have the changes picked up.
+
+
 

--- a/operator/src/main/java/org/bf2/operator/managers/OperandOverrideManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/OperandOverrideManager.java
@@ -89,7 +89,7 @@ public class OperandOverrideManager {
     }
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Kafka extends OperandOverride {
-        public Map<String, Object> brokerConfig = Map.of();
+        private Map<String, Object> brokerConfig = Map.of();
 
         public Map<String, Object> getBrokerConfig() {
             return brokerConfig;

--- a/operator/src/main/java/org/bf2/operator/managers/OperandOverrideManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/OperandOverrideManager.java
@@ -88,6 +88,19 @@ public class OperandOverrideManager {
         }
     }
     @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Kafka extends OperandOverride {
+        public Map<String, Object> brokerConfig = Map.of();
+
+        public Map<String, Object> getBrokerConfig() {
+            return brokerConfig;
+        }
+
+        public void setBrokerConfig(Map<String, Object> kafkaConfig) {
+            this.brokerConfig = kafkaConfig;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Canary extends OperandOverride {
         public OperandOverride init = new OperandOverride();
     }
@@ -99,7 +112,7 @@ public class OperandOverrideManager {
         public OperandOverride adminServer = new OperandOverride();
 
         @JsonProperty(value = "kafka")
-        public OperandOverride kafka = new OperandOverride();
+        public Kafka kafka = new Kafka();
 
         @JsonProperty(value = "zookeeper")
         public OperandOverride zookeeper = new OperandOverride();
@@ -187,7 +200,7 @@ public class OperandOverrideManager {
         return getImage(getAdminServerOverride(strimzi), strimzi, "admin-server").orElse(adminApiImage);
     }
 
-    public OperandOverride getKafkaOverride(String strimzi) {
+    public Kafka getKafkaOverride(String strimzi) {
         return getOverrides(strimzi).kafka;
     }
 

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -61,6 +61,7 @@ import org.bf2.operator.managers.DrainCleanerManager;
 import org.bf2.operator.managers.ImagePullSecretManager;
 import org.bf2.operator.managers.IngressControllerManager;
 import org.bf2.operator.managers.KafkaManager;
+import org.bf2.operator.managers.OperandOverrideManager;
 import org.bf2.operator.managers.StrimziManager;
 import org.bf2.operator.operands.KafkaInstanceConfiguration.AccessControl;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
@@ -631,6 +632,18 @@ public class KafkaCluster extends AbstractKafkaCluster {
         if (cruiseControlEnabled) {
             config.put("cruise.control.metrics.topic.min.insync.replicas", this.configs.getConfig(managedKafka).cruiseControl.getMetricReporterTopicMinInsyncReplicas());
         }
+
+        // Override broker config from operand override
+        String strimzi = managedKafka.getSpec().getVersions().getStrimzi();
+        Optional.ofNullable(this.overrideManager.getKafkaOverride(strimzi)).map(OperandOverrideManager.Kafka::getBrokerConfig).orElse(Map.of()).forEach((key, value) -> {
+            if (value != null) {
+                config.put(key, value);
+            } else {
+                config.remove(key);
+            } ;
+        });
+
+
         return config;
     }
 

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -98,7 +98,6 @@ spec:
       strimzi.authorization.custom-authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
       strimzi.authorization.custom-authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
       strimzi.authorization.custom-authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
-      auto.create.topics.enable: "false"
       strimzi.authorization.custom-authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
       strimzi.authorization.custom-authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
       min.insync.replicas: 2
@@ -213,6 +212,7 @@ spec:
       kas.policy.shared-admin.adminclient-listener.name: "controlplane-9090"
       kas.policy.shared-admin.adminclient-listener.port: 9090
       kas.policy.shared-admin.adminclient-listener.protocol: "SSL"
+      broker.foo: bar
     storage:
       volumes:
       - type: "persistent-claim"


### PR DESCRIPTION
Using this mechanism, we can override configuration passed to the broker by populating the `brokerConfig` object on the operator override.  This will have utility for temporary feature flags as well as experimentation in dev.    Note you can remove a broker config key by passing a null value.

```
oc edit cm -n redhat-managed-kafka-operator  strimzi-cluster-operator.v0.26.0-15
```

```
  fleetshard_operands.yaml: |
    canary:
      init:
        image: null
    admin-server:
      image: null
    kafka:
      brokerConfig:
        kas.policy.topic-config.topic-config-policy-enforced: "true" # Inject a new broker config item
        auto.create.topics.enable: ~ # Null causes an existing one to be removed.
```


and showing it works end to end:

```
% oc logs -f kafka-instance-kafka-0 | grep kas.policy.topic-config.topic-config-policy-enforced
kas.policy.topic-config.topic-config-policy-enforced=true
```

