### PR TITLE
remove now redundant broker plugins properties

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -70,7 +70,6 @@ import org.bf2.operator.operands.KafkaInstanceConfiguration.AccessControl;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaAuthenticationOAuth;
 import org.bf2.operator.resources.v1alpha1.ServiceAccount;
-import org.bf2.operator.resources.v1alpha1.Versions;
 import org.eclipse.microprofile.config.Config;
 import org.jboss.logging.Logger;
 
@@ -659,8 +658,6 @@ public class KafkaCluster extends AbstractKafkaCluster {
         config.put("inter.broker.protocol.version", this.kafkaManager.currentKafkaIbpVersion(managedKafka));
         config.put("ssl.enabled.protocols", "TLSv1.3,TLSv1.2");
         config.put("ssl.protocol", "TLS");
-        config.put("strimzi.authorization.custom-authorizer.partition-limit-enforced",
-                kafkaConfigs.isPartitionLimitEnforced());
         config.put("kas.policy.create-topic.partition-limit-enforced",
                 kafkaConfigs.isPartitionLimitEnforced());
 
@@ -679,11 +676,8 @@ public class KafkaCluster extends AbstractKafkaCluster {
                 kafkaConfigs.getMaximumSessionLifetimeDefault();
         config.put("connections.max.reauth.ms", maxReauthMs);
 
-        if (managedKafka.getSpec().getVersions().compareStrimziVersionTo(Versions.STRIMZI_CLUSTER_OPERATOR_V0_23_0_4) >= 0) {
-            // extension to manage the create topic to ensure valid Replication Factor and ISR
-            config.put("create.topic.policy.class.name", "io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy");
-            config.put("alter.config.policy.class.name", "io.bf2.kafka.config.ManagedKafkaAlterConfigPolicy");
-        }
+        config.put("create.topic.policy.class.name", "io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy");
+        config.put("alter.config.policy.class.name", "io.bf2.kafka.config.ManagedKafkaAlterConfigPolicy");
 
         // forcing the preferred leader election as soon as possible
         // NOTE: mostly useful for canary when Kafka brokers roll, partitions move but a preferred leader is not elected
@@ -700,20 +694,10 @@ public class KafkaCluster extends AbstractKafkaCluster {
         // custom authorizer configuration
         AccessControl aclConfig = getAclConfig(managedKafka);
         addKafkaAuthorizerConfig(managedKafka, config, aclConfig::getBrokerPluginsConfigPrefix);
-        addKafkaAuthorizerConfig(managedKafka, config, aclConfig::getConfigPrefix);
 
         if (managedKafka.getSpec().getCapacity().getMaxPartitions() != null) {
             config.put(MAX_PARTITIONS, managedKafka.getSpec().getCapacity().getMaxPartitions());
         }
-
-        config.put("strimzi.authorization.custom-authorizer.partition-counter.timeout-seconds", 10);
-        config.put("strimzi.authorization.custom-authorizer.partition-counter.schedule-interval-seconds", 15);
-        config.put("strimzi.authorization.custom-authorizer.partition-counter.private-topic-prefix",
-                instanceConfig.kafka.acl.privatePrefix);
-
-        config.put("strimzi.authorization.custom-authorizer.adminclient-listener.name", "controlplane-9090");
-        config.put("strimzi.authorization.custom-authorizer.adminclient-listener.port", 9090);
-        config.put("strimzi.authorization.custom-authorizer.adminclient-listener.protocol", "SSL");
 
         config.put("kas.policy.create-topic.partition-counter.private-topic-prefix", instanceConfig.kafka.acl.privatePrefix);
         config.put("kas.policy.create-topic.partition-counter.schedule-interval-seconds", 15);

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -432,9 +432,6 @@ public class KafkaInstanceConfiguration {
         protected String authorizerClass = null;
         @JsonProperty("broker-plugins-config-prefix")
         protected String brokerPluginsConfigPrefix = null;
-        @Deprecated
-        @JsonProperty("config-prefix")
-        protected String configPrefix = null;
         @JsonProperty("global")
         protected String global = null;
         @JsonProperty("owner")
@@ -508,16 +505,6 @@ public class KafkaInstanceConfiguration {
 
         public void setBrokerPluginsConfigPrefix(String brokerPluginsConfigPrefix) {
             this.brokerPluginsConfigPrefix = brokerPluginsConfigPrefix;
-        }
-
-        @Deprecated
-        public String getConfigPrefix() {
-            return configPrefix;
-        }
-
-        @Deprecated
-        public void setConfigPrefix(String configPrefix) {
-            this.configPrefix = configPrefix;
         }
 
         public String getGlobal() {

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -86,7 +86,6 @@ managedkafka.upgrade.consuming-percentage-threshold=90
 
 # Static ACL static configuration for CustomAuthorizer
 managedkafka.kafka.acl.authorizer-class=io.bf2.kafka.authorizer.CustomAclAuthorizer
-managedkafka.kafka.acl.config-prefix=strimzi.authorization.custom-authorizer.
 managedkafka.kafka.acl.broker-plugins-config-prefix=kas.authorizer.
 managedkafka.kafka.acl.allowed-listeners=SRE-9096
 managedkafka.kafka.acl.logging.suppression-window.duration=PT300S

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -95,11 +95,6 @@ spec:
       type: "internal"
       tls: false
     config:
-      strimzi.authorization.custom-authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
-      strimzi.authorization.custom-authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
       min.insync.replicas: 2
       create.topic.policy.class.name: "io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy"
       alter.config.policy.class.name: "io.bf2.kafka.config.ManagedKafkaAlterConfigPolicy"
@@ -111,62 +106,22 @@ spec:
       log.message.format.version: "2.6"
       connections.max.reauth.ms: 299000
       quota.window.size.seconds: "2"
-      strimzi.authorization.custom-authorizer.allowed-listeners: "SRE-9096"
       quota.window.num: "30"
-      strimzi.authorization.custom-authorizer.adminclient-listener.port: 9090
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.duration: "PT300S"
-      strimzi.authorization.custom-authorizer.adminclient-listener.name: "controlplane-9090"
       client.quota.callback.static.storage.check-interval: "30"
       client.quota.callback.usageMetrics.topic: __redhat_strimzi_volumeUsageMetrics
       client.quota.callback.quotaPolicy.check-interval: "15"
       client.quota.callback.kafka.clientIdPrefix: __redhat_strimzi
-      strimzi.authorization.custom-authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
-      strimzi.authorization.custom-authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
-      strimzi.authorization.custom-authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
-      strimzi.authorization.custom-authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
       max.partitions: 3000
-      strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
-      strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
-      strimzi.authorization.custom-authorizer.adminclient-listener.protocol: "SSL"
       client.quota.callback.static.storage.soft: "10737418240"
-      strimzi.authorization.custom-authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
-      strimzi.authorization.custom-authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
-      strimzi.authorization.custom-authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
       inter.broker.protocol.version: "2.6"
-      strimzi.authorization.custom-authorizer.partition-counter.private-topic-prefix: "__redhat_"
       client.quota.callback.static.produce: "349525"
-      strimzi.authorization.custom-authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
       ssl.protocol: "TLS"
-      strimzi.authorization.custom-authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
       client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
-      strimzi.authorization.custom-authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
-      strimzi.authorization.custom-authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
       ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
-      strimzi.authorization.custom-authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
-      strimzi.authorization.custom-authorizer.partition-counter.timeout-seconds: 10
-      strimzi.authorization.custom-authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
       client.quota.callback.static.storage.hard: "10737418240"
-      strimzi.authorization.custom-authorizer.partition-counter.schedule-interval-seconds: 15
-      strimzi.authorization.custom-authorizer.resource-operations: "{ \"cluster\"\
-        : [ \"describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\"\
-        , \"read\" ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\"\
-        , \"delete\", \"describe\", \"describe_configs\", \"read\", \"write\" ], \"\
-        transactional_id\": [ \"all\", \"describe\", \"write\" ] }"
       leader.imbalance.per.broker.percentage: 0
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.eventCount: 5000
-      strimzi.authorization.custom-authorizer.partition-limit-enforced: true
 
       kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
       kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -86,12 +86,7 @@ spec:
       type: "internal"
       tls: false
     config:
-      strimzi.authorization.custom-authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
       auto.create.topics.enable: "false"
-      strimzi.authorization.custom-authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
-      strimzi.authorization.custom-authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
       min.insync.replicas: 1
       create.topic.policy.class.name: "io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy"
       alter.config.policy.class.name: "io.bf2.kafka.config.ManagedKafkaAlterConfigPolicy"
@@ -105,60 +100,20 @@ spec:
       log.message.format.version: "2.6"
       connections.max.reauth.ms: 299000
       quota.window.size.seconds: "2"
-      strimzi.authorization.custom-authorizer.allowed-listeners: "SRE-9096"
       quota.window.num: "30"
-      strimzi.authorization.custom-authorizer.adminclient-listener.port: 9090
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.duration: "PT300S"
-      strimzi.authorization.custom-authorizer.adminclient-listener.name: "controlplane-9090"
       client.quota.callback.static.storage.check-interval: "30"
-      strimzi.authorization.custom-authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
-      strimzi.authorization.custom-authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
-      strimzi.authorization.custom-authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
-      strimzi.authorization.custom-authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
       max.partitions: 100
-      strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
       offsets.topic.replication.factor: 1
       transaction.state.log.min.isr: 1
-      strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
-      strimzi.authorization.custom-authorizer.adminclient-listener.protocol: "SSL"
       client.quota.callback.static.storage.soft: "64424509440"
-      strimzi.authorization.custom-authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
-      strimzi.authorization.custom-authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
-      strimzi.authorization.custom-authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
-      strimzi.authorization.custom-authorizer.partition-limit-enforced: true
       client.quota.callback.usageMetrics.topic: "__redhat_strimzi_volumeUsageMetrics"
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
       inter.broker.protocol.version: "2.6"
-      strimzi.authorization.custom-authorizer.partition-counter.private-topic-prefix: "__redhat_"
       client.quota.callback.static.produce: "2097152"
-      strimzi.authorization.custom-authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
       ssl.protocol: "TLS"
-      strimzi.authorization.custom-authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
       client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
-      strimzi.authorization.custom-authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
-      strimzi.authorization.custom-authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
       ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
-      strimzi.authorization.custom-authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
-      strimzi.authorization.custom-authorizer.partition-counter.timeout-seconds: 10
-      strimzi.authorization.custom-authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
       client.quota.callback.static.storage.hard: "64424509440"
-      strimzi.authorization.custom-authorizer.partition-counter.schedule-interval-seconds: 15
-      strimzi.authorization.custom-authorizer.resource-operations: "{ \"cluster\"\
-        : [ \"describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\"\
-        , \"read\" ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\"\
-        , \"delete\", \"describe\", \"describe_configs\", \"read\", \"write\" ], \"\
-        transactional_id\": [ \"all\", \"describe\", \"write\" ] }"
       leader.imbalance.per.broker.percentage: 0
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.eventCount: 5000
 
       kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
       kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"

--- a/operator/src/test/resources/expected/scaling-one.yml
+++ b/operator/src/test/resources/expected/scaling-one.yml
@@ -1,9 +1,4 @@
-strimzi.authorization.custom-authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
-strimzi.authorization.custom-authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
-strimzi.authorization.custom-authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
 auto.create.topics.enable: "false"
-strimzi.authorization.custom-authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
-strimzi.authorization.custom-authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
 min.insync.replicas: 1
 create.topic.policy.class.name: "io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy"
 alter.config.policy.class.name: "io.bf2.kafka.config.ManagedKafkaAlterConfigPolicy"
@@ -15,61 +10,21 @@ transaction.state.log.replication.factor: 1
 log.message.format.version: "2.6"
 connections.max.reauth.ms: 299000
 quota.window.size.seconds: "2"
-strimzi.authorization.custom-authorizer.allowed-listeners: "SRE-9096"
 quota.window.num: "30"
-strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.duration: "PT300S"
 client.quota.callback.static.storage.check-interval: "30"
 client.quota.callback.usageMetrics.topic: __redhat_strimzi_volumeUsageMetrics
 client.quota.callback.quotaPolicy.check-interval: "15"
 client.quota.callback.kafka.clientIdPrefix: __redhat_strimzi
-strimzi.authorization.custom-authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
-strimzi.authorization.custom-authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
-strimzi.authorization.custom-authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
-strimzi.authorization.custom-authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
-strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
 offsets.topic.replication.factor: 1
 transaction.state.log.min.isr: 1
-strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
 client.quota.callback.static.storage.soft: "64424509440"
-strimzi.authorization.custom-authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
-strimzi.authorization.custom-authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
-strimzi.authorization.custom-authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
-strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
 inter.broker.protocol.version: "2.6"
 client.quota.callback.static.produce: "2097152"
-strimzi.authorization.custom-authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
-strimzi.authorization.custom-authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
 ssl.protocol: "TLS"
-strimzi.authorization.custom-authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
-strimzi.authorization.custom-authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
 client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
-strimzi.authorization.custom-authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
-strimzi.authorization.custom-authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
-strimzi.authorization.custom-authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
 ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
-strimzi.authorization.custom-authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
-strimzi.authorization.custom-authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
-strimzi.authorization.custom-authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
-strimzi.authorization.custom-authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
-strimzi.authorization.custom-authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
-strimzi.authorization.custom-authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
-strimzi.authorization.custom-authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
-strimzi.authorization.custom-authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
 client.quota.callback.static.storage.hard: "64424509440"
-strimzi.authorization.custom-authorizer.resource-operations: "{ \"cluster\": [ \"\
-  describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\", \"read\"\
-  \ ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\", \"delete\"\
-  , \"describe\", \"describe_configs\", \"read\", \"write\" ], \"transactional_id\"\
-  : [ \"all\", \"describe\", \"write\" ] }"
 leader.imbalance.per.broker.percentage: 0
-strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.eventCount: 5000
-strimzi.authorization.custom-authorizer.partition-counter.timeout-seconds: 10
-strimzi.authorization.custom-authorizer.partition-counter.schedule-interval-seconds: 15
-strimzi.authorization.custom-authorizer.partition-counter.private-topic-prefix: __redhat_
-strimzi.authorization.custom-authorizer.adminclient-listener.name: controlplane-9090
-strimzi.authorization.custom-authorizer.adminclient-listener.port: 9090
-strimzi.authorization.custom-authorizer.adminclient-listener.protocol: SSL
-strimzi.authorization.custom-authorizer.partition-limit-enforced: true
 
 kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
 kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -89,12 +89,7 @@ spec:
       type: "internal"
       tls: false
     config:
-      strimzi.authorization.custom-authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
       auto.create.topics.enable: "false"
-      strimzi.authorization.custom-authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
-      strimzi.authorization.custom-authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
       min.insync.replicas: 2
       create.topic.policy.class.name: "io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy"
       alter.config.policy.class.name: "io.bf2.kafka.config.ManagedKafkaAlterConfigPolicy"
@@ -106,61 +101,21 @@ spec:
       log.message.format.version: "2.6"
       connections.max.reauth.ms: 299000
       quota.window.size.seconds: "2"
-      strimzi.authorization.custom-authorizer.allowed-listeners: "SRE-9096"
       quota.window.num: "30"
-      strimzi.authorization.custom-authorizer.adminclient-listener.port: 9090
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.duration: "PT300S"
-      strimzi.authorization.custom-authorizer.adminclient-listener.name: "controlplane-9090"
       client.quota.callback.static.storage.check-interval: "30"
       client.quota.callback.usageMetrics.topic: __redhat_strimzi_volumeUsageMetrics
       client.quota.callback.quotaPolicy.check-interval: "15"
       client.quota.callback.kafka.clientIdPrefix: __redhat_strimzi
-      strimzi.authorization.custom-authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
-      strimzi.authorization.custom-authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
-      strimzi.authorization.custom-authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
-      strimzi.authorization.custom-authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
-      strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
-      strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
-      strimzi.authorization.custom-authorizer.adminclient-listener.protocol: "SSL"
       client.quota.callback.static.storage.soft: "21474836480"
-      strimzi.authorization.custom-authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
-      strimzi.authorization.custom-authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
-      strimzi.authorization.custom-authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
       inter.broker.protocol.version: "2.6"
-      strimzi.authorization.custom-authorizer.partition-counter.private-topic-prefix: "__redhat_"
       client.quota.callback.static.produce: "699050"
-      strimzi.authorization.custom-authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
       ssl.protocol: "TLS"
-      strimzi.authorization.custom-authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
       client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
-      strimzi.authorization.custom-authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
-      strimzi.authorization.custom-authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
       ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
-      strimzi.authorization.custom-authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
-      strimzi.authorization.custom-authorizer.partition-counter.timeout-seconds: 10
-      strimzi.authorization.custom-authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
       client.quota.callback.static.storage.hard: "21474836480"
-      strimzi.authorization.custom-authorizer.partition-counter.schedule-interval-seconds: 15
-      strimzi.authorization.custom-authorizer.resource-operations: "{ \"cluster\"\
-        : [ \"describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\"\
-        , \"read\" ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\"\
-        , \"delete\", \"describe\", \"describe_configs\", \"read\", \"write\" ], \"\
-        transactional_id\": [ \"all\", \"describe\", \"write\" ] }"
       leader.imbalance.per.broker.percentage: 0
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.eventCount: 5000
-      strimzi.authorization.custom-authorizer.partition-limit-enforced: true
 
       kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
       kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"

--- a/operator/src/test/resources/expected/strimzi_su2.yml
+++ b/operator/src/test/resources/expected/strimzi_su2.yml
@@ -95,12 +95,7 @@ spec:
         type: "internal"
         tls: false
     config:
-      strimzi.authorization.custom-authorizer.acl.022: "priority=1;permission=deny;principal=canary-123;topic=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.023: "priority=1;permission=deny;principal=canary-123;group=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.024: "priority=1;permission=deny;principal=canary-123;transactional_id=*;operations=all"
       auto.create.topics.enable: "false"
-      strimzi.authorization.custom-authorizer.acl.020: "priority=0;permission=allow;principal=canary-123;topic=__redhat_strimzi_canary;operations=create,describe,read,write,alter,alter_configs"
-      strimzi.authorization.custom-authorizer.acl.021: "priority=0;permission=allow;principal=canary-123;group=__redhat_strimzi_canary_group;operations=describe,read"
       min.insync.replicas: 2
       create.topic.policy.class.name: "io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy"
       alter.config.policy.class.name: "io.bf2.kafka.config.ManagedKafkaAlterConfigPolicy"
@@ -112,61 +107,21 @@ spec:
       log.message.format.version: "2.6"
       connections.max.reauth.ms: 299000
       quota.window.size.seconds: "2"
-      strimzi.authorization.custom-authorizer.allowed-listeners: "SRE-9096"
       quota.window.num: "30"
-      strimzi.authorization.custom-authorizer.adminclient-listener.port: 9090
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.duration: "PT300S"
-      strimzi.authorization.custom-authorizer.adminclient-listener.name: "controlplane-9090"
       client.quota.callback.static.storage.check-interval: "30"
       client.quota.callback.usageMetrics.topic: __redhat_strimzi_volumeUsageMetrics
       client.quota.callback.quotaPolicy.check-interval: "15"
       client.quota.callback.kafka.clientIdPrefix: __redhat_strimzi
-      strimzi.authorization.custom-authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
-      strimzi.authorization.custom-authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"
-      strimzi.authorization.custom-authorizer.acl.003: "default=true;permission=allow;cluster=*;operations=describe"
-      strimzi.authorization.custom-authorizer.acl.008: "priority=1;permission=deny;topic=__consumer_offsets;operations=all"
-      strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
-      strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
-      strimzi.authorization.custom-authorizer.adminclient-listener.protocol: "SSL"
       client.quota.callback.static.storage.soft: "366503875925"
-      strimzi.authorization.custom-authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"
-      strimzi.authorization.custom-authorizer.acl.006: "permission=deny;cluster=*;operations=describe;apis-except=describe_acls"
-      strimzi.authorization.custom-authorizer.acl.007: "permission=allow;cluster=*;operations=idempotent_write"
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.apis: "PRODUCE,FETCH"
       inter.broker.protocol.version: "2.6"
-      strimzi.authorization.custom-authorizer.partition-counter.private-topic-prefix: "__redhat_"
       client.quota.callback.static.produce: "17476266"
-      strimzi.authorization.custom-authorizer.acl.011: "priority=1;permission=deny;group=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.004: "priority=1;topic=__redhat_*;operations=describe,read,write;level=DEBUG"
       ssl.protocol: "TLS"
-      strimzi.authorization.custom-authorizer.acl.012: "priority=1;permission=deny;transactional_id=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.003: "topic=*;operations=describe;level=DEBUG"
       client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
-      strimzi.authorization.custom-authorizer.acl.013: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=describe;apis=describe_acls"
-      strimzi.authorization.custom-authorizer.acl.logging.005: "group=*;apis=offset_fetch,offset_commit,heartbeat,describe_groups;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.014: "priority=1;permission=allow;principal=userid-123;cluster=*;operations=alter;apis=create_acls,delete_acls"
       ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
-      strimzi.authorization.custom-authorizer.acl.010: "priority=1;permission=deny;topic=__redhat_*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.019: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=alter;apis=alter_partition_reassignments"
-      strimzi.authorization.custom-authorizer.partition-counter.timeout-seconds: 10
-      strimzi.authorization.custom-authorizer.acl.015: "priority=1;permission=allow;principal=userid-123;topic=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.016: "priority=1;permission=allow;principal=userid-123;group=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.002: "topic=*;apis=list_offsets;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.017: "priority=1;permission=allow;principal=userid-123;transactional_id=*;operations=all"
-      strimzi.authorization.custom-authorizer.acl.logging.001: "cluster=*;apis=fetch,list_groups,describe_configs;level=DEBUG"
-      strimzi.authorization.custom-authorizer.acl.018: "priority=1;permission=allow;principal=canary-123;cluster=*;operations=describe;apis=list_partition_reassignments"
       client.quota.callback.static.storage.hard: "366503875925"
-      strimzi.authorization.custom-authorizer.partition-counter.schedule-interval-seconds: 15
-      strimzi.authorization.custom-authorizer.resource-operations: "{ \"cluster\"\
-        : [ \"describe\", \"alter\" ], \"group\": [ \"all\", \"delete\", \"describe\"\
-        , \"read\" ], \"topic\": [ \"all\", \"alter\", \"alter_configs\", \"create\"\
-        , \"delete\", \"describe\", \"describe_configs\", \"read\", \"write\" ], \"\
-        transactional_id\": [ \"all\", \"describe\", \"write\" ] }"
       leader.imbalance.per.broker.percentage: 0
-      strimzi.authorization.custom-authorizer.acl.logging.suppressionWindow.eventCount: 5000
-      strimzi.authorization.custom-authorizer.partition-limit-enforced: true
 
       kas.authorizer.acl.001: "default=true;permission=allow;topic=*;operations=describe,describe_configs"
       kas.authorizer.acl.002: "default=true;permission=allow;group=*;operations=describe"


### PR DESCRIPTION
The broker plugin was refactored to us avoid use of 'strimzi' in its configuration properties.  The version of the plugin that replied on the old name is no longer in use.  Thus the configuration using the old name can now be removed.