### PR TITLE
[MGDSTRM-9354] Pause ManagedKafka reconciliation based on annotation

### DIFF
--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaAgentController.java
@@ -12,6 +12,7 @@ import io.quarkus.scheduler.Scheduled;
 import io.quarkus.scheduler.Scheduled.ConcurrentExecution;
 import org.bf2.common.ConditionUtils;
 import org.bf2.common.ManagedKafkaAgentResourceClient;
+import org.bf2.operator.events.ControllerEventFilter;
 import org.bf2.operator.managers.ObservabilityManager;
 import org.bf2.operator.managers.StrimziManager;
 import org.bf2.operator.resources.v1alpha1.ClusterCapacity;
@@ -45,7 +46,10 @@ import java.util.List;
  * updates directly based upon the changes it sees in the ManagedKafka instances.
  */
 @ApplicationScoped
-@ControllerConfiguration(finalizerName = Constants.NO_FINALIZER)
+@ControllerConfiguration(
+        finalizerName = Constants.NO_FINALIZER,
+        generationAwareEventProcessing = false,
+        eventFilters = { ControllerEventFilter.class })
 public class ManagedKafkaAgentController implements Reconciler<ManagedKafkaAgent> {
 
     @Inject

--- a/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
+++ b/operator/src/main/java/org/bf2/operator/controllers/ManagedKafkaController.java
@@ -14,6 +14,7 @@ import io.micrometer.core.annotation.Counted;
 import io.micrometer.core.annotation.Timed;
 import org.bf2.common.ConditionUtils;
 import org.bf2.common.ManagedKafkaResourceClient;
+import org.bf2.operator.events.ControllerEventFilter;
 import org.bf2.operator.events.ResourceEventSource;
 import org.bf2.operator.managers.IngressControllerManager;
 import org.bf2.operator.managers.KafkaManager;
@@ -45,7 +46,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-@ControllerConfiguration(finalizerName = Constants.NO_FINALIZER)
+@ControllerConfiguration(
+        finalizerName = Constants.NO_FINALIZER,
+        generationAwareEventProcessing = false,
+        eventFilters = { ControllerEventFilter.class })
 public class ManagedKafkaController implements Reconciler<ManagedKafka>, EventSourceInitializer<HasMetadata> {
 
     // 1 for bootstrap URL + 1 for Admin API server

--- a/operator/src/main/java/org/bf2/operator/events/ControllerEventFilter.java
+++ b/operator/src/main/java/org/bf2/operator/events/ControllerEventFilter.java
@@ -1,0 +1,84 @@
+package org.bf2.operator.events;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.zjsonpatch.JsonDiff;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEventFilter;
+import org.jboss.logging.Logger;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Resource event filter for use with
+ * {@link io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration#eventFilters
+ * eventFilters} used by {@code ManagedKafka} and {@code ManagedKafkaAgent}
+ * controllers. This event filter will accept any change where the resource:
+ * <ul>
+ * <li>is added
+ * <li>generation has changed
+ * <li>annotations have changed
+ * <li>labels have changed
+ * </ul>
+ *
+ */
+public class ControllerEventFilter implements ResourceEventFilter<HasMetadata> {
+
+    private static Logger log = Logger.getLogger(ControllerEventFilter.class);
+
+    @Override
+    public boolean acceptChange(ControllerConfiguration<HasMetadata> configuration,
+            HasMetadata oldResource,
+            HasMetadata newResource) {
+
+        Optional<ObjectMeta> oldMeta = meta(oldResource);
+        Optional<ObjectMeta> newMeta = meta(newResource);
+
+        boolean resourceChanged =
+                oldResource == null || // Always accept an "add" change
+                changed(oldMeta, newMeta, this::generation) ||
+                changed(oldMeta, newMeta, this::annotations) ||
+                changed(oldMeta, newMeta, this::labels);
+
+        if (log.isDebugEnabled() && resourceChanged && oldResource != null) {
+            String kind = Optional.ofNullable(oldResource.getKind()).orElseGet(newResource::getKind);
+            String name = newMeta.map(ObjectMeta::getName).orElse("<UNKNOWN NAME>");
+            ObjectMapper objectMapper = Serialization.yamlMapper();
+            JsonNode expectedJson = objectMapper.convertValue(oldResource, JsonNode.class);
+            JsonNode actualJson = objectMapper.convertValue(newResource, JsonNode.class);
+            JsonNode patch = JsonDiff.asJson(expectedJson, actualJson);
+            log.debugf("%s/%s changed =>\n%s", kind, name, patch.toPrettyString());
+        }
+
+        return resourceChanged;
+    }
+
+    Optional<ObjectMeta> meta(HasMetadata resource) {
+        return Optional.ofNullable(resource).map(HasMetadata::getMetadata);
+    }
+
+    Long generation(Optional<ObjectMeta> meta) {
+        return meta.map(ObjectMeta::getGeneration).orElse(null);
+    }
+
+    Map<String, String> annotations(Optional<ObjectMeta> meta) {
+        return meta.map(ObjectMeta::getAnnotations).orElse(Collections.emptyMap());
+    }
+
+    Map<String, String> labels(Optional<ObjectMeta> meta) {
+        return meta.map(ObjectMeta::getLabels).orElse(Collections.emptyMap());
+    }
+
+    boolean changed(Optional<ObjectMeta> oldMeta, Optional<ObjectMeta> newMeta, Function<Optional<ObjectMeta>, Object> source) {
+        Object oldAttr = source.apply(oldMeta);
+        Object newAttr = source.apply(newMeta);
+        return !Objects.equals(oldAttr, newAttr);
+    }
+}

--- a/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
@@ -41,6 +41,7 @@ public class MetricsManager implements ResourceEventHandler<Kafka>{
     static final String KAFKA_INSTANCE_CONNECTION_LIMIT = "kafka_instance_connection_limit";
     static final String KAFKA_INSTANCE_CONNECTION_CREATION_RATE_LIMIT = "kafka_instance_connection_creation_rate_limit";
     static final String KAFKA_INSTANCE_QUOTA_CONSUMED = "kafka_instance_profile_quota_consumed";
+    public static final String KAFKA_INSTANCE_PAUSED = "kafka_instance_paused";
 
     static final String TAG_LABEL_OWNER = "owner";
     static final String TAG_LABEL_BROKER_ID = "broker_id";

--- a/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
@@ -1,5 +1,6 @@
 package org.bf2.operator.managers;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
@@ -111,7 +112,7 @@ public class MetricsManager implements ResourceEventHandler<Kafka>{
         orphanMeters.forEach(meterRegistry::remove);
     }
 
-    private Tags buildKafkaInstanceTags(Kafka obj) {
+    public static Tags buildKafkaInstanceTags(HasMetadata obj) {
         ObjectMeta metadata = obj.getMetadata();
         return Tags.of(Tag.of(TAG_LABEL_NAMESPACE, metadata.getNamespace()), Tag.of(TAG_LABEL_INSTANCE_NAME, metadata.getName()), OWNER);
     }

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstance.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstance.java
@@ -57,12 +57,12 @@ public class KafkaInstance implements Operand<ManagedKafka> {
         Tags tags = MetricsManager.buildKafkaInstanceTags(managedKafka);
 
         if (managedKafka.getAnnotation(ManagedKafkaKeys.Annotations.PAUSE_RECONCILIATION).map(Boolean::valueOf).orElse(false)) {
-            meterRegistry.gauge("kafka_instance_paused", tags, 1);
+            meterRegistry.gauge(MetricsManager.KAFKA_INSTANCE_PAUSED, tags, 1);
             return;
         }
 
         Search.in(meterRegistry)
-            .name("kafka_instance_paused")
+            .name(MetricsManager.KAFKA_INSTANCE_PAUSED)
             .tags(tags)
             .meters()
             .forEach(meterRegistry::remove);

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstance.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstance.java
@@ -109,7 +109,7 @@ public class KafkaInstance implements Operand<ManagedKafka> {
             return new OperandReadiness(isDeleted(managedKafka) ? Status.False : Status.Unknown, Reason.Deleted, null);
         }
         if (managedKafka.getAnnotation(ManagedKafkaKeys.Annotations.PAUSE_RECONCILIATION).map(Boolean::valueOf).orElse(false)) {
-            return new OperandReadiness(Status.Unknown, Reason.Paused, null);
+            return new OperandReadiness(Status.Unknown, Reason.Paused, "Reconciliation paused via annotation");
         }
         List<OperandReadiness> readiness = operands.stream().map(o -> o.getReadiness(managedKafka)).filter(Objects::nonNull).collect(Collectors.toList());
 

--- a/operator/src/test/java/org/bf2/operator/events/ControllerEventFilterTest.java
+++ b/operator/src/test/java/org/bf2/operator/events/ControllerEventFilterTest.java
@@ -1,0 +1,100 @@
+package org.bf2.operator.events;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import org.bf2.operator.resources.v1alpha1.ManagedKafka;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ControllerEventFilterTest {
+
+    ControllerEventFilter target;
+    ControllerConfiguration<HasMetadata> mockConfiguration;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setup() {
+        target = new ControllerEventFilter();
+        mockConfiguration = Mockito.mock(ControllerConfiguration.class);
+    }
+
+    @Test
+    void testAddResourceAccepted() {
+        assertTrue(target.acceptChange(mockConfiguration, null, new ManagedKafka()));
+    }
+
+    @Test
+    void testChangedGenerationAccepted() {
+        ManagedKafka oldMk = new ManagedKafkaBuilder()
+                .withNewMetadata()
+                    .withGeneration(1L)
+                .endMetadata()
+                .build();
+        ManagedKafka newMk = new ManagedKafkaBuilder()
+                .withNewMetadata()
+                    .withGeneration(2L)
+                .endMetadata()
+                .build();
+
+        assertTrue(target.acceptChange(mockConfiguration, oldMk, newMk));
+    }
+
+    @Test
+    void testChangedAnnotationsAccepted() {
+        ManagedKafka oldMk = new ManagedKafkaBuilder()
+                .withNewMetadata()
+                    .withAnnotations(Map.of("anno1", "v1"))
+                .endMetadata()
+                .build();
+        ManagedKafka newMk = new ManagedKafkaBuilder()
+                .withNewMetadata()
+                    .withAnnotations(Map.of("anno2", "v2"))
+                .endMetadata()
+                .build();
+
+        assertTrue(target.acceptChange(mockConfiguration, oldMk, newMk));
+    }
+
+    @Test
+    void testChangedLabelsAccepted() {
+        ManagedKafka oldMk = new ManagedKafkaBuilder()
+                .withNewMetadata()
+                    .withLabels(Map.of("label1", "v1"))
+                .endMetadata()
+                .build();
+        ManagedKafka newMk = new ManagedKafkaBuilder()
+                .withNewMetadata()
+                    .withLabels(Map.of("label2", "v2"))
+                .endMetadata()
+                .build();
+
+        assertTrue(target.acceptChange(mockConfiguration, oldMk, newMk));
+    }
+
+    @Test
+    void testUnchangedNotAccepted() {
+        ManagedKafka oldMk = new ManagedKafkaBuilder()
+                .withNewMetadata()
+                    .withGeneration(1L)
+                    .withAnnotations(Map.of("anno1", "v1"))
+                    .withLabels(Map.of("label1", "v1"))
+                .endMetadata()
+                .build();
+        ManagedKafka newMk = new ManagedKafkaBuilder()
+                .withNewMetadata()
+                    .withGeneration(1L)
+                    .withAnnotations(Map.of("anno1", "v1"))
+                    .withLabels(Map.of("label1", "v1"))
+                .endMetadata()
+                .build();
+
+        assertFalse(target.acceptChange(mockConfiguration, oldMk, newMk));
+    }
+}

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaInstanceTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaInstanceTest.java
@@ -17,7 +17,6 @@ import javax.inject.Inject;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
@@ -101,7 +100,7 @@ public class KafkaInstanceTest {
         OperandReadiness readiness = kafkaInstance.getReadiness(pausedInstance);
         assertEquals(Status.Unknown, readiness.getStatus());
         assertEquals(Reason.Paused, readiness.getReason());
-        assertNull(readiness.getMessage());
+        assertEquals("Reconciliation paused via annotation", readiness.getMessage());
     }
 
     @Test

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaInstanceTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaInstanceTest.java
@@ -1,20 +1,24 @@
 package org.bf2.operator.operands;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import org.bf2.operator.ManagedKafkaKeys;
+import org.bf2.operator.managers.MetricsManager;
 import org.bf2.operator.managers.SecuritySecretManager;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Reason;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaCondition.Status;
 import org.bf2.operator.utils.ManagedKafkaUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import javax.inject.Inject;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,7 +28,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
-public class KafkaInstanceTest {
+class KafkaInstanceTest {
 
     private static final ManagedKafka DUMMY_MANAGED_KAFKA = ManagedKafkaUtils.dummyManagedKafka("x");
 
@@ -41,7 +45,15 @@ public class KafkaInstanceTest {
     SecuritySecretManager securitySecretManager;
 
     @Inject
+    MeterRegistry meterRegistry;
+
+    @Inject
     KafkaInstance kafkaInstance;
+
+    @AfterEach
+    void teardown() {
+        meterRegistry.forEachMeter(meterRegistry::remove);
+    }
 
     @Test
     void statusInstallingTrumpsError() {
@@ -96,11 +108,29 @@ public class KafkaInstanceTest {
     @Test
     void statusUnknownWhenPaused() {
         ManagedKafka pausedInstance = ManagedKafkaUtils.dummyManagedKafka("x");
+        OperandReadiness readiness;
+
+        when(kafkaCluster.getReadiness(pausedInstance)).thenReturn(new OperandReadiness(Status.False, Reason.Installing, null));
+        when(canary.getReadiness(pausedInstance)).thenReturn(new OperandReadiness(Status.False, Reason.Installing, null));
+        when(adminServer.getReadiness(pausedInstance)).thenReturn(new OperandReadiness(Status.False, Reason.Installing, null));
+
         pausedInstance.getMetadata().setAnnotations(Map.of(ManagedKafkaKeys.Annotations.PAUSE_RECONCILIATION, "true"));
-        OperandReadiness readiness = kafkaInstance.getReadiness(pausedInstance);
+        readiness = kafkaInstance.getReadiness(pausedInstance);
         assertEquals(Status.Unknown, readiness.getStatus());
         assertEquals(Reason.Paused, readiness.getReason());
         assertEquals("Reconciliation paused via annotation", readiness.getMessage());
+
+        pausedInstance.getMetadata().setAnnotations(Map.of(ManagedKafkaKeys.Annotations.PAUSE_RECONCILIATION, "false"));
+        readiness = kafkaInstance.getReadiness(pausedInstance);
+        assertEquals(Status.False, readiness.getStatus());
+        assertEquals(Reason.Installing, readiness.getReason());
+        assertEquals("", readiness.getMessage());
+
+        pausedInstance.getMetadata().setAnnotations(Collections.emptyMap());
+        readiness = kafkaInstance.getReadiness(pausedInstance);
+        assertEquals(Status.False, readiness.getStatus());
+        assertEquals(Reason.Installing, readiness.getReason());
+        assertEquals("", readiness.getMessage());
     }
 
     @Test
@@ -136,6 +166,7 @@ public class KafkaInstanceTest {
         inOrder.verify(kafkaCluster, times(1)).createOrUpdate(DUMMY_MANAGED_KAFKA);
         inOrder.verify(canary, times(1)).createOrUpdate(DUMMY_MANAGED_KAFKA);
         inOrder.verify(adminServer, times(1)).createOrUpdate(DUMMY_MANAGED_KAFKA);
+        assertEquals(0, meterRegistry.find(MetricsManager.KAFKA_INSTANCE_PAUSED).gauges().size());
     }
 
     @Test
@@ -148,5 +179,6 @@ public class KafkaInstanceTest {
         inOrder.verify(kafkaCluster, never()).createOrUpdate(pausedInstance);
         inOrder.verify(canary, never()).createOrUpdate(pausedInstance);
         inOrder.verify(adminServer, never()).createOrUpdate(pausedInstance);
+        assertEquals(1, meterRegistry.find(MetricsManager.KAFKA_INSTANCE_PAUSED).gauge().value());
     }
 }

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaInstanceTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaInstanceTest.java
@@ -146,8 +146,8 @@ public class KafkaInstanceTest {
         kafkaInstance.createOrUpdate(pausedInstance);
 
         InOrder inOrder = inOrder(kafkaCluster, canary, adminServer);
-        inOrder.verify(kafkaCluster, never()).createOrUpdate(DUMMY_MANAGED_KAFKA);
-        inOrder.verify(canary, never()).createOrUpdate(DUMMY_MANAGED_KAFKA);
-        inOrder.verify(adminServer, never()).createOrUpdate(DUMMY_MANAGED_KAFKA);
+        inOrder.verify(kafkaCluster, never()).createOrUpdate(pausedInstance);
+        inOrder.verify(canary, never()).createOrUpdate(pausedInstance);
+        inOrder.verify(adminServer, never()).createOrUpdate(pausedInstance);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <strimzi.version>0.26.0</strimzi.version>
         <fabric8.client.version>5.12.2</fabric8.client.version>
-        <quarkus.operator.extension>3.0.7</quarkus.operator.extension>
+        <quarkus.operator.extension>3.0.9</quarkus.operator.extension>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <junit.platform.version>1.7.2</junit.platform.version>
         <sundrio.version>0.50.4</sundrio.version>
@@ -73,7 +73,7 @@
         <format.skip>false</format.skip>
         <findbugs.annotations.version>3.0.0</findbugs.annotations.version>
         <jakarta.validation.version>2.0.2</jakarta.validation.version>
-        
+
         <!-- Override version for maven-install-plugin because there is a bug in
              3.0.0-M1 preventing installing of modules with packaging of feature
              see: https://issues.apache.org/jira/browse/MINSTALL-151 -->


### PR DESCRIPTION
- Pause ManagedKafka reconciliation based on annotation `managedkafka.bf2.org/pause-reconciliation=true`
- Update quarkus-operatork-sdk to 3.0.9 + implement event filter to process events for modified generation or changes to labels/annotations
