### PR TITLE
MGDSTRM-9567 MGDSTRM-9555 allowing for the transition from 3 to 2

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -457,11 +457,13 @@ public class IngressControllerManager {
         LongSummaryStatistics egress = summarize(kafkas, KafkaCluster::getFetchQuota, () -> {throw new IllegalStateException("A kafka lacks a fetch quota");});
         LongSummaryStatistics ingress = summarize(kafkas, KafkaCluster::getProduceQuota, () -> {throw new IllegalStateException("A kafka lacks a produce quota");});
 
+        // there is an assumption that the nodes / brokers will be balanced by zone
+        double zonePercentage = 1d / ingressControllers.size();
         ingressControllers.entrySet().stream().forEach(e -> {
             String zone = e.getKey();
             String kasZone = "kas-" + zone;
             String domain = kasZone + "." + clusterDomain;
-            int replicas = numReplicasForZone(zone, nodeInformer.getList(), ingress, egress, connectionDemand);
+            int replicas = numReplicasForZone(zone, ingress, egress, connectionDemand, zonePercentage);
 
             Map<String, String> routeMatchLabel = Map.of(ManagedKafkaKeys.forKey(kasZone), "true");
             LabelSelector routeSelector = new LabelSelector(null, routeMatchLabel);
@@ -474,7 +476,7 @@ public class IngressControllerManager {
     private void buildDefaultIngressController(List<String> zones, String clusterDomain, long connectionDemand) {
         IngressController existing = ingressControllerInformer.getByKey(Cache.namespaceKeyFunc(INGRESS_OPERATOR_NAMESPACE, "kas"));
 
-        int replicas = numReplicasForAllZones(nodeInformer.getList(), connectionDemand);
+        int replicas = numReplicasForAllZones(connectionDemand);
 
         final Map<String, String> routeMatchLabel = Map.of(Labels.KAS_MULTI_ZONE, "true");
         LabelSelector routeSelector = new LabelSelector(null, routeMatchLabel);
@@ -493,6 +495,12 @@ public class IngressControllerManager {
         // retain replicas as long as we're above the min reduction
         if (existingReplicas != null && existingReplicas - replicas <= MIN_REPLICA_REDUCTION) {
             replicas = Math.max(existingReplicas, replicas);
+        }
+
+        // enforce a minimum of two replicas on clusters that can accommodate it - which may change if we don't want to
+        // provide pod / node level HA for the az specific replicas.
+        if (replicas == 1 && nodeInformer.getList().size() > 3) {
+            replicas = 2;
         }
 
         builder
@@ -555,18 +563,12 @@ public class IngressControllerManager {
         createOrEdit(builder.build(), existing);
     }
 
-    int numReplicasForZone(String zone, List<Node> nodes, LongSummaryStatistics ingress, LongSummaryStatistics egress, long connectionDemand) {
+    int numReplicasForZone(String zone, LongSummaryStatistics ingress, LongSummaryStatistics egress,
+            long connectionDemand, double zonePercentage) {
         // use the override if present
         if (azReplicaCount.isPresent()) {
             return azReplicaCount.get();
         }
-
-        int nodesInZone = Math.toIntExact(nodes.stream()
-                .filter(node -> zone.equals(node.getMetadata().getLabels().get(TOPOLOGY_KEY)))
-                .filter(Objects::nonNull)
-                .count());
-
-        double zonePercentage = nodesInZone / (double)nodes.size();
 
         long throughput = (egress.getMax() + ingress.getMax())/2;
         long replicationThroughput = ingress.getMax()*2;
@@ -589,12 +591,7 @@ public class IngressControllerManager {
         int replicaCount = (int)Math.ceil(throughputDemanded / throughputPerIngressReplica);
         int connectionReplicaCount = numReplicasForConnectionDemand((long) (connectionDemand * zonePercentage));
 
-        /*
-         * we want at least 2 replicas, unless there are fewer nodes
-         * each replica roughly has the responsibility for access to NODES_PER_REPLICA nodes
-         * we'll therefore scale up after 2*NODES_PER_REPLICA nodes in the zone
-         */
-        return Math.min(nodesInZone, Math.max(2, Math.max(connectionReplicaCount, replicaCount)));
+        return Math.max(1, Math.max(connectionReplicaCount, replicaCount));
     }
 
     static LongSummaryStatistics summarize(List<Kafka> kafkas, Function<Kafka, String> quantity,
@@ -609,18 +606,16 @@ public class IngressControllerManager {
                 .summaryStatistics();
     }
 
-    int numReplicasForAllZones(List<Node> nodes, long connectionDemand) {
+    int numReplicasForAllZones(long connectionDemand) {
         // use the override if present
         if (defaultReplicaCount.isPresent()) {
             return defaultReplicaCount.get();
         }
 
         /*
-         * we want at least 2 replicas, unless there are fewer nodes
-         *
          * an assumption here is that these ingress replicas will not become bandwidth constrained - but that may need further qualification
          */
-        return Math.min(nodes.size(), Math.max(2, numReplicasForConnectionDemand(connectionDemand)));
+        return numReplicasForConnectionDemand(connectionDemand);
     }
 
     private int numReplicasForConnectionDemand(double connectionDemand) {

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -125,7 +125,7 @@ public class IngressControllerManagerTest {
     }
 
     @Test
-    public void testReplicaReduction3to2() {
+    void testReplicaReduction3to2() {
         openShiftClient.resourceList((List)buildNodes(12)).createOrReplace();
 
         IntStream.range(0, 3).forEach(i -> {
@@ -219,28 +219,28 @@ public class IngressControllerManagerTest {
     public void testIngressControllerReplicaCounts() {
         List<Node> nodes = buildNodes(9);
 
-        assertEquals(1, ingressControllerManager.numReplicasForAllZones(3000));
-        assertEquals(1, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(), new LongSummaryStatistics(), 0, ZONE_PERCENTAGE));
+        assertEquals(1, ingressControllerManager.numReplicasForDefault(3000));
+        assertEquals(1, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(), new LongSummaryStatistics(), 0, ZONE_PERCENTAGE));
 
         nodes = buildNodes(210);
 
-        assertEquals(3, ingressControllerManager.numReplicasForAllZones(160000));
-        assertEquals(1, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(1, 0, 30000000, 1500000000), new LongSummaryStatistics(1, 0, 30000000, 1500000000), 0, ZONE_PERCENTAGE));
-        assertEquals(3, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(), new LongSummaryStatistics(), 480000, ZONE_PERCENTAGE));
+        assertEquals(3, ingressControllerManager.numReplicasForDefault(160000));
+        assertEquals(1, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(1, 0, 30000000, 1500000000), new LongSummaryStatistics(1, 0, 30000000, 1500000000), 0, ZONE_PERCENTAGE));
+        assertEquals(3, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(), new LongSummaryStatistics(), 480000, ZONE_PERCENTAGE));
 
         nodes = buildNodes(310);
 
         long ingress = 50000000;
-        assertEquals(5, ingressControllerManager.numReplicasForAllZones(370000));
-        assertEquals(4, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(1, 0, ingress, ingress*60), new LongSummaryStatistics(1, 0, ingress*2, ingress*120), 0, ZONE_PERCENTAGE));
+        assertEquals(5, ingressControllerManager.numReplicasForDefault(370000));
+        assertEquals(4, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(1, 0, ingress, ingress*60), new LongSummaryStatistics(1, 0, ingress*2, ingress*120), 0, ZONE_PERCENTAGE));
     }
 
     @Test
     public void testIngressControllerReplicaCounts1() {
         List<Node> nodes = buildNodes(99);
 
-        assertEquals(1, ingressControllerManager.numReplicasForAllZones(3000*24));
-        assertEquals(2, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(1, 0, Quantity.getAmountInBytes(Quantity.parse("50Mi")).longValue(), Quantity.getAmountInBytes(Quantity.parse("50Mi")).longValue()*24), new LongSummaryStatistics(1, 0, Quantity.getAmountInBytes(Quantity.parse("100Mi")).longValue(), Quantity.getAmountInBytes(Quantity.parse("100Mi")).longValue()*24), 0, ZONE_PERCENTAGE));
+        assertEquals(1, ingressControllerManager.numReplicasForDefault(3000*24));
+        assertEquals(2, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(1, 0, Quantity.getAmountInBytes(Quantity.parse("50Mi")).longValue(), Quantity.getAmountInBytes(Quantity.parse("50Mi")).longValue()*24), new LongSummaryStatistics(1, 0, Quantity.getAmountInBytes(Quantity.parse("100Mi")).longValue(), Quantity.getAmountInBytes(Quantity.parse("100Mi")).longValue()*24), 0, ZONE_PERCENTAGE));
     }
 
     private List<Node> buildNodes(int nodeCount) {

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -53,6 +53,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 public class IngressControllerManagerTest {
 
+    private static final double ZONE_PERCENTAGE = 1d/3;
+
     @Inject
     IngressControllerManager ingressControllerManager;
 
@@ -105,18 +107,45 @@ public class IngressControllerManagerTest {
         informerManager.createKafkaInformer();
 
         ingressControllerManager.reconcileIngressControllers();
-        checkAzReplicaCount(4);
+        // this is more than the number of nodes, but we're presuming node scaling is available
+        checkAzReplicaCount(5);
 
         // remove two kafkas - we should keep the same number of replicas
         var kafkas = openShiftClient.resources(Kafka.class).inNamespace("ingressTest");
         assertTrue(kafkas.withName("ingressTest0").delete());
         assertTrue(kafkas.withName("ingressTest1").delete());
         ingressControllerManager.reconcileIngressControllers();
-        checkAzReplicaCount(4);
+        checkAzReplicaCount(5);
 
         // remove two more kafkas - and we should reduce
         assertTrue(kafkas.withName("ingressTest2").delete());
         assertTrue(kafkas.withName("ingressTest3").delete());
+        ingressControllerManager.reconcileIngressControllers();
+        checkAzReplicaCount(2);
+    }
+
+    @Test
+    public void testReplicaReduction3to2() {
+        openShiftClient.resourceList((List)buildNodes(12)).createOrReplace();
+
+        IntStream.range(0, 3).forEach(i -> {
+            ManagedKafka mk = ManagedKafka.getDummyInstance(1);
+            mk.getMetadata().setName("ingressTest" + i);
+            mk.getMetadata().setNamespace("ingressTest");
+            mk.getSpec().getCapacity().setIngressPerSec(Quantity.parse("300Mi"));
+            mk.getSpec().getCapacity().setEgressPerSec(Quantity.parse("300Mi"));
+            Kafka kafka = this.kafkaCluster.kafkaFrom(mk, null);
+            openShiftClient.resource(kafka).createOrReplace();
+        });
+        informerManager.createKafkaInformer();
+
+        ingressControllerManager.reconcileIngressControllers();
+        checkAzReplicaCount(3);
+
+        // remove two kafkas - we should reduce to 2
+        var kafkas = openShiftClient.resources(Kafka.class).inNamespace("ingressTest");
+        assertTrue(kafkas.withName("ingressTest0").delete());
+        assertTrue(kafkas.withName("ingressTest1").delete());
         ingressControllerManager.reconcileIngressControllers();
         checkAzReplicaCount(2);
     }
@@ -190,28 +219,28 @@ public class IngressControllerManagerTest {
     public void testIngressControllerReplicaCounts() {
         List<Node> nodes = buildNodes(9);
 
-        assertEquals(2, ingressControllerManager.numReplicasForAllZones(nodes, 3000));
-        assertEquals(2, ingressControllerManager.numReplicasForZone("zone0", nodes, new LongSummaryStatistics(), new LongSummaryStatistics(), 0));
+        assertEquals(1, ingressControllerManager.numReplicasForAllZones(3000));
+        assertEquals(1, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(), new LongSummaryStatistics(), 0, ZONE_PERCENTAGE));
 
         nodes = buildNodes(210);
 
-        assertEquals(3, ingressControllerManager.numReplicasForAllZones(nodes, 160000));
-        assertEquals(2, ingressControllerManager.numReplicasForZone("zone0", nodes, new LongSummaryStatistics(1, 0, 30000000, 1500000000), new LongSummaryStatistics(1, 0, 30000000, 1500000000), 0));
-        assertEquals(3, ingressControllerManager.numReplicasForZone("zone0", nodes, new LongSummaryStatistics(), new LongSummaryStatistics(), 480000));
+        assertEquals(3, ingressControllerManager.numReplicasForAllZones(160000));
+        assertEquals(1, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(1, 0, 30000000, 1500000000), new LongSummaryStatistics(1, 0, 30000000, 1500000000), 0, ZONE_PERCENTAGE));
+        assertEquals(3, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(), new LongSummaryStatistics(), 480000, ZONE_PERCENTAGE));
 
         nodes = buildNodes(310);
 
         long ingress = 50000000;
-        assertEquals(5, ingressControllerManager.numReplicasForAllZones(nodes, 370000));
-        assertEquals(4, ingressControllerManager.numReplicasForZone("zone0", nodes, new LongSummaryStatistics(1, 0, ingress, ingress*60), new LongSummaryStatistics(1, 0, ingress*2, ingress*120), 0));
+        assertEquals(5, ingressControllerManager.numReplicasForAllZones(370000));
+        assertEquals(4, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(1, 0, ingress, ingress*60), new LongSummaryStatistics(1, 0, ingress*2, ingress*120), 0, ZONE_PERCENTAGE));
     }
 
     @Test
     public void testIngressControllerReplicaCounts1() {
         List<Node> nodes = buildNodes(99);
 
-        assertEquals(2, ingressControllerManager.numReplicasForAllZones(nodes, 3000*24));
-        assertEquals(2, ingressControllerManager.numReplicasForZone("zone0", nodes, new LongSummaryStatistics(1, 0, Quantity.getAmountInBytes(Quantity.parse("50Mi")).longValue(), Quantity.getAmountInBytes(Quantity.parse("50Mi")).longValue()*24), new LongSummaryStatistics(1, 0, Quantity.getAmountInBytes(Quantity.parse("100Mi")).longValue(), Quantity.getAmountInBytes(Quantity.parse("100Mi")).longValue()*24), 0));
+        assertEquals(1, ingressControllerManager.numReplicasForAllZones(3000*24));
+        assertEquals(2, ingressControllerManager.numReplicasForZone("zone0", new LongSummaryStatistics(1, 0, Quantity.getAmountInBytes(Quantity.parse("50Mi")).longValue(), Quantity.getAmountInBytes(Quantity.parse("50Mi")).longValue()*24), new LongSummaryStatistics(1, 0, Quantity.getAmountInBytes(Quantity.parse("100Mi")).longValue(), Quantity.getAmountInBytes(Quantity.parse("100Mi")).longValue()*24), 0, ZONE_PERCENTAGE));
     }
 
     private List<Node> buildNodes(int nodeCount) {


### PR DESCRIPTION
also simplifying the logic based upon the possibility of dynamic scaling and node balancing - since we are enforcing balanced node scaling and have the topology spread constraint / scaling factor on brokers, we shouldn't need any deep node logic here.