### PR TITLE
[MGDSTRM-9117] Canary support provided TLS trusted certificate

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -656,9 +656,6 @@ public class KafkaInstanceConfiguration {
     }
 
     public static class Canary extends Container {
-        @JsonProperty("probe-external-bootstrap-server-host")
-        protected boolean probeExternalBootstrapServerHost = false;
-
         @JsonProperty("colocate-with-zookeeper")
         protected boolean colocateWithZookeeper = false;
 
@@ -676,14 +673,6 @@ public class KafkaInstanceConfiguration {
 
         public void setColocateWithZookeeper(boolean colocateWithZookeeper) {
             this.colocateWithZookeeper = colocateWithZookeeper;
-        }
-
-        public boolean isProbeExternalBootstrapServerHost() {
-            return probeExternalBootstrapServerHost;
-        }
-
-        public void setProbeExternalBootstrapServerHost(boolean probeExternalBootstrapServerHost) {
-            this.probeExternalBootstrapServerHost = probeExternalBootstrapServerHost;
         }
 
         public String getTopic() {

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -68,9 +68,6 @@ managedkafka.canary.client-id=${managedkafka.kafka.acl.private-prefix}strimzi_ca
 # Default max session lifetime to 4m 59s
 managedkafka.kafka.maximum-session-lifetime-default=299000
 
-# Default canary to probing the external route
-managedkafka.canary.probe-external-bootstrap-server-host=true
-
 managedkafka.canary.producer-latency-buckets=50,100,150,200,250,300,350,400,450,500
 managedkafka.canary.endtoend-latency-buckets=100,200,300,400,500,600,700,800,900,1000,1100,1200
 managedkafka.canary.connection-check-latency-buckets=100,200,300,400,500,600,700,800,900,1000,1100,1200


### PR DESCRIPTION
- Conditionally use TLS certificate from MK CR when available, else use the Strimzi CA certificate (current behavior)
- Remove obsolete canary option to use non-existent internal port 9093 (MGDSTRM-9118)