### PR TITLE
MGDSTRM-10232 initial configuration to control the ic scope

### DIFF
--- a/api/src/main/java/org/bf2/operator/resources/v1alpha1/NetworkConfiguration.java
+++ b/api/src/main/java/org/bf2/operator/resources/v1alpha1/NetworkConfiguration.java
@@ -1,17 +1,12 @@
 package org.bf2.operator.resources.v1alpha1;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.sundr.builder.annotations.Buildable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import javax.validation.constraints.NotNull;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
+import lombok.experimental.Accessors;
 
 @Buildable(
         builderPackage = "io.fabric8.kubernetes.api.builder",
@@ -19,12 +14,10 @@ import java.util.Map;
 )
 @ToString
 @EqualsAndHashCode
-@JsonInclude(Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Setter
-public class ManagedKafkaAgentSpec {
-    @NotNull
-    ObservabilityConfiguration observability;
-    Map<String, Profile> capacity = new LinkedHashMap<>();
-    NetworkConfiguration net;
+@Accessors(prefix = "_")
+public class NetworkConfiguration {
+    private boolean _private;
 }

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -24,11 +24,13 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.KubernetesServerTestResource;
 import io.quarkus.test.kubernetes.client.KubernetesTestServer;
 import io.strimzi.api.kafka.model.Kafka;
+import org.bf2.common.ManagedKafkaAgentResourceClient;
 import org.bf2.common.OperandUtils;
 import org.bf2.operator.operands.AbstractKafkaCluster;
 import org.bf2.operator.operands.KafkaCluster;
 import org.bf2.operator.resources.v1alpha1.ManagedKafka;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaAgent;
+import org.bf2.operator.resources.v1alpha1.ManagedKafkaAgentBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaBuilder;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaRoute;
 import org.bf2.operator.resources.v1alpha1.ManagedKafkaSpecBuilder;
@@ -451,6 +453,20 @@ class IngressControllerManagerTest {
         // and the expected options are present too.
         assertEquals("5s", updated.getMetadata().getAnnotations().get(IngressControllerManager.HARD_STOP_AFTER_ANNOTATION));
         assertEquals(60, updatedConfig.getAdditionalProperties().get("reloadInterval"));
+    }
+
+    @Test
+    void testIngressControllerInternal() {
+        ManagedKafkaAgent agent = new ManagedKafkaAgentBuilder()
+                .withNewMetadata()
+                .withName(ManagedKafkaAgentResourceClient.RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                .editOrNewNet().withPrivate(true).endNet()
+                .endSpec()
+                .build();
+        IngressController controller = ingressControllerManager.buildIngressController("kas", "kas", null, 1, null, null, agent);
+        assertEquals("Internal", controller.getSpec().getEndpointPublishingStrategy().getLoadBalancer().getScope());
     }
 
     @BeforeEach


### PR DESCRIPTION
Adds a new stanza to the agent spec to control the scope of the ic NLBs.

Since we have a timed job for reconciliation, we don't need to add a specific event handler for the managedkafkaagent - an assumption we were already making about the profile logic.