### PR TITLE
[MGDSTRM-10052] Set Strimzi bundle install plan to Manual

### DIFF
--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -102,12 +102,13 @@ rules:
   - apiGroups:
       - operators.coreos.com
     resources:
-      # the operator watches Subscriptions for Strimzi bundle installation
+      # the operator watches Subscriptions for Strimzi bundle installation and patches it to set Manual install plan approval
       - subscriptions
     verbs:
       - get
       - list
       - watch
+      - patch
   - apiGroups:
       - packages.operators.coreos.com
     resources:

--- a/operator/src/test/java/org/bf2/operator/managers/StrimziBundleManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/StrimziBundleManagerTest.java
@@ -263,6 +263,21 @@ public class StrimziBundleManagerTest {
         this.checkInstallPlan(subscription, false);
     }
 
+    @Test
+    void testAutomaticInstallPlanChangedToManual() {
+        Subscription subscription = installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Automatic",
+                "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
+        this.strimziBundleManager.handleSubscription(subscription);
+        checkInstallPlan(subscription, false);
+
+        subscription = openShiftClient.resources(Subscription.class)
+                .inNamespace(subscription.getMetadata().getNamespace())
+                .withName(subscription.getMetadata().getName())
+                .get();
+
+        assertEquals("Manual", subscription.getSpec().getInstallPlanApproval());
+    }
+
     /**
      * Install or update a Strimzi bundle, creating/updating the corresponding resources
      * like Subscription, InstallPlan and PackageManifest


### PR DESCRIPTION
Changes the Strimzi bundle subscription's install plan approval to `Manual` when not already set. 

This may be tested with kas-installer and the branch in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1387 (until accepted/merged). 

Current state of KFM in standalone mode will deploy Strimzi with the Automatic install plan approval and without the necessary labels for FSO to find the subscription. The KFM PR adds the labels to match the addon installation method.
