### PR TITLE
MGDSTRM-10277 hardening the sync against unhealthy behavior

### DIFF
--- a/common/src/main/java/org/bf2/common/health/SystemTerminator.java
+++ b/common/src/main/java/org/bf2/common/health/SystemTerminator.java
@@ -1,0 +1,25 @@
+package org.bf2.common.health;
+
+import io.quarkus.runtime.Quarkus;
+import org.bf2.common.ResourceInformerFactory;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class SystemTerminator {
+
+    @Inject
+    ResourceInformerFactory resourceInformerFactory;
+
+    @Inject
+    Logger log;
+
+    public void notifyUnhealthy() {
+        boolean watching = resourceInformerFactory.allInformersWatching();
+        log.errorf("The instance has is in an unhealthy state, initiating restart - watching {}", watching);
+        Quarkus.asyncExit();
+    }
+
+}


### PR DESCRIPTION
This is purely trying to be more defensive to what was seen in MGDSTRM-10277.  However there remains a completely unknown root cause - I didn't see anything exceptional called out.  It's also not clear why only sync would be affected - we've moved up enough in the operator sdk such that it's using an informer for the primary controller resource (managedkafka) that should be exactly the same as what the sync is running.

