### PR TITLE
haproxy: allow configuration of hard-stop-after configuration and contstats.

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -163,6 +163,10 @@ public class IngressControllerManager {
     Optional<String> hardStopAfter;
     @ConfigProperty(name = "ingresscontroller.ingress-container-command")
     Optional<List<String>> ingressContainerCommand;
+    @ConfigProperty(name = "ingresscontroller.reload-interval-seconds")
+    Optional<Long> ingressReloadIntervalSeconds;
+
+
     @ConfigProperty(name = "ingresscontroller.peak-throughput-percentage")
     int peakPercentage;
 
@@ -532,6 +536,14 @@ public class IngressControllerManager {
                     .endNodePlacement()
                 .endSpec();
         }
+
+        ingressReloadIntervalSeconds.ifPresent(value -> {
+            builder.editSpec()
+                    .withNewConfigUnsupportedConfigOverrides()
+                    .withAdditionalProperties(Map.of("reloadInterval", value))
+                    .endConfigUnsupportedConfigOverrides()
+                    .endSpec();
+        });
 
         createOrEdit(builder.build(), existing);
     }

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -38,10 +38,13 @@ ingresscontroller.peak-throughput-percentage=40
 # old sizing - this should go higher, but we should need more memory
 ingresscontroller.max-ingress-connections=75000
 
-# Enables haproxy option contstats in the kas ingress so that stats are reported live rather than at connection close.
+# Enables haproxy option contstats in the kas ingress so that stats are reported live rather than at connection close (RFE-3007 provide a proper mechanism to enable this option).
 ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=2 --template /tmp/haproxy-config.template
-# Disconnect established connections after a haproxy reconfiguration.
+# Disconnect established connections after a haproxy reconfiguration (NE-879 should eliminate the need for this)
 ingresscontroller.hard-stop-after=5s
+# Coalesce up-to reloadInterval worth of haproxy updates.  This prevents a flurry of haproxy restarts (1 per OpenShift Route) as each kafka
+# instance is created (NE-879 should eliminate the need for this).
+ingresscontroller.reload-interval-seconds=60
 
 # external configuration injection through configmap
 quarkus.kubernetes-config.enabled=true

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -38,6 +38,11 @@ ingresscontroller.peak-throughput-percentage=40
 # old sizing - this should go higher, but we should need more memory
 ingresscontroller.max-ingress-connections=75000
 
+# Enables haproxy option contstats in the kas ingress so that stats are reported live rather than at connection close.
+ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=2 --template /tmp/haproxy-config.template
+# Disconnect established connections after a haproxy reconfiguration.
+ingresscontroller.hard-stop-after=5s
+
 # external configuration injection through configmap
 quarkus.kubernetes-config.enabled=true
 quarkus.kubernetes-config.fail-on-missing-config=false


### PR DESCRIPTION
This change aims to work around issues on the ingress/egress metrics emitted by the service.

It was discovered that the data transfer metrics (which is exposed to the service user via the console and fleetmanager metrics endpoint) is being reported incorrectly.  In short, this is due to the fact that haproxy [counters used for statistics calculation are incremented only when a session finishes](https://cbonte.github.io/haproxy-dconv/2.2/configuration.html#4.2-option%20contstats) coupled with the way haproxy is reconfigured with new configuration means in progress ingress and egress metrics for inflight connections are lost every time there is a provision or deprovision kafka instance event on the dataplane. For applications like kafka where connections are long lived, this can result in a significantly under estimates for ingress/egress values.

This PR attempts to resolve this issue.  There are three parts:

1. enable haproxy `option contstats` so that haproxy continuous emits statistics for the connection ingress/egress values.  With the old behaviour the stats were emitted when the connection closed, meaning the stat was likely lost if haproxy was restarted,
1. enable haproxy `hard-stop-after` so that when the operator recreates the haproxy process due to a reconfiguration event, the old haprocess dies quickly causing the client to reconnect.  With the old behaviour, the old haproxy remained until the client closed the connection.  This had the downside that the metrics for those connection were never accounted for. 
1. increase `reload-interval` from default of `5s` to `60s` so that successive reconfigurations events are coalesced.   This means there are fewer haproxy restarts and thus fewer client disconnects.  During a kafka instance reprovision there is a reconfiguration event per OpenShift Route (so without this change there are 5 restart events for a 3 broker instance).

This work will hopefully be superseded by https://issues.redhat.com/browse/RFE-3007 and possibly https://issues.redhat.com/browse/NE-879.

