### PR TITLE
MGDSTRM-10301 switching routes to use the loadbalancer hostname

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -696,7 +696,7 @@ public class IngressControllerManager {
     }
 
     private String getIngressControllerDomain(String ingressControllerName, boolean hasPublicDns) {
-      if (!isPrivateNetwork(informerManager.getLocalAgent()) && !hasPublicDns) {
+      if (!hasPublicDns && !isPrivateNetwork(informerManager.getLocalAgent())) {
           // special case - nothing is creating the dns entries for the ingress controller, so we map to the load balancer
           return Optional.ofNullable(informerManager.getLocalService(INGRESS_ROUTER_NAMESPACE, "router-" + ingressControllerName))
               .map(Service::getStatus)

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -224,8 +224,10 @@ spec:
           env:
             - name: QUARKUS_PROFILE
               value: prod
-            - name: INGRESSCONTROLLER_AZ_REPLICA_COUNT
-              value: "1"              
+            - name: KUBERNETES_MAX_CONCURRENT_REQUESTS
+              value: 100
+            - name: KUBERNETES_MAX_CONCURRENT_REQUESTS_PER_HOST
+              value: 100
           ports:
             - containerPort: 8080
               name: http

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -389,6 +389,22 @@ class IngressControllerManagerTest {
         assertEquals("broker-2", managedKafkaRoutes.get(4).getName());
         assertEquals("broker-2", managedKafkaRoutes.get(4).getPrefix());
         assertEquals("kas-zone-broker-2-loadbalancer.provider.com", managedKafkaRoutes.get(4).getRouter());
+
+        // once more, but with public dns
+        // we cannot add a dns to the mock server in fabric8 5.12 as it cannot be looked back up due to a plural error
+        managedKafkaRoutes = ingressControllerManager.getManagedKafkaRoutesFor(mk, true);
+        assertEquals(5, managedKafkaRoutes.size());
+
+        assertEquals(
+                managedKafkaRoutes.stream().sorted(Comparator.comparing(ManagedKafkaRoute::getName)).collect(Collectors.toList()),
+                managedKafkaRoutes,
+                "Expected list of ManagedKafkaRoutes to be sorted by name");
+
+        assertEquals("ingresscontroller.kas.testing.domain.tld", managedKafkaRoutes.get(0).getRouter());
+        assertEquals("ingresscontroller.kas.testing.domain.tld", managedKafkaRoutes.get(1).getRouter());
+        assertEquals("ingresscontroller.kas-zone-broker-0.testing.domain.tld", managedKafkaRoutes.get(2).getRouter());
+        assertEquals("ingresscontroller.kas-zone-broker-1.testing.domain.tld", managedKafkaRoutes.get(3).getRouter());
+        assertEquals("ingresscontroller.kas-zone-broker-2.testing.domain.tld", managedKafkaRoutes.get(4).getRouter());
     }
 
     @Test

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -1,5 +1,6 @@
 package org.bf2.operator.managers;
 
+import io.fabric8.kubernetes.api.model.LoadBalancerIngressBuilder;
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -338,7 +339,28 @@ class IngressControllerManagerTest {
         suffixes.stream().map(suffixToPod).forEach(pod -> openShiftClient.pods().inNamespace(mkName).createOrReplace(pod));
         suffixes.stream().map(suffixToNode).forEach(node -> openShiftClient.nodes().createOrReplace(node));
 
+        final Function<? super String, ? extends Service> suffixToRouterService = suffix -> new ServiceBuilder()
+                .withNewMetadata()
+                .withName("router-" + suffix)
+                .endMetadata()
+                .withNewStatus()
+                .withNewLoadBalancer()
+                .withIngress(new LoadBalancerIngressBuilder()
+                        .withHostname(suffix + "-loadbalancer.provider.com")
+                        .build())
+                .endLoadBalancer()
+                .endStatus()
+                .build();
+
+        List.of("kas", "kas-zone-broker-0", "kas-zone-broker-1", "kas-zone-broker-2")
+                .stream()
+                .map(suffixToRouterService)
+                .forEach(svc -> openShiftClient.services()
+                        .inNamespace(IngressControllerManager.INGRESS_ROUTER_NAMESPACE)
+                        .createOrReplace(svc));
+
         ingressControllerManager.reconcileIngressControllers();
+
         List<ManagedKafkaRoute> managedKafkaRoutes = ingressControllerManager.getManagedKafkaRoutesFor(mk);
 
         assertEquals(5, managedKafkaRoutes.size());
@@ -350,23 +372,23 @@ class IngressControllerManagerTest {
 
         assertEquals("admin-server", managedKafkaRoutes.get(0).getName());
         assertEquals("admin-server", managedKafkaRoutes.get(0).getPrefix());
-        assertEquals("ingresscontroller.kas.testing.domain.tld", managedKafkaRoutes.get(0).getRouter());
+        assertEquals("kas-loadbalancer.provider.com", managedKafkaRoutes.get(0).getRouter());
 
         assertEquals("bootstrap", managedKafkaRoutes.get(1).getName());
         assertEquals("", managedKafkaRoutes.get(1).getPrefix());
-        assertEquals("ingresscontroller.kas.testing.domain.tld", managedKafkaRoutes.get(1).getRouter());
+        assertEquals("kas-loadbalancer.provider.com", managedKafkaRoutes.get(1).getRouter());
 
         assertEquals("broker-0", managedKafkaRoutes.get(2).getName());
         assertEquals("broker-0", managedKafkaRoutes.get(2).getPrefix());
-        assertEquals("ingresscontroller.kas-zone-broker-0.testing.domain.tld", managedKafkaRoutes.get(2).getRouter());
+        assertEquals("kas-zone-broker-0-loadbalancer.provider.com", managedKafkaRoutes.get(2).getRouter());
 
         assertEquals("broker-1", managedKafkaRoutes.get(3).getName());
         assertEquals("broker-1", managedKafkaRoutes.get(3).getPrefix());
-        assertEquals("ingresscontroller.kas-zone-broker-1.testing.domain.tld", managedKafkaRoutes.get(3).getRouter());
+        assertEquals("kas-zone-broker-1-loadbalancer.provider.com", managedKafkaRoutes.get(3).getRouter());
 
         assertEquals("broker-2", managedKafkaRoutes.get(4).getName());
         assertEquals("broker-2", managedKafkaRoutes.get(4).getPrefix());
-        assertEquals("ingresscontroller.kas-zone-broker-2.testing.domain.tld", managedKafkaRoutes.get(4).getRouter());
+        assertEquals("kas-zone-broker-2-loadbalancer.provider.com", managedKafkaRoutes.get(4).getRouter());
     }
 
     @Test


### PR DESCRIPTION
This is to resolve the issue we saw with a private rosa cluster lacking a public entry in the DNS cluster config.  If that is the case, then the hostname of the ingress controller is only known within the private hosted zone - it cannot be used as a target for a route53 CNAME entry.  It is valid to instead directly use the loadbalancer hostname associated with the ingresscontroller.  This version of this change assumes we can do this all of time - but there are some concerns, such as we're effectively assuming that the loadbalancer hostname remains stable and that there's only one entry in the service status.  

Alternatives include:

- merging #840 first and only do this when managedkafkaagent is designated as public and we introspect the DNS config and see that lacks a public entry.  
- instead mandate that cluster owners create an appropriate public entry in their DNS config if they want public kafka.
- alleviate the concern about the loadbalancer host name stability by having the control plane update dns records - it looks like it only validates them currently.

This change is also blocked on the fleetmanager side in their DNS logic: https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/blob/db4c66b6510a4935f793ddad6dc60952fddb0ae6/internal/kafka/internal/services/data_plane_kafka.go#L515 there is an expectation that the router hostname has the same root as the cluster.