### PR TITLE
MGDSTRM-9508 making sure the developer instances are movable

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -475,6 +475,12 @@ public class KafkaCluster extends AbstractKafkaCluster {
 
         podTemplateBuilder.addAllToTolerations(OperandUtils.profileTolerations(managedKafka));
 
+        if (replicas == 1) {
+            podTemplateBuilder.editOrNewMetadata()
+                    .addToAnnotations("cluster-autoscaler.kubernetes.io/safe-to-evict", "true")
+                    .endMetadata();
+        }
+
         KafkaClusterTemplateBuilder templateBuilder = new KafkaClusterTemplateBuilder()
                 .withPod(podTemplateBuilder.build());
 

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -212,6 +212,9 @@ spec:
           optional: false
     template:
       pod:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         affinity:
           podAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
PodSet pods won't have a parent deployment.  This annotation will allow them to still be movable by the auto-scaler.  This does not yet address a non-developer bin-packing scenario as we're not sure if that will be needed.