### PR TITLE
MGDSTRM-9284: Change broker log configuration to sync with upstream kafka and remove unused config

### DIFF
--- a/operator/src/main/resources/kafka-logging.yaml
+++ b/operator/src/main/resources/kafka-logging.yaml
@@ -16,8 +16,6 @@ data:
 
     log4j.rootLogger=${kafka.root.logger.level}, CONSOLE
 
-    log4j.logger.org.I0Itec.zkclient.ZkClient=INFO
-
     log4j.logger.org.apache.zookeeper=INFO
 
     log4j.logger.kafka=INFO

--- a/operator/src/main/resources/kafka-logging.yaml
+++ b/operator/src/main/resources/kafka-logging.yaml
@@ -36,6 +36,6 @@ data:
 
     log4j.logger.kafka.log.LogCleaner=INFO
 
-    log4j.logger.state.change.logger=TRACE
+    log4j.logger.state.change.logger=INFO
 
     log4j.logger.kafka.authorizer.logger=INFO


### PR DESCRIPTION
Why:
We are syncing our log levels with upstream kafka defaults. The default for this logger changed here: https://github.com/apache/kafka/commit/c59835c1d7281863722f5c11b54e6b9c07070304

MGDSTRM-9284