### PR TITLE
[MGDSTRM-7353] Remove Strimzi cluster role bindings w/o namespace match

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/StrimziClusterRoleBindingManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/StrimziClusterRoleBindingManager.java
@@ -1,0 +1,83 @@
+package org.bf2.operator.managers;
+
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.Subject;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.scheduler.Scheduled;
+import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
+import io.quarkus.scheduler.ScheduledExecution;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class StrimziClusterRoleBindingManager implements Scheduled.SkipPredicate {
+
+    static final Map<String, String> STRIMZI_CRB_LABELS = Map.of(
+            "app.kubernetes.io/managed-by", "strimzi-cluster-operator",
+            "strimzi.io/kind", "Kafka");
+    static final String STRIMZI_KAFKA_ROLEREF = "strimzi-kafka-broker";
+
+    @Inject
+    Logger log;
+
+    @Inject
+    KubernetesClient client;
+
+    @ConfigProperty(name = "strimzi.clusterrolebinding-scan.enabled", defaultValue = "true")
+    boolean scanEnabled;
+
+    @Scheduled(
+            every = "{strimzi.clusterrolebinding-scan.interval}",
+            delay = 1,
+            concurrentExecution = ConcurrentExecution.SKIP,
+            skipExecutionIf = StrimziClusterRoleBindingManager.class)
+    void removeAbandonedClusterRoleBindings() {
+        Set<String> namespaces = client.namespaces()
+                .list()
+                .getItems()
+                .stream()
+                .map(Namespace::getMetadata)
+                .map(ObjectMeta::getName)
+                .collect(Collectors.toSet());
+
+        List<ClusterRoleBinding> abandonedBindings = client.rbac()
+                .clusterRoleBindings()
+                .withLabels(STRIMZI_CRB_LABELS)
+                .list()
+                .getItems()
+                .stream()
+                .filter(crb -> STRIMZI_KAFKA_ROLEREF.equals(crb.getRoleRef().getName()))
+                .filter(crb -> crb.getSubjects().stream().map(Subject::getNamespace).noneMatch(namespaces::contains))
+                .collect(Collectors.toList());
+
+        if (abandonedBindings.isEmpty()) {
+            log.infof("No abandoned '%s' ClusterRoleBindings found", STRIMZI_KAFKA_ROLEREF);
+        } else {
+            log.infof("Found %d '%s' ClusterRoleBindings referencing a non-existent namespace", abandonedBindings.size(), STRIMZI_KAFKA_ROLEREF);
+            abandonedBindings.forEach(crb -> {
+                try {
+                    log.infof("ClusterRoleBinding %s will be deleted", crb.getMetadata().getName());
+                    client.rbac().clusterRoleBindings().delete(crb);
+                } catch (Exception e) {
+                    log.warnf(e, "Unexpected exception deleting ClusterRoleBinding %s", crb.getMetadata().getName());
+                }
+            });
+            log.infof("Removal of abandoned '%s' ClusterRoleBindings complete", STRIMZI_KAFKA_ROLEREF);
+        }
+    }
+
+    @Override
+    public boolean test(ScheduledExecution execution) {
+        return !scanEnabled;
+    }
+}

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -135,7 +135,7 @@ rules:
       - pods
       # the operator reads nodes to get AZ information
       - nodes
-      # the operator reads namespaces for event monitoring
+      # the operator reads namespaces for event monitoring and to determine if a CRB has been adandoned
       - namespaces
     verbs:
       - get
@@ -162,6 +162,14 @@ rules:
       - delete
       - patch
       - update
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      # StrimziClusterRoleBindingManager lists and potentially deletes abandoned CRBs
+      - clusterrolebindings
+    verbs:
+      - list
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -2,6 +2,7 @@ agent.status.interval=60s
 strimzi.bundle.interval=60s
 strimzi.bundle.approval-delay=120s
 %test.strimzi.bundle.approval-delay=0s
+strimzi.clusterrolebinding-scan.interval=PT60M
 
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %x %s%e%n
 # for quarkus 1.x compatibility

