### PR TITLE
[MGDSTRM-9509] Bump Strimzi API version from 0.26.0 to 0.29.0

### DIFF
--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -63,6 +63,7 @@ spec:
           host: "broker-4-xxx.yyy.zzz"
         - broker: 5
           host: "broker-5-xxx.yyy.zzz"
+        createBootstrapService: true
         maxConnections: 500
         maxConnectionCreationRate: 50
     - name: "oauth"

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -54,6 +54,7 @@ spec:
         brokers:
         - broker: 0
           host: "broker-0-xxx.yyy.zzz"
+        createBootstrapService: true
         maxConnections: 100
         maxConnectionCreationRate: 50
     - name: "oauth"

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -57,6 +57,7 @@ spec:
           host: "broker-1-xxx.yyy.zzz"
         - broker: 2
           host: "broker-2-xxx.yyy.zzz"
+        createBootstrapService: true
         maxConnections: 1000
         maxConnectionCreationRate: 33
     - name: "oauth"

--- a/operator/src/test/resources/expected/strimzi_su2.yml
+++ b/operator/src/test/resources/expected/strimzi_su2.yml
@@ -63,6 +63,7 @@ spec:
               host: "broker-4-xxx.yyy.zzz"
             - broker: 5
               host: "broker-5-xxx.yyy.zzz"
+          createBootstrapService: true
           maxConnections: 33
           maxConnectionCreationRate: 16
       - name: "oauth"

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <quarkus.platform.test.version>2.7.6.Final</quarkus.platform.test.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-        <strimzi.version>0.26.0</strimzi.version>
+        <strimzi.version>0.29.0</strimzi.version>
         <fabric8.client.version>5.12.2</fabric8.client.version>
         <quarkus.operator.extension>3.0.9</quarkus.operator.extension>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>


### PR DESCRIPTION
Note that new property `createBootstrapService` is present with default value `true`. This property only applies to the load balancer listener type (not ingress/route types) - see [1] for more info.

[1] https://github.com/strimzi/strimzi-kafka-operator/pull/6170