### PR TITLE
Add GCP cluster support to OSD provision script

### DIFF
--- a/perf/templates/CCS_DEFINITION.template
+++ b/perf/templates/CCS_DEFINITION.template
@@ -16,7 +16,7 @@
         "compute":##COMPUTE_NODES##
     },
     "cloud_provider": {
-        "id":"aws"
+        "id":"##CLOUD_PROVIDER##"
     },
     "node_drain_grace_period": {
         "value":60,
@@ -29,9 +29,3 @@
         "enabled":true,
         "disable_scp_checks":false
     },
-    "aws": {
-        "access_key_id":"##AWS_ACCESS_KEY##",
-        "account_id":"##AWS_ACCOUNT_ID##",
-        "secret_access_key":"##AWS_SECRET_ACCESS_KEY##"
-    }
-}


### PR DESCRIPTION
[MGDSTRM-8938](https://issues.redhat.com/browse/MGDSTRM-8938)

Update the `osd-provision.sh` script to allow GCP clusters to be provisioned. The script contains sample commands on how to create a GCP cluster. A GCP service account is required. The script will default to `--cloud-provider aws`,  so it shouldn't break any existing CI.

