### PR TITLE
Increase connection.failed.authentication.delay.ms to 1000

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -685,6 +685,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         int scalingAndReplicationFactor = kafkaConfigs.getScalingAndReplicationFactor();
         int minIsr = Math.min(scalingAndReplicationFactor, 2);
         config.put("offsets.topic.replication.factor", scalingAndReplicationFactor);
+        config.put("connection.failed.authentication.delay.ms", 1000);
         config.put("transaction.state.log.min.isr", minIsr);
         config.put("transaction.state.log.replication.factor", scalingAndReplicationFactor);
         config.put("auto.create.topics.enable", "false");

--- a/operator/src/main/java/org/bf2/operator/operands/dev/DevelopmentKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/dev/DevelopmentKafkaCluster.java
@@ -94,6 +94,7 @@ public class DevelopmentKafkaCluster extends AbstractKafkaCluster {
     private Map<String, Object> buildKafkaConfig(ManagedKafka managedKafka) {
         Map<String, Object> config = new HashMap<>();
         config.put("offsets.topic.replication.factor", 3);
+        config.put("connection.failed.authentication.delay.ms", 1000);
         config.put("transaction.state.log.replication.factor", 3);
         config.put("transaction.state.log.min.isr", 2);
         config.put("log.message.format.version", managedKafka.getSpec().getVersions().getKafka());

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -114,6 +114,7 @@ spec:
       client.quota.callback.kafka.clientIdPrefix: __redhat_strimzi
       max.partitions: 3000
       offsets.topic.replication.factor: 3
+      connection.failed.authentication.delay.ms: 1000
       transaction.state.log.min.isr: 2
       client.quota.callback.static.storage.soft: "10737418240"
       inter.broker.protocol.version: "2.6"

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -105,6 +105,7 @@ spec:
       client.quota.callback.static.storage.check-interval: "30"
       max.partitions: 100
       offsets.topic.replication.factor: 1
+      connection.failed.authentication.delay.ms: 1000
       transaction.state.log.min.isr: 1
       client.quota.callback.static.storage.soft: "64424509440"
       client.quota.callback.usageMetrics.topic: "__redhat_strimzi_volumeUsageMetrics"

--- a/operator/src/test/resources/expected/scaling-one.yml
+++ b/operator/src/test/resources/expected/scaling-one.yml
@@ -16,6 +16,7 @@ client.quota.callback.usageMetrics.topic: __redhat_strimzi_volumeUsageMetrics
 client.quota.callback.quotaPolicy.check-interval: "15"
 client.quota.callback.kafka.clientIdPrefix: __redhat_strimzi
 offsets.topic.replication.factor: 1
+connection.failed.authentication.delay.ms: 1000
 transaction.state.log.min.isr: 1
 client.quota.callback.static.storage.soft: "64424509440"
 inter.broker.protocol.version: "2.6"

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -108,6 +108,7 @@ spec:
       client.quota.callback.quotaPolicy.check-interval: "15"
       client.quota.callback.kafka.clientIdPrefix: __redhat_strimzi
       offsets.topic.replication.factor: 3
+      connection.failed.authentication.delay.ms: 1000
       transaction.state.log.min.isr: 2
       client.quota.callback.static.storage.soft: "21474836480"
       inter.broker.protocol.version: "2.6"

--- a/operator/src/test/resources/expected/strimzi_su2.yml
+++ b/operator/src/test/resources/expected/strimzi_su2.yml
@@ -114,6 +114,7 @@ spec:
       client.quota.callback.quotaPolicy.check-interval: "15"
       client.quota.callback.kafka.clientIdPrefix: __redhat_strimzi
       offsets.topic.replication.factor: 3
+      connection.failed.authentication.delay.ms: 1000
       transaction.state.log.min.isr: 2
       client.quota.callback.static.storage.soft: "366503875925"
       inter.broker.protocol.version: "2.6"


### PR DESCRIPTION
Why:
If a client uses incorrect credentials, or there is some other problem with authentication this will reduce pressure on any backing authentication services.