### PR TITLE
MGDSTRM-9425: retention.ms missing from managedkafka.kafka.topic-config-mutable-rule config

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -144,4 +144,4 @@ managedkafka.canary.init-enabled=true
 managedkafka.canary.init-timeout-seconds=600
 managedkafka.kafka.topic-config-policy-enforced=true
 managedkafka.kafka.topic-config-range-rule=max.message.bytes::1048588,segment.bytes:52428800:,segment.ms:600000:
-managedkafka.kafka.topic-config-mutable-rule=message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable
+managedkafka.kafka.topic-config-mutable-rule=message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,retention.ms,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -216,7 +216,7 @@ spec:
       kas.policy.topic-config.topic-config-policy-enforced: true
       kas.policy.topic-config.enforced: "flush.ms:9223372036854775807,index.interval.bytes:4096,compression.type:producer,flush.messages:9223372036854775807,min.cleanable.dirty.ratio:0.5,file.delete.delay.ms:60000,segment.index.bytes:10485760,preallocate:false,unclean.leader.election.enable:false,min.insync.replicas:2"
       kas.policy.topic-config.range: "max.message.bytes::1048588,segment.bytes:52428800:,segment.ms:600000:"
-      kas.policy.topic-config.mutable: "message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable"
+      kas.policy.topic-config.mutable: "message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,retention.ms,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable"
       broker.foo: bar
     storage:
       volumes:

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -208,7 +208,7 @@ spec:
       kas.policy.topic-config.topic-config-policy-enforced: true
       kas.policy.topic-config.enforced: "flush.ms:9223372036854775807,index.interval.bytes:4096,compression.type:producer,flush.messages:9223372036854775807,min.cleanable.dirty.ratio:0.5,file.delete.delay.ms:60000,segment.index.bytes:10485760,preallocate:false,unclean.leader.election.enable:false,min.insync.replicas:1"
       kas.policy.topic-config.range: "max.message.bytes::1048588,segment.bytes:52428800:,segment.ms:600000:"
-      kas.policy.topic-config.mutable: "message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable"
+      kas.policy.topic-config.mutable: "message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,retention.ms,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable"
     storage:
       volumes:
       - type: "persistent-claim"

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -210,7 +210,7 @@ spec:
       kas.policy.topic-config.topic-config-policy-enforced: true
       kas.policy.topic-config.enforced: "flush.ms:9223372036854775807,index.interval.bytes:4096,compression.type:producer,flush.messages:9223372036854775807,min.cleanable.dirty.ratio:0.5,file.delete.delay.ms:60000,segment.index.bytes:10485760,preallocate:false,unclean.leader.election.enable:false,min.insync.replicas:2"
       kas.policy.topic-config.range: "max.message.bytes::1048588,segment.bytes:52428800:,segment.ms:600000:"
-      kas.policy.topic-config.mutable: "message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable"
+      kas.policy.topic-config.mutable: "message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,retention.ms,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable"
     storage:
       volumes:
       - type: "persistent-claim"

--- a/operator/src/test/resources/expected/strimzi_su2.yml
+++ b/operator/src/test/resources/expected/strimzi_su2.yml
@@ -216,7 +216,7 @@ spec:
       kas.policy.topic-config.topic-config-policy-enforced: true
       kas.policy.topic-config.enforced: "flush.ms:9223372036854775807,index.interval.bytes:4096,compression.type:producer,flush.messages:9223372036854775807,min.cleanable.dirty.ratio:0.5,file.delete.delay.ms:60000,segment.index.bytes:10485760,preallocate:false,unclean.leader.election.enable:false,min.insync.replicas:2"
       kas.policy.topic-config.range: "max.message.bytes::1048588,segment.bytes:52428800:,segment.ms:600000:"
-      kas.policy.topic-config.mutable: "message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable"
+      kas.policy.topic-config.mutable: "message.timestamp.difference.max.ms,message.timestamp.type,retention.bytes,retention.ms,min.compaction.lag.ms,cleanup.policy,max.compaction.lag.ms,delete.retention.ms,message.downconversion.enable"
 
       max.partitions: 3000
       cruise.control.metrics.topic.min.insync.replicas: 2


### PR DESCRIPTION
This is causing a regression when creating topics using the RHOAS CLI:

```
rhoas kafka topic create --name=foo2 -v
{"id":"8","kind":"Error","href":"/api/v1/errors/8","reason":"Request violates topic configuration policy","code":400,"error_message":"Request violates topic configuration policy"}%
```