### PR TITLE
MGDSTRM-9666 removing labels that may change from reserved selectors

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapKeySelector;
 import io.fabric8.kubernetes.api.model.ConfigMapKeySelectorBuilder;
 import io.fabric8.kubernetes.api.model.LabelSelector;
 import io.fabric8.kubernetes.api.model.NodeAffinity;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimStatus;
 import io.fabric8.kubernetes.api.model.PodAffinityTerm;
 import io.fabric8.kubernetes.api.model.PodAffinityTermBuilder;
@@ -226,7 +227,10 @@ public class KafkaCluster extends AbstractKafkaCluster {
         }
         PodTemplate template = templateExtractor.apply(spec);
         Deployment current = informerManager.getLocalDeployment(managedKafka.getMetadata().getNamespace(), name);
-        Deployment reserved = ReservedDeploymentConverter.asReservedDeployment(current, managedKafka, name, kafka.getMetadata(),
+        Deployment reserved = ReservedDeploymentConverter.asReservedDeployment(current, managedKafka, name,
+                new ObjectMetaBuilder(kafka.getMetadata()).withLabels(OperandUtils.getDefaultLabels())
+                        .addToLabels("app", name)
+                        .build(),
                 replicasExtractor.apply(spec), template,
                 resourceExtractor.apply(spec));
 

--- a/operator/src/test/resources/expected/reserved-cruisecontrol.yml
+++ b/operator/src/test/resources/expected/reserved-cruisecontrol.yml
@@ -5,13 +5,7 @@
     generation: 1
     labels:
       app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-      bf2.org/deployment: "reserved"
-      ingressType: "sharded"
-      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-      managedkafka.bf2.org/kas-zone2: "true"
-      managedkafka.bf2.org/kas-zone1: "true"
-      managedkafka.bf2.org/kas-zone0: "true"
-      managedkafka.bf2.org/kas-multi-zone: "true"
+      app: "test-mk-cruisecontrol"
     name: "test-mk-cruisecontrol"
     namespace: "reserved"
     ownerReferences:
@@ -23,24 +17,12 @@
     selector:
       matchLabels:
         app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-        bf2.org/deployment: "reserved"
-        ingressType: "sharded"
-        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-        managedkafka.bf2.org/kas-zone2: "true"
-        managedkafka.bf2.org/kas-zone1: "true"
-        managedkafka.bf2.org/kas-zone0: "true"
-        managedkafka.bf2.org/kas-multi-zone: "true"
+        app: "test-mk-cruisecontrol"
     template:
       metadata:
         labels:
           app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-          bf2.org/deployment: "reserved"
-          ingressType: "sharded"
-          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-          managedkafka.bf2.org/kas-zone2: "true"
-          managedkafka.bf2.org/kas-zone1: "true"
-          managedkafka.bf2.org/kas-zone0: "true"
-          managedkafka.bf2.org/kas-multi-zone: "true"
+          app: "test-mk-cruisecontrol"
           strimzi.io/name: "test-mk-cruisecontrol"
         name: "test-mk-cruisecontrol"
       spec:
@@ -62,13 +44,7 @@
     generation: 1
     labels:
       app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-      bf2.org/deployment: "reserved"
-      ingressType: "sharded"
-      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-      managedkafka.bf2.org/kas-zone2: "true"
-      managedkafka.bf2.org/kas-zone1: "true"
-      managedkafka.bf2.org/kas-zone0: "true"
-      managedkafka.bf2.org/kas-multi-zone: "true"
+      app: "test-mk-exporter"
     name: "test-mk-exporter"
     namespace: "reserved"
     ownerReferences:
@@ -80,24 +56,12 @@
     selector:
       matchLabels:
         app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-        bf2.org/deployment: "reserved"
-        ingressType: "sharded"
-        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-        managedkafka.bf2.org/kas-zone2: "true"
-        managedkafka.bf2.org/kas-zone1: "true"
-        managedkafka.bf2.org/kas-zone0: "true"
-        managedkafka.bf2.org/kas-multi-zone: "true"
+        app: "test-mk-exporter"
     template:
       metadata:
         labels:
           app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-          bf2.org/deployment: "reserved"
-          ingressType: "sharded"
-          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-          managedkafka.bf2.org/kas-zone2: "true"
-          managedkafka.bf2.org/kas-zone1: "true"
-          managedkafka.bf2.org/kas-zone0: "true"
-          managedkafka.bf2.org/kas-multi-zone: "true"
+          app: "test-mk-exporter"
           strimzi.io/name: "test-mk-exporter"
         name: "test-mk-exporter"
       spec:
@@ -131,13 +95,7 @@
     generation: 1
     labels:
       app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-      bf2.org/deployment: "reserved"
-      ingressType: "sharded"
-      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-      managedkafka.bf2.org/kas-zone2: "true"
-      managedkafka.bf2.org/kas-zone1: "true"
-      managedkafka.bf2.org/kas-zone0: "true"
-      managedkafka.bf2.org/kas-multi-zone: "true"
+      app: "test-mk-kafka"
     name: "test-mk-kafka"
     namespace: "reserved"
     ownerReferences:
@@ -149,24 +107,12 @@
     selector:
       matchLabels:
         app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-        bf2.org/deployment: "reserved"
-        ingressType: "sharded"
-        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-        managedkafka.bf2.org/kas-zone2: "true"
-        managedkafka.bf2.org/kas-zone1: "true"
-        managedkafka.bf2.org/kas-zone0: "true"
-        managedkafka.bf2.org/kas-multi-zone: "true"
+        app: "test-mk-kafka"
     template:
       metadata:
         labels:
           app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-          bf2.org/deployment: "reserved"
-          ingressType: "sharded"
-          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-          managedkafka.bf2.org/kas-zone2: "true"
-          managedkafka.bf2.org/kas-zone1: "true"
-          managedkafka.bf2.org/kas-zone0: "true"
-          managedkafka.bf2.org/kas-multi-zone: "true"
+          app: "test-mk-kafka"
           strimzi.io/name: "test-mk-kafka"
         name: "test-mk-kafka"
       spec:
@@ -214,13 +160,7 @@
     generation: 1
     labels:
       app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-      bf2.org/deployment: "reserved"
-      ingressType: "sharded"
-      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-      managedkafka.bf2.org/kas-zone2: "true"
-      managedkafka.bf2.org/kas-zone1: "true"
-      managedkafka.bf2.org/kas-zone0: "true"
-      managedkafka.bf2.org/kas-multi-zone: "true"
+      app: "test-mk-zookeeper"
     name: "test-mk-zookeeper"
     namespace: "reserved"
     ownerReferences:
@@ -232,24 +172,12 @@
     selector:
       matchLabels:
         app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-        bf2.org/deployment: "reserved"
-        ingressType: "sharded"
-        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-        managedkafka.bf2.org/kas-zone2: "true"
-        managedkafka.bf2.org/kas-zone1: "true"
-        managedkafka.bf2.org/kas-zone0: "true"
-        managedkafka.bf2.org/kas-multi-zone: "true"
+        app: "test-mk-zookeeper"
     template:
       metadata:
         labels:
           app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-          bf2.org/deployment: "reserved"
-          ingressType: "sharded"
-          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-          managedkafka.bf2.org/kas-zone2: "true"
-          managedkafka.bf2.org/kas-zone1: "true"
-          managedkafka.bf2.org/kas-zone0: "true"
-          managedkafka.bf2.org/kas-multi-zone: "true"
+          app: "test-mk-zookeeper"
           strimzi.io/name: "test-mk-zookeeper"
         name: "test-mk-zookeeper"
       spec:

--- a/operator/src/test/resources/expected/reserved.yml
+++ b/operator/src/test/resources/expected/reserved.yml
@@ -5,13 +5,7 @@
     generation: 1
     labels:
       app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-      bf2.org/deployment: "reserved"
-      ingressType: "sharded"
-      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-      managedkafka.bf2.org/kas-zone0: "true"
-      managedkafka.bf2.org/kas-zone1: "true"
-      managedkafka.bf2.org/kas-zone2: "true"
-      managedkafka.bf2.org/kas-multi-zone: "true"
+      app: "test-mk-exporter"
     name: "test-mk-exporter"
     namespace: "reserved"
     ownerReferences:
@@ -23,24 +17,12 @@
     selector:
       matchLabels:
         app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-        bf2.org/deployment: "reserved"
-        ingressType: "sharded"
-        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-        managedkafka.bf2.org/kas-zone0: "true"
-        managedkafka.bf2.org/kas-zone1: "true"
-        managedkafka.bf2.org/kas-zone2: "true"
-        managedkafka.bf2.org/kas-multi-zone: "true"
+        app: "test-mk-exporter"
     template:
       metadata:
         labels:
           app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-          bf2.org/deployment: "reserved"
-          ingressType: "sharded"
-          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-          managedkafka.bf2.org/kas-zone0: "true"
-          managedkafka.bf2.org/kas-zone1: "true"
-          managedkafka.bf2.org/kas-zone2: "true"
-          managedkafka.bf2.org/kas-multi-zone: "true"
+          app: "test-mk-exporter"
           strimzi.io/name: "test-mk-exporter"
         name: "test-mk-exporter"
       spec:
@@ -74,13 +56,7 @@
     generation: 1
     labels:
       app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-      bf2.org/deployment: "reserved"
-      ingressType: "sharded"
-      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-      managedkafka.bf2.org/kas-zone0: "true"
-      managedkafka.bf2.org/kas-zone1: "true"
-      managedkafka.bf2.org/kas-zone2: "true"
-      managedkafka.bf2.org/kas-multi-zone: "true"
+      app: "test-mk-kafka"
     name: "test-mk-kafka"
     namespace: "reserved"
     ownerReferences:
@@ -92,24 +68,12 @@
     selector:
       matchLabels:
         app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-        bf2.org/deployment: "reserved"
-        ingressType: "sharded"
-        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-        managedkafka.bf2.org/kas-zone0: "true"
-        managedkafka.bf2.org/kas-zone1: "true"
-        managedkafka.bf2.org/kas-zone2: "true"
-        managedkafka.bf2.org/kas-multi-zone: "true"
+        app: "test-mk-kafka"
     template:
       metadata:
         labels:
           app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-          bf2.org/deployment: "reserved"
-          ingressType: "sharded"
-          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-          managedkafka.bf2.org/kas-zone0: "true"
-          managedkafka.bf2.org/kas-zone1: "true"
-          managedkafka.bf2.org/kas-zone2: "true"
-          managedkafka.bf2.org/kas-multi-zone: "true"
+          app: "test-mk-kafka"
           strimzi.io/name: "test-mk-kafka"
         name: "test-mk-kafka"
       spec:
@@ -157,13 +121,7 @@
     generation: 1
     labels:
       app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-      bf2.org/deployment: "reserved"
-      ingressType: "sharded"
-      managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-      managedkafka.bf2.org/kas-zone0: "true"
-      managedkafka.bf2.org/kas-zone1: "true"
-      managedkafka.bf2.org/kas-zone2: "true"
-      managedkafka.bf2.org/kas-multi-zone: "true"
+      app: "test-mk-zookeeper"
     name: "test-mk-zookeeper"
     namespace: "reserved"
     ownerReferences:
@@ -175,24 +133,12 @@
     selector:
       matchLabels:
         app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-        bf2.org/deployment: "reserved"
-        ingressType: "sharded"
-        managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-        managedkafka.bf2.org/kas-zone0: "true"
-        managedkafka.bf2.org/kas-zone1: "true"
-        managedkafka.bf2.org/kas-zone2: "true"
-        managedkafka.bf2.org/kas-multi-zone: "true"
+        app: "test-mk-zookeeper"
     template:
       metadata:
         labels:
           app.kubernetes.io/managed-by: "kas-fleetshard-operator"
-          bf2.org/deployment: "reserved"
-          ingressType: "sharded"
-          managedkafka.bf2.org/strimziVersion: "strimzi-cluster-operator.v0.23.0-4"
-          managedkafka.bf2.org/kas-zone0: "true"
-          managedkafka.bf2.org/kas-zone1: "true"
-          managedkafka.bf2.org/kas-zone2: "true"
-          managedkafka.bf2.org/kas-multi-zone: "true"
+          app: "test-mk-zookeeper"
           strimzi.io/name: "test-mk-zookeeper"
         name: "test-mk-zookeeper"
       spec:


### PR DESCRIPTION
I was mistaken that this could be addressed by using a patch - the selectors are still immutable.  The proper way to do this is to just choose labels that won't change, similar to what is applied to our other deployments.