### PR TITLE
Set transaction.id.expiration.ms to 1 day

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -84,6 +84,7 @@ import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -652,6 +653,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         config.put("offsets.topic.replication.factor", scalingAndReplicationFactor);
         config.put("transaction.state.log.min.isr", minIsr);
         config.put("transaction.state.log.replication.factor", scalingAndReplicationFactor);
+        config.put("transaction.id.expiration.ms", Duration.ofDays(1).toMillis());
         config.put("auto.create.topics.enable", "false");
         config.put("min.insync.replicas", minIsr);
         config.put("default.replication.factor", scalingAndReplicationFactor);

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -128,6 +128,7 @@ spec:
       strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
+      transaction.id.expiration.ms: 86400000
       strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
       strimzi.authorization.custom-authorizer.adminclient-listener.protocol: "SSL"
       client.quota.callback.static.storage.soft: "10737418240"

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -119,6 +119,7 @@ spec:
       strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
       offsets.topic.replication.factor: 1
       transaction.state.log.min.isr: 1
+      transaction.id.expiration.ms: 86400000
       strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
       strimzi.authorization.custom-authorizer.adminclient-listener.protocol: "SSL"
       client.quota.callback.static.storage.soft: "64424509440"

--- a/operator/src/test/resources/expected/scaling-one.yml
+++ b/operator/src/test/resources/expected/scaling-one.yml
@@ -29,6 +29,7 @@ strimzi.authorization.custom-authorizer.acl.008: "priority=1;permission=deny;top
 strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
 offsets.topic.replication.factor: 1
 transaction.state.log.min.isr: 1
+transaction.id.expiration.ms: 86400000
 strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
 client.quota.callback.static.storage.soft: "64424509440"
 strimzi.authorization.custom-authorizer.acl.005: "permission=deny;cluster=*;operations=alter;apis-except=create_acls,delete_acls"

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -122,6 +122,7 @@ spec:
       strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
+      transaction.id.expiration.ms: 86400000
       strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
       strimzi.authorization.custom-authorizer.adminclient-listener.protocol: "SSL"
       client.quota.callback.static.storage.soft: "21474836480"

--- a/operator/src/test/resources/expected/strimzi_su2.yml
+++ b/operator/src/test/resources/expected/strimzi_su2.yml
@@ -128,6 +128,7 @@ spec:
       strimzi.authorization.custom-authorizer.acl.009: "priority=1;permission=deny;topic=__transaction_state;operations=all"
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2
+      transaction.id.expiration.ms: 86400000
       strimzi.authorization.custom-authorizer.acl.004: "permission=deny;cluster=*;operations-except=alter,describe,idempotent_write"
       strimzi.authorization.custom-authorizer.adminclient-listener.protocol: "SSL"
       client.quota.callback.static.storage.soft: "366503875925"


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDSTRM-9293

The default value for this is 7 days, but we want to reduce it to 1
day for the moment to reduce the chances that we'll hit an OOM as a
result of too many idempotent producer IDs being stored for too long.