### PR TITLE
MGDSTRM-10069 updating the properties based upon additional testing

### DIFF
--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -27,7 +27,7 @@ mock.factory.interval=15s
 
 #ingress controller resources - an alternative profile can create fewer/smaller
 ingresscontroller.request-cpu=1700m
-ingresscontroller.request-memory=2Gi
+ingresscontroller.request-memory=1Gi
 #ingresscontroller.default-replica-count=1
 #ingresscontroller.az-replica-count=0
 
@@ -36,9 +36,9 @@ ingresscontroller.max-ingress-throughput=300Mi
 # percentage of peak throughput you actually need to meet
 ingresscontroller.peak-throughput-percentage=40
 # this has yet to be completely verified - this could go higher, but we should need more memory
-ingresscontroller.max-ingress-connections=54000
+ingresscontroller.max-ingress-connections=108000
 # percentage of peak connections you actually need to meet
-ingresscontroller.peak-connection-percentage=72
+ingresscontroller.peak-connection-percentage=100
 
 # Enables haproxy option contstats in the kas ingress so that stats are reported live rather than at connection close (RFE-3007 provide a proper mechanism to enable this option).
 ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=2 --template /tmp/haproxy-config.template

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -265,12 +265,12 @@ class IngressControllerManagerTest {
         assertEquals(1, ingressControllerManager.numReplicasForDefault(3000));
         assertEquals(0, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(), new LongSummaryStatistics(), 0, ZONE_PERCENTAGE));
 
-        assertEquals(3, ingressControllerManager.numReplicasForDefault(160000));
+        assertEquals(3, ingressControllerManager.numReplicasForDefault(240000));
         assertEquals(1, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(1, 0, 30000000, 1500000000), new LongSummaryStatistics(1, 0, 30000000, 1500000000), 0, ZONE_PERCENTAGE));
-        assertEquals(3, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(), new LongSummaryStatistics(), 480000, ZONE_PERCENTAGE));
+        assertEquals(3, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(), new LongSummaryStatistics(), 660000, ZONE_PERCENTAGE));
 
         long ingress = 50000000;
-        assertEquals(5, ingressControllerManager.numReplicasForDefault(370000));
+        assertEquals(5, ingressControllerManager.numReplicasForDefault(460000));
         assertEquals(4, ingressControllerManager.numReplicasForZone(new LongSummaryStatistics(1, 0, ingress, ingress*60), new LongSummaryStatistics(1, 0, ingress*2, ingress*120), 0, ZONE_PERCENTAGE));
     }
 
@@ -421,8 +421,8 @@ class IngressControllerManagerTest {
         assertEquals("5s", ingressController.getMetadata().getAnnotations().get(IngressControllerManager.HARD_STOP_AFTER_ANNOTATION));
         assertEquals(60, ((Config) ingressController.getSpec().getUnsupportedConfigOverrides()).getAdditionalProperties().get("reloadInterval"));
         assertEquals(60, ingressController.getSpec().getTuningOptions().getAdditionalProperties().get("reloadInterval"));
-        assertEquals(54000, ((Config) ingressController.getSpec().getUnsupportedConfigOverrides()).getAdditionalProperties().get("maxConnections"));
-        assertEquals(54000, ingressController.getSpec().getTuningOptions().getAdditionalProperties().get("maxConnections"));
+        assertEquals(108000, ((Config) ingressController.getSpec().getUnsupportedConfigOverrides()).getAdditionalProperties().get("maxConnections"));
+        assertEquals(108000, ingressController.getSpec().getTuningOptions().getAdditionalProperties().get("maxConnections"));
     }
 
     @Test


### PR DESCRIPTION
Based upon some additional scale testing I'm seeing no worse than 100MiB per 10000 connections, so we should be good to lower our memory request to 1 gig instead of 2.  We should also try to satisfy the connection demand for ~36 SU to match our current assumptions about bandwidth at a rate of 100% peak (locally I actually had to set the max connections well above the desired level to not see any errors - so even the 100% rate could be conservative).