### PR TITLE
MGDSTRM-9799 adding overrides for standard / r5.xlarge

### DIFF
--- a/operator/src/main/resources/instances/standard-dynamic.properties
+++ b/operator/src/main/resources/instances/standard-dynamic.properties
@@ -1,0 +1,7 @@
+# designed to fit on 4 cpu / 32 GB mem class machines, namely r5.xlarge
+kafkaexporter.container-request-cpu=200m
+adminserver.container-request-cpu=100m
+zookeeper.container-request-cpu=100m
+cruisecontrol.container-request-cpu=100m
+kafka.container-cpu=3200m
+kafka.container-request-cpu=3100m

--- a/operator/src/test/resources/expected/adminserver-affinity.yml
+++ b/operator/src/test/resources/expected/adminserver-affinity.yml
@@ -98,7 +98,7 @@ spec:
             cpu: "500m"
           requests:
             memory: "512Mi"
-            cpu: "500m"
+            cpu: "100m"
         volumeMounts:
         - mountPath: "/opt/kafka-admin-api/custom-config/"
           name: "custom-config"


### PR DESCRIPTION
We don't have a great mechanism for this - it's dependent upon both profile type and strimzi version.  So for now I'm just creating a one-off that we can refine later.

I've also refined the initially proposed values slightly so that the cpu request of the broker will fit on an r5.xlarge that has a max allocatable cpu of 3.5.  The cpu limit was then raised separately, so the numbers will still be inline with what was reported.