### PR TITLE
Update kafka_log_log_size metric with new labels

### DIFF
--- a/operator/src/main/resources/kafka-metrics.yaml
+++ b/operator/src/main/resources/kafka-metrics.yaml
@@ -150,6 +150,8 @@ data:
       - labels:
           partition: $2
           topic: $1
+          partition_id: $2
+          topic_name: $1
         name: kafka_log_log_size
         pattern: 'kafka.log<type=Log, name=Size, topic=(.+), partition=(.*)><>Value'
         type: GAUGE


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDSTRM-10072

These are duplications of the pre-existing label names for
compatibility. The new names are part of the consistent user-facing
metrics initiative. In future we'll also come to rename the metric
itself.