--- a/operator/src/test/java/org/bf2/operator/managers/StrimziClusterRoleBindingManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/StrimziClusterRoleBindingManagerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 
+import java.time.Duration;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertNull;
@@ -41,42 +42,81 @@ class StrimziClusterRoleBindingManagerTest {
 
     @Test
     @SuppressWarnings("resource")
-    void testRemoveAbandonedClusterRoleBindingsWhenNoneAbandoned() {
+    void testRemoveAbandonedClusterRoleBindingsWhenNoneAbandoned() throws InterruptedException {
         Stream.of(createNamespace("ns1"), createNamespace("ns2"))
             .forEach(client.namespaces()::create);
-        Stream.of(createStrimziCRB("crb1", "ns1"), createStrimziCRB("crb2", "ns2"))
+
+        Stream.of(
+                createStrimziCRB("crb1", "ns1", StrimziClusterRoleBindingManager.STRIMZI_KAFKA_ROLEREF),
+                createStrimziCRB("crb2", "ns2", StrimziClusterRoleBindingManager.STRIMZI_KAFKA_ROLEREF),
+                createStrimziCRB("crb3", "ns3", "roleref3"))
             .forEach(client.rbac().clusterRoleBindings()::create);
 
+        crbManager.setScanInterval(Duration.ofMillis(100));
+        Thread.sleep(200);
         crbManager.removeAbandonedClusterRoleBindings();
+
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns1-crb1").get());
         assertNotNull(client.rbac().clusterRoleBindings().withName("ns2-crb2").get());
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns3-crb3").get());
     }
 
     @Test
     @SuppressWarnings("resource")
-    void testRemoveAbandonedClusterRoleBindingsWhenOneAbandoned() {
+    void testRemoveAbandonedClusterRoleBindingsWhenOneAbandoned() throws InterruptedException {
         client.namespaces().create(createNamespace("ns1"));
-        Stream.of(createStrimziCRB("crb1", "ns1"), createStrimziCRB("crb2", "ns2"))
+        Stream.of(
+                createStrimziCRB("crb1", "ns1", StrimziClusterRoleBindingManager.STRIMZI_KAFKA_ROLEREF),
+                createStrimziCRB("crb2", "ns2", StrimziClusterRoleBindingManager.STRIMZI_KAFKA_ROLEREF),
+                createStrimziCRB("crb3", "ns3", "roleref3"))
             .forEach(client.rbac().clusterRoleBindings()::create);
 
         assertNotNull(client.rbac().clusterRoleBindings().withName("ns2-crb2").get());
 
+        crbManager.setScanInterval(Duration.ofMillis(100));
+        Thread.sleep(200);
         crbManager.removeAbandonedClusterRoleBindings();
 
+
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns1-crb1").get());
         assertNull(client.rbac().clusterRoleBindings().withName("ns2-crb2").get());
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns3-crb3").get());
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void testRemoveAbandonedClusterRoleBindingsWhenOneAbandonedWithinGracePeriod() throws InterruptedException {
+        client.namespaces().create(createNamespace("ns1"));
+        Stream.of(
+                createStrimziCRB("crb1", "ns1", StrimziClusterRoleBindingManager.STRIMZI_KAFKA_ROLEREF),
+                createStrimziCRB("crb2", "ns2", StrimziClusterRoleBindingManager.STRIMZI_KAFKA_ROLEREF),
+                createStrimziCRB("crb3", "ns3", "roleref3"))
+            .forEach(client.rbac().clusterRoleBindings()::create);
+
+        crbManager.setScanInterval(Duration.ofMinutes(1));
+        crbManager.removeAbandonedClusterRoleBindings();
+
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns1-crb1").get());
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns2-crb2").get());
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns3-crb3").get());
     }
 
     static Namespace createNamespace(String name) {
-        return new NamespaceBuilder().withNewMetadata().withName(name).endMetadata().build();
+        return new NamespaceBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                .endMetadata()
+                .build();
     }
 
-    static ClusterRoleBinding createStrimziCRB(String name, String namespace) {
+    static ClusterRoleBinding createStrimziCRB(String name, String namespace, String roleRef) {
         return new ClusterRoleBindingBuilder()
                 .withNewMetadata()
                     .withName(namespace + '-' + name)
                     .withLabels(StrimziClusterRoleBindingManager.STRIMZI_CRB_LABELS)
                 .endMetadata()
                 .withRoleRef(new RoleRefBuilder()
-                        .withName(StrimziClusterRoleBindingManager.STRIMZI_KAFKA_ROLEREF)
+                        .withName(roleRef)
                         .build())
                 .withSubjects(new SubjectBuilder()
                         .withName(name)

--- a/operator/src/test/java/org/bf2/operator/managers/StrimziClusterRoleBindingManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/StrimziClusterRoleBindingManagerTest.java
@@ -1,0 +1,87 @@
+package org.bf2.operator.managers;
+
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleRefBuilder;
+import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+import org.bf2.operator.MockProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@QuarkusTestResource(KubernetesServerTestResource.class)
+@TestProfile(MockProfile.class)
+@QuarkusTest
+class StrimziClusterRoleBindingManagerTest {
+
+    @Inject
+    KubernetesClient client;
+
+    @Inject
+    StrimziClusterRoleBindingManager crbManager;
+
+    @BeforeEach
+    void setup() {
+        client.namespaces().delete();
+        client.rbac().clusterRoleBindings().delete();
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void testRemoveAbandonedClusterRoleBindingsWhenNoneAbandoned() {
+        Stream.of(createNamespace("ns1"), createNamespace("ns2"))
+            .forEach(client.namespaces()::create);
+        Stream.of(createStrimziCRB("crb1", "ns1"), createStrimziCRB("crb2", "ns2"))
+            .forEach(client.rbac().clusterRoleBindings()::create);
+
+        crbManager.removeAbandonedClusterRoleBindings();
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns2-crb2").get());
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    void testRemoveAbandonedClusterRoleBindingsWhenOneAbandoned() {
+        client.namespaces().create(createNamespace("ns1"));
+        Stream.of(createStrimziCRB("crb1", "ns1"), createStrimziCRB("crb2", "ns2"))
+            .forEach(client.rbac().clusterRoleBindings()::create);
+
+        assertNotNull(client.rbac().clusterRoleBindings().withName("ns2-crb2").get());
+
+        crbManager.removeAbandonedClusterRoleBindings();
+
+        assertNull(client.rbac().clusterRoleBindings().withName("ns2-crb2").get());
+    }
+
+    static Namespace createNamespace(String name) {
+        return new NamespaceBuilder().withNewMetadata().withName(name).endMetadata().build();
+    }
+
+    static ClusterRoleBinding createStrimziCRB(String name, String namespace) {
+        return new ClusterRoleBindingBuilder()
+                .withNewMetadata()
+                    .withName(namespace + '-' + name)
+                    .withLabels(StrimziClusterRoleBindingManager.STRIMZI_CRB_LABELS)
+                .endMetadata()
+                .withRoleRef(new RoleRefBuilder()
+                        .withName(StrimziClusterRoleBindingManager.STRIMZI_KAFKA_ROLEREF)
+                        .build())
+                .withSubjects(new SubjectBuilder()
+                        .withName(name)
+                        .withNamespace(namespace)
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
Remove Strimzi cluster role bindings when the subject is in a nonexistent namespace.