### PR TITLE
MGDSTRM-9483 delaying deployment of admin/canary until kafka is ready

### DIFF
--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -166,7 +166,7 @@ public class ManagedKafkaController implements Reconciler<ManagedKafka>, EventSo
 
         int replicas = kafkaCluster.getReplicas(managedKafka);
 
-        if (ingressControllerManagerInstance.isResolvable()) {
+        if (ingressControllerManagerInstance.isResolvable() && kafkaCluster.hasKafkaBeenReady(managedKafka)) {
             IngressControllerManager ingressControllerManager = ingressControllerManagerInstance.get();
             List<ManagedKafkaRoute> routes = ingressControllerManager.getManagedKafkaRoutesFor(managedKafka);
 

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractAdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractAdminServer.java
@@ -2,43 +2,25 @@ package org.bf2.operator.operands;
 
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import org.bf2.common.OperandUtils;
 import org.bf2.operator.managers.InformerManager;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
-import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
 import org.jboss.logging.Logger;
 
 import javax.inject.Inject;
 
-public abstract class AbstractAdminServer implements Operand<ManagedKafka> {
+public abstract class AbstractAdminServer extends DeploymentOperand {
 
     @Inject
     Logger log;
 
     @Inject
-    protected KubernetesClient kubernetesClient;
-
-    @Inject
     protected InformerManager informerManager;
-
-    @Inject
-    protected AbstractKafkaCluster kafkaCluster;
 
     @Override
     public void createOrUpdate(ManagedKafka managedKafka) {
         Deployment currentDeployment = cachedDeployment(managedKafka);
-
-        if (currentDeployment == null) {
-            OperandReadiness kafkaReadiness = kafkaCluster.getReadiness(managedKafka);
-            if (kafkaReadiness.getStatus() != Status.True) {
-                // don't create until ready
-                return;
-            }
-        }
-
         Deployment deployment = deploymentFrom(managedKafka, currentDeployment);
         createOrUpdate(deployment);
 
@@ -47,21 +29,11 @@ public abstract class AbstractAdminServer implements Operand<ManagedKafka> {
         createOrUpdate(service);
     }
 
-    protected void createOrUpdate(Deployment deployment) {
-        OperandUtils.createOrUpdate(kubernetesClient.apps().deployments(), deployment);
-    }
-
-    protected void createOrUpdate(Service service) {
-        OperandUtils.createOrUpdate(kubernetesClient.services(), service);
-    }
-
     @Override
     public void delete(ManagedKafka managedKafka, Context context) {
         adminDeploymentResource(managedKafka).delete();
         adminServiceResource(managedKafka).delete();
     }
-
-    public abstract Deployment deploymentFrom(ManagedKafka managedKafka, Deployment current);
 
     public abstract Service serviceFrom(ManagedKafka managedKafka, Service current);
 
@@ -91,6 +63,7 @@ public abstract class AbstractAdminServer implements Operand<ManagedKafka> {
                 .withName(adminServerName(managedKafka));
     }
 
+    @Override
     protected Deployment cachedDeployment(ManagedKafka managedKafka) {
         return informerManager.getLocalDeployment(adminServerNamespace(managedKafka), adminServerName(managedKafka));
     }

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -212,6 +212,16 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
         return informerManager.getLocalKafka(kafkaClusterNamespace(managedKafka), kafkaClusterName(managedKafka));
     }
 
+    public boolean hasKafkaBeenReady(ManagedKafka managedKafka) {
+        Kafka kafka = cachedKafka(managedKafka);
+        // if we don't yet have a clusterId, then we've never been ready
+        return hasClusterId(kafka);
+    }
+
+    static boolean hasClusterId(Kafka kafka) {
+        return kafka != null && kafka.getStatus() != null && kafka.getStatus().getClusterId() != null;
+    }
+
     @Override
     public void createOrUpdate(ManagedKafka managedKafka) {
         Kafka current = cachedKafka(managedKafka);

--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -52,7 +52,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -112,14 +111,7 @@ public class AdminServer extends AbstractAdminServer {
 
     @Override
     public void createOrUpdate(ManagedKafka managedKafka) {
-        if (managedKafka.isReserveDeployment()) {
-            Deployment current = cachedDeployment(managedKafka);
-            Deployment deployment = deploymentFrom(managedKafka, null);
-
-            deployment = ReservedDeploymentConverter.asReservedDeployment(current, deployment, managedKafka);
-            if (!Objects.equals(current, deployment)) {
-                createOrUpdate(deployment);
-            }
+        if (handleReserveOrWaitForKafka(managedKafka)) {
             return;
         }
 

--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -172,15 +171,7 @@ public class Canary extends AbstractCanary {
 
     @Override
     public void createOrUpdate(ManagedKafka managedKafka) {
-        if (managedKafka.isReserveDeployment()) {
-            Deployment current = cachedDeployment(managedKafka);
-            Deployment deployment = deploymentFrom(managedKafka, null);
-
-            deployment = ReservedDeploymentConverter.asReservedDeployment(current, deployment, managedKafka);
-
-            if (!Objects.equals(current, deployment)) {
-                createOrUpdate(deployment);
-            }
+        if (handleReserveOrWaitForKafka(managedKafka)) {
             return;
         }
         super.createOrUpdate(managedKafka);

--- a/operator/src/main/java/org/bf2/operator/operands/Canary.java
+++ b/operator/src/main/java/org/bf2/operator/operands/Canary.java
@@ -89,9 +89,6 @@ public class Canary extends AbstractCanary {
     @Inject
     protected OperandOverrideManager overrideManager;
 
-    @Inject
-    protected AbstractKafkaCluster kafkaCluster;
-
     @Override
     public Deployment deploymentFrom(ManagedKafka managedKafka, Deployment current) {
         String canaryName = canaryName(managedKafka);

--- a/operator/src/main/java/org/bf2/operator/operands/DeploymentOperand.java
+++ b/operator/src/main/java/org/bf2/operator/operands/DeploymentOperand.java
@@ -1,0 +1,58 @@
+package org.bf2.operator.operands;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.bf2.common.OperandUtils;
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
+
+import javax.inject.Inject;
+
+import java.util.Objects;
+
+public abstract class DeploymentOperand implements Operand<ManagedKafka> {
+
+    @Inject
+    protected KubernetesClient kubernetesClient;
+
+    @Inject
+    protected AbstractKafkaCluster kafkaCluster;
+
+    protected abstract Deployment cachedDeployment(ManagedKafka managedKafka);
+
+    protected void createOrUpdate(Deployment deployment) {
+        OperandUtils.createOrUpdate(kubernetesClient.apps().deployments(), deployment);
+    }
+
+    protected void createOrUpdate(Service service) {
+        OperandUtils.createOrUpdate(kubernetesClient.services(), service);
+    }
+
+    public abstract Deployment deploymentFrom(ManagedKafka managedKafka, Deployment current);
+
+    protected boolean handleReserveOrWaitForKafka(ManagedKafka managedKafka) {
+        Deployment current = cachedDeployment(managedKafka);
+
+        if (managedKafka.isReserveDeployment()) {
+            Deployment deployment = deploymentFrom(managedKafka, null);
+
+            deployment = ReservedDeploymentConverter.asReservedDeployment(current, deployment, managedKafka);
+            if (!Objects.equals(current, deployment)) {
+                createOrUpdate(deployment);
+            }
+            return true;
+        }
+
+        if (current == null) {
+            OperandReadiness kafkaReadiness = kafkaCluster.getReadiness(managedKafka);
+            if (kafkaReadiness.getStatus() != Status.True) {
+                // don't create until ready
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/operator/src/main/java/org/bf2/operator/operands/DeploymentOperand.java
+++ b/operator/src/main/java/org/bf2/operator/operands/DeploymentOperand.java
@@ -3,7 +3,6 @@ package org.bf2.operator.operands;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.strimzi.api.kafka.model.Kafka;
 import org.bf2.common.OperandUtils;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 
@@ -21,6 +20,8 @@ public abstract class DeploymentOperand implements Operand<ManagedKafka> {
 
     protected abstract Deployment cachedDeployment(ManagedKafka managedKafka);
 
+    public abstract Deployment deploymentFrom(ManagedKafka managedKafka, Deployment current);
+
     protected void createOrUpdate(Deployment deployment) {
         OperandUtils.createOrUpdate(kubernetesClient.apps().deployments(), deployment);
     }
@@ -28,8 +29,6 @@ public abstract class DeploymentOperand implements Operand<ManagedKafka> {
     protected void createOrUpdate(Service service) {
         OperandUtils.createOrUpdate(kubernetesClient.services(), service);
     }
-
-    public abstract Deployment deploymentFrom(ManagedKafka managedKafka, Deployment current);
 
     protected boolean handleReserveOrWaitForKafka(ManagedKafka managedKafka) {
         Deployment current = cachedDeployment(managedKafka);
@@ -44,15 +43,8 @@ public abstract class DeploymentOperand implements Operand<ManagedKafka> {
             return true;
         }
 
-        if (current == null) {
-            Kafka kafka = kafkaCluster.cachedKafka(managedKafka);
-            // if we don't yet have a clusterId, then we've never been ready
-            if (kafka == null || kafka.getStatus() == null || kafka.getStatus().getClusterId() == null) {
-                return true;
-            }
-        }
-
-        return false;
+        // if not yet created, wait until kafka is ready
+        return current == null && !kafkaCluster.hasKafkaBeenReady(managedKafka);
     }
 
 }

--- a/operator/src/main/java/org/bf2/operator/operands/DeploymentOperand.java
+++ b/operator/src/main/java/org/bf2/operator/operands/DeploymentOperand.java
@@ -3,9 +3,9 @@ package org.bf2.operator.operands;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.model.Kafka;
 import org.bf2.common.OperandUtils;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
-import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
 
 import javax.inject.Inject;
 
@@ -45,9 +45,9 @@ public abstract class DeploymentOperand implements Operand<ManagedKafka> {
         }
 
         if (current == null) {
-            OperandReadiness kafkaReadiness = kafkaCluster.getReadiness(managedKafka);
-            if (kafkaReadiness.getStatus() != Status.True) {
-                // don't create until ready
+            Kafka kafka = kafkaCluster.cachedKafka(managedKafka);
+            // if we don't yet have a clusterId, then we've never been ready
+            if (kafka == null || kafka.getStatus() == null || kafka.getStatus().getClusterId() == null) {
                 return true;
             }
         }

--- a/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
@@ -11,12 +11,12 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
+import io.strimzi.api.kafka.model.KafkaBuilder;
 import org.bf2.operator.managers.OperandOverrideManager;
 import org.bf2.operator.managers.OperandOverrideManager.OperandOverride;
 import org.bf2.operator.managers.SecuritySecretManager;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
-import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
 import org.bf2.operator.resources.v1alpha1.TlsKeyPair;
 import org.junit.jupiter.api.BeforeEach;
@@ -164,7 +164,8 @@ class AdminServerTest {
     void testDeploymentCreatedWhenSecretsExist() {
         KafkaCluster kafkaCluster = Mockito.mock(KafkaCluster.class);
         QuarkusMock.installMockForType(kafkaCluster, KafkaCluster.class);
-        Mockito.when(kafkaCluster.getReadiness(Mockito.any())).thenReturn(new OperandReadiness(ManagedKafkaCondition.Status.True, null, null));
+        Mockito.when(kafkaCluster.cachedKafka(Mockito.any()))
+                .thenReturn(new KafkaBuilder().withNewStatus().withClusterId("all-good").endStatus().build());
 
         ManagedKafka mk = buildBasicManagedKafka("test", "0.26.0-10", new TlsKeyPair());
 
@@ -217,7 +218,7 @@ class AdminServerTest {
 
         // check kafka delay
         deployment.delete();
-        Mockito.when(kafkaCluster.getReadiness(Mockito.any())).thenReturn(new OperandReadiness(ManagedKafkaCondition.Status.False, null, null));
+        Mockito.when(kafkaCluster.cachedKafka(Mockito.any())).thenReturn(new KafkaBuilder().build());
         adminServer.createOrUpdate(mk);
         assertNull(deployment.get());
     }

--- a/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
@@ -11,7 +11,6 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
-import io.strimzi.api.kafka.model.KafkaBuilder;
 import org.bf2.operator.managers.OperandOverrideManager;
 import org.bf2.operator.managers.OperandOverrideManager.OperandOverride;
 import org.bf2.operator.managers.SecuritySecretManager;
@@ -164,8 +163,7 @@ class AdminServerTest {
     void testDeploymentCreatedWhenSecretsExist() {
         KafkaCluster kafkaCluster = Mockito.mock(KafkaCluster.class);
         QuarkusMock.installMockForType(kafkaCluster, KafkaCluster.class);
-        Mockito.when(kafkaCluster.cachedKafka(Mockito.any()))
-                .thenReturn(new KafkaBuilder().withNewStatus().withClusterId("all-good").endStatus().build());
+        Mockito.when(kafkaCluster.hasKafkaBeenReady(Mockito.any())).thenReturn(true);
 
         ManagedKafka mk = buildBasicManagedKafka("test", "0.26.0-10", new TlsKeyPair());
 
@@ -218,7 +216,7 @@ class AdminServerTest {
 
         // check kafka delay
         deployment.delete();
-        Mockito.when(kafkaCluster.cachedKafka(Mockito.any())).thenReturn(new KafkaBuilder().build());
+        Mockito.when(kafkaCluster.hasKafkaBeenReady(Mockito.any())).thenReturn(false);
         adminServer.createOrUpdate(mk);
         assertNull(deployment.get());
     }

--- a/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
@@ -16,6 +16,7 @@ import org.bf2.operator.managers.OperandOverrideManager.OperandOverride;
 import org.bf2.operator.managers.SecuritySecretManager;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
 import org.bf2.operator.resources.v1alpha1.TlsKeyPair;
 import org.junit.jupiter.api.BeforeEach;
@@ -161,6 +162,10 @@ class AdminServerTest {
 
     @Test
     void testDeploymentCreatedWhenSecretsExist() {
+        KafkaCluster kafkaCluster = Mockito.mock(KafkaCluster.class);
+        QuarkusMock.installMockForType(kafkaCluster, KafkaCluster.class);
+        Mockito.when(kafkaCluster.getReadiness(Mockito.any())).thenReturn(new OperandReadiness(ManagedKafkaCondition.Status.True, null, null));
+
         ManagedKafka mk = buildBasicManagedKafka("test", "0.26.0-10", new TlsKeyPair());
 
         Resource<Deployment> deployment = client.apps().deployments()

--- a/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/AdminServerTest.java
@@ -31,9 +31,9 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTestResource(KubernetesServerTestResource.class)
@@ -214,6 +214,29 @@ class AdminServerTest {
         // 2 of 2 required secrets fully exist
         adminServer.createOrUpdate(mk);
         assertNotNull(deployment.get());
+
+        // check kafka delay
+        deployment.delete();
+        Mockito.when(kafkaCluster.getReadiness(Mockito.any())).thenReturn(new OperandReadiness(ManagedKafkaCondition.Status.False, null, null));
+        adminServer.createOrUpdate(mk);
+        assertNull(deployment.get());
+    }
+
+    @Test
+    void testReservedDeployment() throws Exception {
+        ManagedKafka mk = ManagedKafka.getDummyInstance(1);
+        mk = new ManagedKafkaBuilder(mk).editMetadata()
+                .withNamespace("reserved")
+                .addToLabels(ManagedKafka.DEPLOYMENT_TYPE, ManagedKafka.RESERVED_DEPLOYMENT_TYPE)
+                .endMetadata()
+                .build();
+        adminServer.createOrUpdate(mk);
+        Resource<Deployment> deployment = client.apps().deployments()
+                .inNamespace(AdminServer.adminServerNamespace(mk))
+                .withName(AdminServer.adminServerName(mk));
+
+        Deployment reserved = deployment.get();
+        assertEquals("pause", reserved.getSpec().getTemplate().getSpec().getContainers().get(0).getName());
     }
 
 }

--- a/operator/src/test/java/org/bf2/operator/operands/CanaryTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/CanaryTest.java
@@ -14,10 +14,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
+import io.strimzi.api.kafka.model.KafkaBuilder;
 import org.bf2.operator.managers.OperandOverrideManager;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
-import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
 import org.bf2.operator.resources.v1alpha1.TlsKeyPairBuilder;
 import org.junit.jupiter.api.Test;
@@ -172,7 +172,7 @@ public class CanaryTest {
         KafkaCluster kafkaCluster = Mockito.mock(KafkaCluster.class);
         QuarkusMock.installMockForType(kafkaCluster, KafkaCluster.class);
 
-        Mockito.when(kafkaCluster.getReadiness(Mockito.any())).thenReturn(new OperandReadiness(ManagedKafkaCondition.Status.False, null, null));
+        Mockito.when(kafkaCluster.cachedKafka(Mockito.any())).thenReturn(null);
 
         ManagedKafka mk = ManagedKafka.getDummyInstance(1);
         canary.createOrUpdate(mk);
@@ -182,7 +182,8 @@ public class CanaryTest {
         assertNull(deployment.get());
 
         // should proceed once ready
-        Mockito.when(kafkaCluster.getReadiness(Mockito.any())).thenReturn(new OperandReadiness(ManagedKafkaCondition.Status.True, null, null));
+        Mockito.when(kafkaCluster.cachedKafka(Mockito.any()))
+            .thenReturn(new KafkaBuilder().withNewStatus().withClusterId("all-good").endStatus().build());
         configureMockOverrideManager(mk, Collections.emptyList(), Collections.emptyList());
         canary.createOrUpdate(mk);
         assertNotNull(deployment.get());

--- a/operator/src/test/java/org/bf2/operator/operands/CanaryTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/CanaryTest.java
@@ -14,7 +14,6 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
-import io.strimzi.api.kafka.model.KafkaBuilder;
 import org.bf2.operator.managers.OperandOverrideManager;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
@@ -172,7 +171,7 @@ public class CanaryTest {
         KafkaCluster kafkaCluster = Mockito.mock(KafkaCluster.class);
         QuarkusMock.installMockForType(kafkaCluster, KafkaCluster.class);
 
-        Mockito.when(kafkaCluster.cachedKafka(Mockito.any())).thenReturn(null);
+        Mockito.when(kafkaCluster.hasKafkaBeenReady(Mockito.any())).thenReturn(false);
 
         ManagedKafka mk = ManagedKafka.getDummyInstance(1);
         canary.createOrUpdate(mk);
@@ -182,8 +181,7 @@ public class CanaryTest {
         assertNull(deployment.get());
 
         // should proceed once ready
-        Mockito.when(kafkaCluster.cachedKafka(Mockito.any()))
-            .thenReturn(new KafkaBuilder().withNewStatus().withClusterId("all-good").endStatus().build());
+        Mockito.when(kafkaCluster.hasKafkaBeenReady(Mockito.any())).thenReturn(true);
         configureMockOverrideManager(mk, Collections.emptyList(), Collections.emptyList());
         canary.createOrUpdate(mk);
         assertNotNull(deployment.get());

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -66,6 +66,7 @@ import java.util.stream.Collectors;
 import static org.bf2.operator.utils.ManagedKafkaUtils.dummyManagedKafka;
 import static org.bf2.operator.utils.ManagedKafkaUtils.exampleManagedKafka;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -682,7 +683,6 @@ class KafkaClusterTest {
         assertNull(((KafkaListenerAuthenticationOAuth) oauthListener2.getAuth()).getClientSecret());
     }
 
-
     private void configureMockOverrideManager(ManagedKafka mk, Map<String, Object> brokerConfigOverride) {
         String strimzi = mk.getSpec().getVersions().getStrimzi();
         OperandOverrideManager.Kafka canary = new OperandOverrideManager.Kafka();
@@ -692,5 +692,11 @@ class KafkaClusterTest {
         when(overrideManager.getCanaryInitImage(strimzi)).thenReturn("quay.io/mk-ci-cd/strimzi-canary:0.2.0-220111183833");
     }
 
+    @Test
+    void testHasClusterId() {
+        assertTrue(KafkaCluster.hasClusterId(new KafkaBuilder().withNewStatus().withClusterId("all-good").endStatus().build()));
+        assertFalse(KafkaCluster.hasClusterId(new KafkaBuilder().build()));
+        assertFalse(KafkaCluster.hasClusterId(null));
+    }
 
 }


### PR DESCRIPTION
Given that node auto-scaling can introduce a delay in the deployment of the kafka, it would be best to wait until it is ready before creating the other deployments, so that any applicable timeouts start only at that point.  

The only difference to this approach vs now is there will be a small delay in the instance being seen as ready, and if the kafka ends up in an error state that will be reported as Ready=False Reason=Installing - because the admin / canary will still be in the installing state. Given the direction of MGDSTRM-9395 / MGDSTRM-9498 that is probably ok - the fleetmanager doesn't want to show the installation in an failed state regardless until the slo has expired.  However it hasn't been, and still won't be, clear the difference between installing and error - so we may eventually want to refine that with separate conditions.