### PR TITLE
MGDSTRM-9334 correcting the defaults for developer instances

### DIFF
--- a/operator/src/main/resources/instances/developer.properties
+++ b/operator/src/main/resources/instances/developer.properties
@@ -27,4 +27,11 @@ storage.min-margin=1Gi
 kafka.partition-capacity=1500
 kafka.message-max-bytes=1048588
 
+# default values for spec capacity - only exist for ease of testing
+# we should require instances to have these values specified, rather than relying on a default
+kafka.max-connections=100
+kafka.connection-attempts-per-sec=50
+kafka.ingress-per-sec=1Mi
+kafka.egress-per-sec=1Mi
+
 cruisecontrol.enabled=false

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -54,8 +54,8 @@ spec:
         brokers:
         - broker: 0
           host: "broker-0-xxx.yyy.zzz"
-        maxConnections: 3000
-        maxConnectionCreationRate: 100
+        maxConnections: 100
+        maxConnectionCreationRate: 50
     - name: "oauth"
       port: 9095
       type: "internal"


### PR DESCRIPTION
For now the capacity values are technically optional, so we should have valid defaults - however the control plane is supplying these, so there should be no impact to actual instances.  Once we address https://issues.redhat.com/browse/MGDSTRM-8648 we could remove the possibility of not setting these capacity values.