### PR TITLE
MGDSTRM-10036: Add bf2_org_kafkaInstanceProfileType to Kafka instance metrics

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/MetricsManager.java
@@ -15,6 +15,7 @@ import io.strimzi.api.kafka.model.KafkaClusterSpec;
 import io.strimzi.api.kafka.model.KafkaSpec;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListener;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerConfiguration;
+import org.bf2.common.OperandUtils;
 import org.bf2.operator.operands.AbstractKafkaCluster;
 import org.bf2.operator.operands.KafkaCluster;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
@@ -47,6 +48,7 @@ public class MetricsManager implements ResourceEventHandler<Kafka>{
     static final String TAG_LABEL_BROKER_ID = "broker_id";
     static final String TAG_LABEL_NAMESPACE = "namespace";
     static final String TAG_LABEL_INSTANCE_NAME = "instance_name";
+    static final String TAG_LABEL_INSTANCE_TYPE = "bf2_org_kafkaInstanceProfileType";
 
     static final Tag OWNER = Tag.of(TAG_LABEL_OWNER, "KafkaInstanceMetricsManager");
     static final String TAG_LABEL_LISTENER = "listener";
@@ -115,7 +117,8 @@ public class MetricsManager implements ResourceEventHandler<Kafka>{
 
     public static Tags buildKafkaInstanceTags(HasMetadata obj) {
         ObjectMeta metadata = obj.getMetadata();
-        return Tags.of(Tag.of(TAG_LABEL_NAMESPACE, metadata.getNamespace()), Tag.of(TAG_LABEL_INSTANCE_NAME, metadata.getName()), OWNER);
+        String profileType = OperandUtils.getOrDefault(metadata.getLabels(), ManagedKafka.PROFILE_TYPE, "standard");
+        return Tags.of(Tag.of(TAG_LABEL_NAMESPACE, metadata.getNamespace()), Tag.of(TAG_LABEL_INSTANCE_NAME, metadata.getName()), Tag.of(TAG_LABEL_INSTANCE_TYPE, profileType), OWNER);
     }
 
     private Double replicas(AtomicReference<Kafka> r) {


### PR DESCRIPTION
ZookeeperContainersDown and KafkaBrokerContainersDown alerts rely on this label which is set on 'kafka_brokers' metric emitted from Kafka. However, if kafka containers are not running, this metric disappear. In this situation, the alerts never trigger which is counter to their purpose of alerting when containers are not running.

Instead of 'kafka_brokers', the alerts can use Kafka instance metrics emitted from kas-fleetshard so that it doesn't rely on Kafka itself.