### PR TITLE
MGDSTRM-8585 adding support for reserved deployments

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/ManagedKafka.java
@@ -27,6 +27,8 @@ import java.util.UUID;
 @Version("v1alpha1")
 public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaStatus> implements Namespaced {
 
+    public static final String RESERVED_DEPLOYMENT_TYPE = "reserved";
+
     private static final String CERT = "cert";
 
     public static final String BF2_DOMAIN = "bf2.org/";
@@ -35,6 +37,8 @@ public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaS
 
     public static final String PROFILE_TYPE = BF2_DOMAIN + "kafkaInstanceProfileType";
     public static final String PROFILE_QUOTA_CONSUMED = BF2_DOMAIN + "kafkaInstanceProfileQuotaConsumed";
+
+    public static final String DEPLOYMENT_TYPE = BF2_DOMAIN + "deployment";
 
     @Override
     protected ManagedKafkaSpec initSpec() {
@@ -172,6 +176,14 @@ public class ManagedKafka extends CustomResource<ManagedKafkaSpec, ManagedKafkaS
     public static ManagedKafka getDummyInstance(int name) {
         return getDefault("mk-" + name, "mk-" + name, "xyz.com", CERT, CERT, "clientId", CERT, "secret",
                 "claim", "fallbackClaim", "http://jwks", "https://token", "http://issuer", "strimzi-cluster-operator.v0.23.0", "2.7.0");
+    }
+
+    @JsonIgnore
+    public boolean isReserveDeployment() {
+        if (getMetadata().getLabels() == null) {
+            return false;
+        }
+        return RESERVED_DEPLOYMENT_TYPE.equals(getMetadata().getLabels().get(DEPLOYMENT_TYPE));
     }
 
 }

--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -110,6 +111,17 @@ public class AdminServer extends AbstractAdminServer {
 
     @Override
     public void createOrUpdate(ManagedKafka managedKafka) {
+        if (managedKafka.isReserveDeployment()) {
+            Deployment current = cachedDeployment(managedKafka);
+            Deployment deployment = deploymentFrom(managedKafka, null);
+
+            deployment = ReservedDeploymentConverter.asReservedDeployment(current, deployment, managedKafka);
+            if (!Objects.equals(current, deployment)) {
+                createOrUpdate(deployment);
+            }
+            return;
+        }
+
         if (!secretDependenciesPresent(managedKafka)) {
             return;
         }

--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -170,6 +171,22 @@ public class Canary extends AbstractCanary {
         OperandUtils.setAsOwner(managedKafka, service);
 
         return service;
+    }
+
+    @Override
+    public void createOrUpdate(ManagedKafka managedKafka) {
+        if (managedKafka.isReserveDeployment()) {
+            Deployment current = cachedDeployment(managedKafka);
+            Deployment deployment = deploymentFrom(managedKafka, null);
+
+            deployment = ReservedDeploymentConverter.asReservedDeployment(current, deployment, managedKafka);
+
+            if (!Objects.equals(current, deployment)) {
+                createOrUpdate(deployment);
+            }
+            return;
+        }
+        super.createOrUpdate(managedKafka);
     }
 
     private List<Volume> buildVolumes(ManagedKafka managedKafka) {

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -14,10 +14,12 @@ import io.fabric8.kubernetes.api.model.PodAffinityTermBuilder;
 import io.fabric8.kubernetes.api.model.PodAntiAffinity;
 import io.fabric8.kubernetes.api.model.PodAntiAffinityBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.TolerationBuilder;
 import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
 import io.fabric8.kubernetes.api.model.TopologySpreadConstraintBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.quarkus.arc.DefaultBean;
@@ -52,6 +54,7 @@ import io.strimzi.api.kafka.model.storage.Storage;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplateBuilder;
 import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplateBuilder;
+import io.strimzi.api.kafka.model.template.PodTemplate;
 import io.strimzi.api.kafka.model.template.PodTemplateBuilder;
 import io.strimzi.api.kafka.model.template.ZookeeperClusterTemplate;
 import io.strimzi.api.kafka.model.template.ZookeeperClusterTemplateBuilder;
@@ -81,6 +84,7 @@ import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -88,6 +92,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -97,6 +102,14 @@ import java.util.function.Supplier;
 @ApplicationScoped
 @DefaultBean
 public class KafkaCluster extends AbstractKafkaCluster {
+
+    private static final String CRUISECONTROL_SUFFIX = "-cruisecontrol";
+
+    private static final String ZOOKEEPER_SUFFIX = "-zookeeper";
+
+    private static final String EXPORTER_SUFFIX = "-exporter";
+
+    private static final String KAFKA_SUFFIX = "-kafka";
 
     private static final String JMX_PORT = "9999";
 
@@ -148,6 +161,11 @@ public class KafkaCluster extends AbstractKafkaCluster {
 
     @Override
     public void createOrUpdate(ManagedKafka managedKafka) {
+        if (managedKafka.isReserveDeployment()) {
+            asReserveDeployments(managedKafka);
+            return;
+        }
+
         secretManager.createOrUpdate(managedKafka);
 
         ConfigMap currentKafkaMetricsConfigMap = cachedConfigMap(managedKafka, kafkaMetricsConfigMapName(managedKafka));
@@ -182,8 +200,47 @@ public class KafkaCluster extends AbstractKafkaCluster {
         super.createOrUpdate(managedKafka);
     }
 
+    private void asReserveDeployments(ManagedKafka managedKafka) {
+        // start with the desired kafka state - there will be no existing instance
+        Kafka kafka = kafkaFrom(managedKafka, null);
+
+        // we need to use a bunch of lambdas as there's no interfaces for the common functionality
+        createOrUpdateReservedDeployment(managedKafka, kafka, ZOOKEEPER_SUFFIX, k -> k.getSpec().getZookeeper(),
+                s -> s.getTemplate().getPod(), s -> s.getReplicas(), s -> s.getResources());
+        createOrUpdateReservedDeployment(managedKafka, kafka, EXPORTER_SUFFIX, k -> k.getSpec().getKafkaExporter(),
+                s -> s.getTemplate().getPod(), s -> 1, s -> s.getResources());
+        createOrUpdateReservedDeployment(managedKafka, kafka, KAFKA_SUFFIX, k -> k.getSpec().getKafka(),
+                s -> s.getTemplate().getPod(), s -> s.getReplicas(), s -> s.getResources());
+        createOrUpdateReservedDeployment(managedKafka, kafka, CRUISECONTROL_SUFFIX, k -> k.getSpec().getKafka(),
+                s -> s.getTemplate().getPod(), s -> 1, s -> s.getResources());
+    }
+
+    private <T> void createOrUpdateReservedDeployment(ManagedKafka managedKafka, Kafka kafka, String nameSuffix,
+            Function<Kafka, T> specExtractor, Function<T, PodTemplate> templateExtractor,
+            Function<T, Integer> replicasExtractor,
+            Function<T, ResourceRequirements> resourceExtractor) {
+        T spec = specExtractor.apply(kafka);
+        String name = managedKafka.getMetadata().getName() + nameSuffix;
+        if (spec == null) {
+            kubernetesClient.apps().deployments().inNamespace(managedKafka.getMetadata().getNamespace()).withName(name).delete();
+            return;
+        }
+        PodTemplate template = templateExtractor.apply(spec);
+        Deployment current = informerManager.getLocalDeployment(managedKafka.getMetadata().getNamespace(), name);
+        Deployment reserved = ReservedDeploymentConverter.asReservedDeployment(current, managedKafka, name, kafka.getMetadata(),
+                replicasExtractor.apply(spec), template,
+                resourceExtractor.apply(spec));
+
+        if (!Objects.equals(current, reserved)) {
+            OperandUtils.createOrUpdate(kubernetesClient.apps().deployments(), reserved);
+        }
+    }
+
     @Override
     public void delete(ManagedKafka managedKafka, Context context) {
+        if (managedKafka.isReserveDeployment()) {
+            log.warnf("Deleted flag is not expected to be used with a reserved deployment %s/%s", managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName());
+        }
         super.delete(managedKafka, context);
         secretManager.delete(managedKafka);
 
@@ -404,7 +461,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         // this only comes into picture when there are more number of nodes than the brokers
         PodTemplateBuilder podTemplateBuilder = new PodTemplateBuilder()
                 .withImagePullSecrets(imagePullSecretManager.getOperatorImagePullSecrets(managedKafka))
-                .withTopologySpreadConstraints(azAwareTopologySpreadConstraint(managedKafka.getMetadata().getName() + "-kafka", DO_NOT_SCHEDULE));
+                .withTopologySpreadConstraints(azAwareTopologySpreadConstraint(managedKafka.getMetadata().getName() + KAFKA_SUFFIX, DO_NOT_SCHEDULE));
 
         Affinity affinity = OperandUtils.buildAffinity(this.informerManager.getLocalAgent(), managedKafka,
                 this.configs.getConfig(managedKafka).getKafka().isColocateWithZookeeper());
@@ -471,7 +528,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         PodNested<ZookeeperClusterTemplateBuilder> podNestedBuilder = new ZookeeperClusterTemplateBuilder()
                 .withNewPod()
                         .withImagePullSecrets(imagePullSecretManager.getOperatorImagePullSecrets(managedKafka))
-                        .withTopologySpreadConstraints(azAwareTopologySpreadConstraint(managedKafka.getMetadata().getName() + "-zookeeper", DO_NOT_SCHEDULE));
+                        .withTopologySpreadConstraints(azAwareTopologySpreadConstraint(managedKafka.getMetadata().getName() + ZOOKEEPER_SUFFIX, DO_NOT_SCHEDULE));
 
         AffinityBuilder affinityBuilder = new AffinityBuilder();
         boolean addAffinity = false;
@@ -1086,6 +1143,33 @@ public class KafkaCluster extends AbstractKafkaCluster {
         String currentDigest = currentCM.getMetadata().getAnnotations() == null ? null : currentCM.getMetadata().getAnnotations().get(DIGEST);
         String newDigest = newCM.getMetadata().getAnnotations() == null ? null : newCM.getMetadata().getAnnotations().get(DIGEST);
         return !Objects.equals(currentDigest, newDigest);
+    }
+
+    @Override
+    public OperandReadiness getReadiness(ManagedKafka managedKafka) {
+        if (managedKafka.isReserveDeployment()) {
+            List<OperandReadiness> readiness = new ArrayList<>();
+            readiness.add(Operand.getDeploymentReadiness(
+                    informerManager.getLocalDeployment(managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName() + KAFKA_SUFFIX),
+                    managedKafka.getMetadata().getName() + KAFKA_SUFFIX));
+            readiness.add(Operand.getDeploymentReadiness(
+                    informerManager.getLocalDeployment(managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName() + EXPORTER_SUFFIX),
+                    managedKafka.getMetadata().getName() + EXPORTER_SUFFIX));
+
+            Kafka kafka = kafkaFrom(managedKafka, null);
+            if (kafka.getSpec().getCruiseControl() != null) {
+                readiness.add(Operand.getDeploymentReadiness(
+                        informerManager.getLocalDeployment(managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName() + CRUISECONTROL_SUFFIX),
+                        managedKafka.getMetadata().getName() + CRUISECONTROL_SUFFIX));
+            }
+            if (kafka.getSpec().getZookeeper() != null) {
+                readiness.add(Operand.getDeploymentReadiness(
+                        informerManager.getLocalDeployment(managedKafka.getMetadata().getNamespace(), managedKafka.getMetadata().getName() + ZOOKEEPER_SUFFIX),
+                        managedKafka.getMetadata().getName() + ZOOKEEPER_SUFFIX));
+            }
+            return KafkaInstance.combineReadiness(readiness);
+        }
+        return super.getReadiness(managedKafka);
     }
 
 }

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstance.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstance.java
@@ -90,6 +90,10 @@ public class KafkaInstance implements Operand<ManagedKafka> {
         }
         List<OperandReadiness> readiness = operands.stream().map(o -> o.getReadiness(managedKafka)).filter(Objects::nonNull).collect(Collectors.toList());
 
+        return combineReadiness(readiness);
+    }
+
+    public static OperandReadiness combineReadiness(List<OperandReadiness> readiness) {
         // default to the first reason, with can come from the kafka by the order of the operands
         Reason reason = readiness.stream().map(OperandReadiness::getReason).filter(Objects::nonNull).findFirst().orElse(null);
         // default the status to false or unknown if any are unknown

--- a/operator/src/main/java/org/bf2/operator/operands/ReservedDeploymentConverter.java
+++ b/operator/src/main/java/org/bf2/operator/operands/ReservedDeploymentConverter.java
@@ -1,0 +1,85 @@
+package org.bf2.operator.operands;
+
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.LabelSelectorBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.strimzi.api.kafka.model.template.PodTemplate;
+import org.bf2.common.OperandUtils;
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+
+import java.util.List;
+
+/**
+ * Utility for converting a deployment or a strimzi resource into a pause pod deployment
+ */
+public class ReservedDeploymentConverter {
+
+    public static Deployment asReservedDeployment(Deployment existing, Deployment toModify, ManagedKafka managedKafka) {
+        PodSpec spec = toModify.getSpec().getTemplate().getSpec();
+        if (spec.getContainers().size() > 1) {
+            throw new AssertionError();
+        }
+        return ReservedDeploymentConverter.asReservedDeployment(existing, managedKafka, toModify.getMetadata().getName(),
+                toModify.getMetadata(), toModify.getSpec().getReplicas(),
+                spec.getAffinity(),
+                spec.getTolerations(),
+                spec.getTopologySpreadConstraints(),
+                spec.getContainers().get(0).getResources());
+    }
+
+    public static Deployment asReservedDeployment(Deployment existing, ManagedKafka managedKafka, String deploymentName,
+            ObjectMeta meta,
+            Integer replicas, PodTemplate template, ResourceRequirements resources) {
+        return asReservedDeployment(existing, managedKafka, deploymentName, meta, replicas, template.getAffinity(),
+                template.getTolerations(), template.getTopologySpreadConstraints(), resources);
+    }
+
+    static Deployment asReservedDeployment(Deployment existing, ManagedKafka managedKafka, String deploymentName,
+            ObjectMeta meta,
+            Integer replicas, Affinity affinity, List<Toleration> tolerations,
+            List<TopologySpreadConstraint> topologySpreadConstraints, ResourceRequirements resources) {
+        Deployment result =
+                (existing == null ? new DeploymentBuilder() : new DeploymentBuilder(existing)).editOrNewMetadata()
+                        .withLabels(meta.getLabels())
+                        .addToLabels(OperandUtils.MANAGED_BY_LABEL, OperandUtils.FLEETSHARD_OPERATOR_NAME)
+                        .withName(deploymentName)
+                        .withNamespace(meta.getNamespace())
+                        .endMetadata()
+                        .editOrNewSpec()
+                        .withSelector(new LabelSelectorBuilder().withMatchLabels(meta.getLabels()).build())
+                        .withReplicas(replicas)
+                        .editOrNewTemplate()
+                        .editOrNewMetadata()
+                        .withName(deploymentName)
+                        .withLabels(meta.getLabels())
+                        .addToLabels("strimzi.io/name", deploymentName)
+                        .endMetadata()
+                        .editOrNewSpec()
+                        .withAffinity(affinity)
+                        .withContainers((existing == null ? new ContainerBuilder()
+                                : new ContainerBuilder(
+                                        existing.getSpec().getTemplate().getSpec().getContainers().get(0)))
+                                                .withName("pause")
+                                                .withImage("k8s.gcr.io/pause:3.1")
+                                                .withResources(resources)
+                                                .withImagePullPolicy("IfNotPresent")
+                                                .build())
+                        .withPriorityClassName("kas-fleetshard-reservation")
+                        .withTolerations(tolerations)
+                        .withTopologySpreadConstraints(topologySpreadConstraints)
+                        .endSpec()
+                        .endTemplate()
+                        .endSpec()
+                        .build();
+        OperandUtils.setAsOwner(managedKafka, result);
+        return result;
+    }
+
+}

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -231,3 +231,10 @@ spec:
     matchLabels:
       app: kas-fleetshard-operator
 ---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: kas-fleetshard-reservation
+value: -4
+globalDefault: false
+---

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -9,6 +9,8 @@ import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import io.fabric8.kubernetes.client.utils.Serialization;
@@ -38,6 +40,7 @@ import org.bf2.operator.managers.OperandOverrideManager;
 import org.bf2.operator.managers.StrimziManager;
 import org.bf2.operator.operands.KafkaInstanceConfigurations.InstanceType;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Reason;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +54,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -101,6 +105,9 @@ class KafkaClusterTest {
                 "managedkafka.bf2.org/kas-zone2", "true"));
 
         QuarkusMock.installMockForType(controllerManager, IngressControllerManager.class);
+
+        // clean out all deployments
+        client.apps().deployments().inAnyNamespace().delete();
     }
 
     @Test
@@ -116,6 +123,43 @@ class KafkaClusterTest {
         Kafka kafka = kafkaCluster.kafkaFrom(mk, null);
 
         diffToExpected(kafka, "/expected/strimzi.yml");
+    }
+
+    @Test
+    void testManagedKafkaToReserved() throws IOException {
+        ManagedKafka mk = exampleManagedKafka("60Gi");
+        mk.getMetadata().setNamespace("reserved");
+        mk = new ManagedKafkaBuilder(mk).editMetadata()
+                .addToLabels(ManagedKafka.DEPLOYMENT_TYPE, ManagedKafka.RESERVED_DEPLOYMENT_TYPE)
+                .endMetadata()
+                .build();
+
+        kafkaCluster.createOrUpdate(mk);
+        List<Deployment> deployments = client.apps()
+                .deployments()
+                .inNamespace(mk.getMetadata().getNamespace())
+                .list()
+                .getItems();
+
+        diffToExpected(deployments.stream()
+                .map(d -> new DeploymentBuilder(d).editMetadata()
+                        .withCreationTimestamp(null)
+                        .withUid(null)
+                        .withResourceVersion(null)
+                        .endMetadata()
+                        .build())
+                .sorted((d1, d2) -> d1.getMetadata().getName().compareTo(d2.getMetadata().getName()))
+                .toArray(), "/expected/reserved.yml");
+
+        // after a status update or other change we'll attempt to reconcile
+        // again.  make sure that we end up in the same state
+        kafkaCluster.createOrUpdate(mk);
+        List<Deployment> deployments1 = client.apps()
+                .deployments()
+                .inNamespace(mk.getMetadata().getNamespace())
+                .list()
+                .getItems();
+        assertEquals(new HashSet<>(deployments), new HashSet<>(deployments1));
     }
 
     @Test
@@ -397,14 +441,14 @@ class KafkaClusterTest {
         diffToExpected(kafka.getSpec().getZookeeper().getTemplate(), "/expected/broker-per-node-zookeeper.yml");
     }
 
-    static JsonNode diffToExpected(Object kafka, String expected) throws IOException, JsonProcessingException, JsonMappingException {
-        return diffToExpected(kafka, expected, "[]");
+    static JsonNode diffToExpected(Object obj, String expected) throws IOException, JsonProcessingException, JsonMappingException {
+        return diffToExpected(obj, expected, "[]");
     }
 
-    static JsonNode diffToExpected(Object kafka, String expected, String diff) throws IOException, JsonProcessingException, JsonMappingException {
+    static JsonNode diffToExpected(Object obj, String expected, String diff) throws IOException, JsonProcessingException, JsonMappingException {
         ObjectMapper objectMapper = Serialization.yamlMapper();
         JsonNode expectedJson = objectMapper.readTree(KafkaClusterTest.class.getResourceAsStream(expected));
-        String yaml = Serialization.asYaml(kafka);
+        String yaml = Serialization.asYaml(obj);
         JsonNode actualJson = objectMapper.readTree(yaml);
         JsonNode patch = JsonDiff.asJson(expectedJson, actualJson);
         assertEquals(diff, patch.toString(), yaml);

--- a/operator/src/test/resources/expected/reserved.yml
+++ b/operator/src/test/resources/expected/reserved.yml
@@ -1,0 +1,310 @@
+- apiVersion: "apps/v1"
+  kind: "Deployment"
+  metadata:
+    generation: 1
+    labels:
+      app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+      bf2.org/deployment: "reserved"
+      ingressType: "sharded"
+      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+      managedkafka.bf2.org/kas-multi-zone: "true"
+      managedkafka.bf2.org/kas-zone0: "true"
+      managedkafka.bf2.org/kas-zone1: "true"
+      managedkafka.bf2.org/kas-zone2: "true"
+    name: "test-mk-cruisecontrol"
+    namespace: "reserved"
+    ownerReferences:
+    - apiVersion: "managedkafka.bf2.org/v1alpha1"
+      kind: "ManagedKafka"
+      name: "test-mk"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+        bf2.org/deployment: "reserved"
+        ingressType: "sharded"
+        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+        managedkafka.bf2.org/kas-multi-zone: "true"
+        managedkafka.bf2.org/kas-zone0: "true"
+        managedkafka.bf2.org/kas-zone1: "true"
+        managedkafka.bf2.org/kas-zone2: "true"
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+          bf2.org/deployment: "reserved"
+          ingressType: "sharded"
+          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+          managedkafka.bf2.org/kas-multi-zone: "true"
+          managedkafka.bf2.org/kas-zone0: "true"
+          managedkafka.bf2.org/kas-zone1: "true"
+          managedkafka.bf2.org/kas-zone2: "true"
+          strimzi.io/name: "test-mk-cruisecontrol"
+        name: "test-mk-cruisecontrol"
+      spec:
+        affinity:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: "strimzi.io/name"
+                    operator: "In"
+                    values:
+                    - "test-mk-zookeeper"
+                topologyKey: "kubernetes.io/hostname"
+              weight: 100
+        containers:
+        - image: "k8s.gcr.io/pause:3.1"
+          imagePullPolicy: "IfNotPresent"
+          name: "pause"
+          resources:
+            limits:
+              memory: "17.3Gi"
+              cpu: "4900m"
+            requests:
+              memory: "17.3Gi"
+              cpu: "4900m"
+        priorityClassName: "kas-fleetshard-reservation"
+        tolerations:
+        - effect: "NoExecute"
+          key: "org.bf2.operator/kafka-broker"
+          operator: "Exists"
+        topologySpreadConstraints:
+        - labelSelector:
+            matchExpressions:
+            - key: "strimzi.io/name"
+              operator: "In"
+              values:
+              - "test-mk-kafka"
+          maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: "DoNotSchedule"
+- apiVersion: "apps/v1"
+  kind: "Deployment"
+  metadata:
+    generation: 1
+    labels:
+      app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+      bf2.org/deployment: "reserved"
+      ingressType: "sharded"
+      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+      managedkafka.bf2.org/kas-multi-zone: "true"
+      managedkafka.bf2.org/kas-zone0: "true"
+      managedkafka.bf2.org/kas-zone1: "true"
+      managedkafka.bf2.org/kas-zone2: "true"
+    name: "test-mk-exporter"
+    namespace: "reserved"
+    ownerReferences:
+    - apiVersion: "managedkafka.bf2.org/v1alpha1"
+      kind: "ManagedKafka"
+      name: "test-mk"
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+        bf2.org/deployment: "reserved"
+        ingressType: "sharded"
+        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+        managedkafka.bf2.org/kas-multi-zone: "true"
+        managedkafka.bf2.org/kas-zone0: "true"
+        managedkafka.bf2.org/kas-zone1: "true"
+        managedkafka.bf2.org/kas-zone2: "true"
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+          bf2.org/deployment: "reserved"
+          ingressType: "sharded"
+          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+          managedkafka.bf2.org/kas-multi-zone: "true"
+          managedkafka.bf2.org/kas-zone0: "true"
+          managedkafka.bf2.org/kas-zone1: "true"
+          managedkafka.bf2.org/kas-zone2: "true"
+          strimzi.io/name: "test-mk-exporter"
+        name: "test-mk-exporter"
+      spec:
+        affinity:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: "strimzi.io/name"
+                    operator: "In"
+                    values:
+                    - "test-mk-zookeeper"
+                topologyKey: "kubernetes.io/hostname"
+              weight: 100
+        containers:
+        - image: "k8s.gcr.io/pause:3.1"
+          imagePullPolicy: "IfNotPresent"
+          name: "pause"
+          resources:
+            limits:
+              memory: "256Mi"
+              cpu: "1000m"
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
+        priorityClassName: "kas-fleetshard-reservation"
+- apiVersion: "apps/v1"
+  kind: "Deployment"
+  metadata:
+    generation: 1
+    labels:
+      app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+      bf2.org/deployment: "reserved"
+      ingressType: "sharded"
+      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+      managedkafka.bf2.org/kas-multi-zone: "true"
+      managedkafka.bf2.org/kas-zone0: "true"
+      managedkafka.bf2.org/kas-zone1: "true"
+      managedkafka.bf2.org/kas-zone2: "true"
+    name: "test-mk-kafka"
+    namespace: "reserved"
+    ownerReferences:
+    - apiVersion: "managedkafka.bf2.org/v1alpha1"
+      kind: "ManagedKafka"
+      name: "test-mk"
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+        bf2.org/deployment: "reserved"
+        ingressType: "sharded"
+        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+        managedkafka.bf2.org/kas-multi-zone: "true"
+        managedkafka.bf2.org/kas-zone0: "true"
+        managedkafka.bf2.org/kas-zone1: "true"
+        managedkafka.bf2.org/kas-zone2: "true"
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+          bf2.org/deployment: "reserved"
+          ingressType: "sharded"
+          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+          managedkafka.bf2.org/kas-multi-zone: "true"
+          managedkafka.bf2.org/kas-zone0: "true"
+          managedkafka.bf2.org/kas-zone1: "true"
+          managedkafka.bf2.org/kas-zone2: "true"
+          strimzi.io/name: "test-mk-kafka"
+        name: "test-mk-kafka"
+      spec:
+        affinity:
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: "strimzi.io/name"
+                    operator: "In"
+                    values:
+                    - "test-mk-zookeeper"
+                topologyKey: "kubernetes.io/hostname"
+              weight: 100
+        containers:
+        - image: "k8s.gcr.io/pause:3.1"
+          imagePullPolicy: "IfNotPresent"
+          name: "pause"
+          resources:
+            limits:
+              memory: "17.3Gi"
+              cpu: "4900m"
+            requests:
+              memory: "17.3Gi"
+              cpu: "4900m"
+        priorityClassName: "kas-fleetshard-reservation"
+        tolerations:
+        - effect: "NoExecute"
+          key: "org.bf2.operator/kafka-broker"
+          operator: "Exists"
+        topologySpreadConstraints:
+        - labelSelector:
+            matchExpressions:
+            - key: "strimzi.io/name"
+              operator: "In"
+              values:
+              - "test-mk-kafka"
+          maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: "DoNotSchedule"
+- apiVersion: "apps/v1"
+  kind: "Deployment"
+  metadata:
+    generation: 1
+    labels:
+      app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+      bf2.org/deployment: "reserved"
+      ingressType: "sharded"
+      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+      managedkafka.bf2.org/kas-multi-zone: "true"
+      managedkafka.bf2.org/kas-zone0: "true"
+      managedkafka.bf2.org/kas-zone1: "true"
+      managedkafka.bf2.org/kas-zone2: "true"
+    name: "test-mk-zookeeper"
+    namespace: "reserved"
+    ownerReferences:
+    - apiVersion: "managedkafka.bf2.org/v1alpha1"
+      kind: "ManagedKafka"
+      name: "test-mk"
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+        bf2.org/deployment: "reserved"
+        ingressType: "sharded"
+        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+        managedkafka.bf2.org/kas-multi-zone: "true"
+        managedkafka.bf2.org/kas-zone0: "true"
+        managedkafka.bf2.org/kas-zone1: "true"
+        managedkafka.bf2.org/kas-zone2: "true"
+    template:
+      metadata:
+        labels:
+          app.kubernetes.io/managed-by: "kas-fleetshard-operator"
+          bf2.org/deployment: "reserved"
+          ingressType: "sharded"
+          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
+          managedkafka.bf2.org/kas-multi-zone: "true"
+          managedkafka.bf2.org/kas-zone0: "true"
+          managedkafka.bf2.org/kas-zone1: "true"
+          managedkafka.bf2.org/kas-zone2: "true"
+          strimzi.io/name: "test-mk-zookeeper"
+        name: "test-mk-zookeeper"
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: "zookeeper"
+              namespaceSelector: {}
+              topologyKey: "kubernetes.io/hostname"
+        containers:
+        - image: "k8s.gcr.io/pause:3.1"
+          imagePullPolicy: "IfNotPresent"
+          name: "pause"
+          resources:
+            limits:
+              memory: "4Gi"
+              cpu: "1000m"
+            requests:
+              memory: "4Gi"
+              cpu: "1000m"
+        priorityClassName: "kas-fleetshard-reservation"
+        topologySpreadConstraints:
+        - labelSelector:
+            matchExpressions:
+            - key: "strimzi.io/name"
+              operator: "In"
+              values:
+              - "test-mk-zookeeper"
+          maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: "DoNotSchedule"

--- a/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
+++ b/sync/src/main/java/org/bf2/sync/ManagedKafkaSync.java
@@ -158,6 +158,9 @@ public class ManagedKafkaSync {
             return false; // not a managed instance
         }
         if (!local.getSpec().isDeleted()) {
+            if (local.isReserveDeployment()) {
+                return true;
+            }
             if (local.getStatus() != null
                     && ConditionUtils.findManagedKafkaCondition(local.getStatus().getConditions(), Type.Ready)
                             .filter(c -> Reason.Rejected.name().equals(c.getReason())).isPresent()) {


### PR DESCRIPTION
Updating the pr to be independent of capacity reporting.  If the operator sees a deployment marked as reserved, then it won't actually create the expected resources.  Instead deployments with pause pods at a lower priority will be created with resources and replicas that match the expected instances.  The parent managedkafka will be marked as ready once all of these deployments are ready.

The priority class kas-fleetshard-reservation (which I'm open to changing) was added to the kubernetes.yml in the project as we need it to be part of the workload, which diverges from the kas-fleetshard-high used in the bundle for the operator components.

There is no interaction with metrics as those are derived from kafka resources.

This change has no expectation that profile specific machine pools will be in use.

I'll run this on my local cluster again to make sure I didn't miss anything pulling this over to main.