### PR TITLE
PoC: Add an internal-to-OpenShift listener

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -388,6 +388,13 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                 .withMaxConnections(totalMaxConnections)
                 .withMaxConnectionCreationRate(maxConnectionAttemptsPerSec);
 
+        GenericKafkaListenerConfigurationBuilder internalListenerConfigBuilder = new GenericKafkaListenerConfigurationBuilder()
+                .withBrokerCertChainAndKey(new CertAndKeySecretSourceBuilder()
+                        .withSecretName(managedKafka.getMetadata().getName() + "-kafka-brokers-local")
+                        .withCertificate("tls.crt")
+                        .withKey("tls.key")
+                        .build());
+
         return Arrays.asList(
                         new GenericKafkaListenerBuilder()
                                 .withName(EXTERNAL_LISTENER_NAME)
@@ -413,6 +420,14 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                                 .withPort(9096)
                                 .withType(KafkaListenerType.INTERNAL)
                                 .withTls(false)
+                                .build(),
+                        new GenericKafkaListenerBuilder()
+                                .withName("internal")
+                                .withPort(9097)
+                                .withType(KafkaListenerType.INTERNAL)
+                                .withTls(true)
+                                .withAuth(plainOverOauthAuthenticationListener)
+                                .withConfiguration(internalListenerConfigBuilder.build())
                                 .build()
                 );
     }

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -52,6 +52,7 @@ import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
 import io.strimzi.api.kafka.model.storage.PersistentClaimStorageBuilder;
 import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
 import io.strimzi.api.kafka.model.storage.Storage;
+import io.strimzi.api.kafka.model.template.InternalServiceTemplateBuilder;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplate;
 import io.strimzi.api.kafka.model.template.KafkaClusterTemplateBuilder;
 import io.strimzi.api.kafka.model.template.PodDisruptionBudgetTemplateBuilder;
@@ -525,8 +526,14 @@ public class KafkaCluster extends AbstractKafkaCluster {
                     .endMetadata();
         }
 
+        InternalServiceTemplateBuilder brokersTemplateBuilder = new InternalServiceTemplateBuilder()
+            .editOrNewMetadata()
+            .addToAnnotations("service.beta.openshift.io/serving-cert-secret-name", managedKafka.getMetadata().getName() + "-kafka-brokers-local")
+            .endMetadata();
+
         KafkaClusterTemplateBuilder templateBuilder = new KafkaClusterTemplateBuilder()
-                .withPod(podTemplateBuilder.build());
+                .withPod(podTemplateBuilder.build())
+                .withBrokersService(brokersTemplateBuilder.build());
 
         if (replicas > 1 && drainCleanerManager.isDrainCleanerWebhookFound()) {
             templateBuilder.withPodDisruptionBudget(


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDSTRM-9651

This listener would be accessible through the <name>-kafka-brokers service, rather than through the ELB/Ingress controller setup.

The TLS cert is provided by the cluster CA, and client apps can be given access to that CA by following the docs here:

https://docs.openshift.com/container-platform/4.11/security/certificates/service-serving-certificate.html

One oddity is that the controller that creates the cert in response to the annotation on the Service will try to add an additional annotation also, but Strimzi removes that. I don't know if that causes any problems.