### PR TITLE
fix: spec/unsupportedConfigOverrides/reloadInterval backing var has wrong type

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -165,7 +165,7 @@ public class IngressControllerManager {
     @ConfigProperty(name = "ingresscontroller.ingress-container-command")
     List<String> ingressContainerCommand;
     @ConfigProperty(name = "ingresscontroller.reload-interval-seconds")
-    Long ingressReloadIntervalSeconds;
+    Integer ingressReloadIntervalSeconds;
 
 
     @ConfigProperty(name = "ingresscontroller.peak-throughput-percentage")


### PR DESCRIPTION
prevents periodic, believed harmless, messages in the fleetshard logs

```
Updating the existing IngressController openshift-ingress-operator/kas [{"op":"replace","path":"/spec/unsupportedConfigOverrides/reloadInterval","value":60}]
```