### PR TITLE
MGDSTRM-9181: Have kas ingress controller utilise the openshift-router's dynamic config manager.

### DIFF
--- a/common/src/main/java/org/bf2/common/OperandUtils.java
+++ b/common/src/main/java/org/bf2/common/OperandUtils.java
@@ -36,10 +36,14 @@ public class OperandUtils {
     public static final String OPENSHIFT_RATE_LIMIT_ANNOTATION = "haproxy.router.openshift.io/rate-limit-connections";
     public static final String OPENSHIFT_RATE_LIMIT_ANNOTATION_CONCURRENT_TCP = OPENSHIFT_RATE_LIMIT_ANNOTATION + ".concurrent-tcp";
     public static final String OPENSHIFT_RATE_LIMIT_ANNOTATION_TCP_RATE = OPENSHIFT_RATE_LIMIT_ANNOTATION + ".rate-tcp";
+    public static final String OPENSHIFT_INGRESS_BALANCE = "haproxy.router.openshift.io/balance";
+    public static final String OPENSHIFT_INGRESS_BALANCE_LEASTCONN = "leastconn";
 
     public static final String STRIMZI_OPERATOR_NAME = "strimzi-cluster-operator";
     public static final String FLEETSHARD_OPERATOR_NAME = "kas-fleetshard-operator";
     public static final String MASTER_SECRET_NAME = "master-secret";
+    public static final String INGRESS_TYPE = "ingressType";
+    public static final String SHARDED = "sharded";
 
     /**
      * Set the provided resource as owner of the resource

--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -64,6 +64,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;

--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -482,10 +482,9 @@ public class IngressControllerManager {
         var stable = new Base32().encodeToString(stableIdDigest.digest()).toLowerCase().replaceFirst("=$", "");
         var stableResourceName = String.format("%s-%s-blueprint", blueprintBaseName, stable);
 
-        var blueprintRouteLabels = OperandUtils.getDefaultLabels();
+        var blueprintRouteLabels = new HashMap<>(getRouteMatchLabels());
         blueprintRouteLabels.put(OperandUtils.INGRESS_TYPE, OperandUtils.SHARDED);
         blueprintRouteLabels.put("bf2.org/blueprint", "true");
-        blueprintRouteLabels.putAll(getRouteMatchLabels());
 
         // strip InsecureEdgeTerminationPolicy from the placeholder, the operator doesn't consider it.
        var config = new TLSConfigBuilder(tlsConfig.orElse(new TLSConfig())).withInsecureEdgeTerminationPolicy(null).build();

--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -483,6 +483,7 @@ public class IngressControllerManager {
 
         var blueprintRouteLabels = OperandUtils.getDefaultLabels();
         blueprintRouteLabels.put(OperandUtils.INGRESS_TYPE, OperandUtils.SHARDED);
+        blueprintRouteLabels.put("bf2.org/blueprint", "true");
         blueprintRouteLabels.putAll(getRouteMatchLabels());
 
         // strip InsecureEdgeTerminationPolicy from the placeholder, the operator doesn't consider it.

--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -797,4 +797,9 @@ public class IngressControllerManager {
     Optional<Quantity> getRequestMemory() {
         return requestMemory;
     }
+
+    /* testing */ String getBlueprintRouteNamespace() {
+        return blueprintRouteNamespace;
+    }
+
 }

--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -467,8 +467,8 @@ public class IngressControllerManager {
         try {
             stableIdDigest = MessageDigest.getInstance("SHA-1");
             orderedAnnotations.ifPresent(m -> m.forEach((k, v) -> {
-                stableIdDigest.update(String.valueOf(k).getBytes());
-                stableIdDigest.update(String.valueOf(v).getBytes());
+                stableIdDigest.update(String.valueOf(k).getBytes(StandardCharsets.UTF_8));
+                stableIdDigest.update(String.valueOf(v).getBytes(StandardCharsets.UTF_8));
             }));
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);

--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -92,6 +92,7 @@ public class IngressControllerManager {
 
     private static final String MAX_CONNECTIONS = "maxConnections";
     private static final String RELOAD_INTERVAL = "reloadInterval";
+    private static final String DYNAMIC_CONFIG_MANAGER = "dynamicConfigManager";
     private static final String UNSUPPORTED_CONFIG_OVERRIDES = "unsupportedConfigOverrides";
     private static final String TUNING_OPTIONS = "tuningOptions";
     protected static final String INGRESSCONTROLLER_LABEL = "ingresscontroller.operator.openshift.io/owning-ingresscontroller";
@@ -170,6 +171,9 @@ public class IngressControllerManager {
     List<String> ingressContainerCommand;
     @ConfigProperty(name = "ingresscontroller.reload-interval-seconds")
     Integer ingressReloadIntervalSeconds;
+
+    @ConfigProperty(name = "ingresscontroller.dynamic-config-manager")
+    Boolean dynamicConfigManager;
 
     @ConfigProperty(name = "ingresscontroller.peak-throughput-percentage")
     int peakThroughputPercentage;
@@ -563,11 +567,12 @@ public class IngressControllerManager {
         } else {
             removeSpecProperty(spec, RELOAD_INTERVAL);
         }
+        setSpecProperty(spec, UNSUPPORTED_CONFIG_OVERRIDES, DYNAMIC_CONFIG_MANAGER, dynamicConfigManager != null ? dynamicConfigManager.toString() : Boolean.FALSE.toString());
         setSpecProperty(spec, TUNING_OPTIONS, MAX_CONNECTIONS, maxIngressConnections);
         setSpecProperty(spec, UNSUPPORTED_CONFIG_OVERRIDES, MAX_CONNECTIONS, maxIngressConnections);
 
         // on fabric8 6.1 we can convert back from the generic to the actual spec, on earlier versions we cannot
-        // because the unsupportOptions won't be preserved
+        // because the unsupportedOptions won't be preserved
         builder.editSpec()
                 .withTuningOptions(Serialization.jsonMapper()
                         .convertValue(spec.get(TUNING_OPTIONS), IngressControllerTuningOptions.class))

--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -463,22 +463,22 @@ public class IngressControllerManager {
         }
 
         var orderedAnnotations = annotations.map(TreeMap::new);
-        MessageDigest instance;
+        MessageDigest stableIdDigest;
         try {
-            instance = MessageDigest.getInstance("SHA-1");
+            stableIdDigest = MessageDigest.getInstance("SHA-1");
             orderedAnnotations.ifPresent(m -> m.forEach((k, v) -> {
-                instance.update(String.valueOf(k).getBytes());
-                instance.update(String.valueOf(v).getBytes());
+                stableIdDigest.update(String.valueOf(k).getBytes());
+                stableIdDigest.update(String.valueOf(v).getBytes());
             }));
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        tlsConfig.map(TLSConfig::getTermination).map(String::getBytes).ifPresent(instance::update);
-        tlsConfig.map(TLSConfig::getCertificate).map(String::getBytes).ifPresent(instance::update);
-        tlsConfig.map(TLSConfig::getKey).map(String::getBytes).ifPresent(instance::update);
-        tlsConfig.map(TLSConfig::getCaCertificate).map(String::getBytes).ifPresent(instance::update);
+        tlsConfig.map(TLSConfig::getTermination).map(String::getBytes).ifPresent(stableIdDigest::update);
+        tlsConfig.map(TLSConfig::getCertificate).map(String::getBytes).ifPresent(stableIdDigest::update);
+        tlsConfig.map(TLSConfig::getKey).map(String::getBytes).ifPresent(stableIdDigest::update);
+        tlsConfig.map(TLSConfig::getCaCertificate).map(String::getBytes).ifPresent(stableIdDigest::update);
 
-        var stable = new Base32().encodeToString(instance.digest()).toLowerCase().replaceFirst("=$", "");
+        var stable = new Base32().encodeToString(stableIdDigest.digest()).toLowerCase().replaceFirst("=$", "");
         var stableResourceName = String.format("%s-%s-blueprint", blueprintBaseName, stable);
 
         var blueprintRouteLabels = OperandUtils.getDefaultLabels();

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -431,7 +431,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
     }
 
     protected Map<String, String> buildExternalListenerAnnotations(ManagedKafka managedKafka) {
-        return null;
+        return Map.of();
     }
 
     protected List<GenericKafkaListenerConfigurationBroker> buildBrokerOverrides(ManagedKafka managedKafka, int replicas) {

--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -388,7 +388,7 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
         GenericKafkaListenerConfigurationBuilder listenerConfigBuilder = new GenericKafkaListenerConfigurationBuilder()
                 .withBootstrap(new GenericKafkaListenerConfigurationBootstrapBuilder()
                         .withHost(managedKafka.getSpec().getEndpoint().getBootstrapServerHost())
-                        .withAnnotations(Map.of("haproxy.router.openshift.io/balance", "leastconn"))
+                        .withAnnotations(buildExternalListenerAnnotations(managedKafka))
                         .build()
                 )
                 .withBrokers(buildBrokerOverrides(managedKafka, replicas))
@@ -428,6 +428,10 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                                 .withTls(false)
                                 .build()
                 );
+    }
+
+    protected Map<String, String> buildExternalListenerAnnotations(ManagedKafka managedKafka) {
+        return null;
     }
 
     protected List<GenericKafkaListenerConfigurationBroker> buildBrokerOverrides(ManagedKafka managedKafka, int replicas) {

--- a/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AdminServer.java
@@ -120,6 +120,9 @@ public class AdminServer extends AbstractAdminServer {
         if (openShiftClient != null) {
             Route currentRoute = cachedRoute(managedKafka);
             Route route = routeFrom(managedKafka, currentRoute);
+            if (ingressControllerManagerInstance.isResolvable()) {
+                ingressControllerManagerInstance.get().ensureBlueprintRouteMatching(route, "kafka-admin");
+            }
 
             OperandUtils.createOrUpdate(openShiftClient.routes(), route);
         }
@@ -385,7 +388,7 @@ public class AdminServer extends AbstractAdminServer {
 
     private Map<String, String> buildRouteLabels() {
         Map<String, String> labels = OperandUtils.getDefaultLabels();
-        labels.put("ingressType", "sharded");
+        labels.put(OperandUtils.INGRESS_TYPE, OperandUtils.SHARDED);
 
         if (ingressControllerManagerInstance.isResolvable()) {
             labels.putAll(ingressControllerManagerInstance.get().getRouteMatchLabels());

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
 import io.fabric8.kubernetes.api.model.TopologySpreadConstraintBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.TLSConfigBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.quarkus.arc.DefaultBean;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
@@ -208,7 +209,9 @@ public class KafkaCluster extends AbstractKafkaCluster {
         createOrUpdateIfNecessary(currentCruiseControlLoggingConfigMap, cruiseControlLoggingConfigMap);
 
         if (ingressControllerManagerInstance.isResolvable()) {
-            ingressControllerManagerInstance.get().ensureBlueprintRouteMatching(Optional.ofNullable(buildExternalListenerAnnotations(managedKafka)),Optional.of("passthrough"), "kafka-bootstrap");
+            ingressControllerManagerInstance.get().ensureBlueprintRouteMatching(Optional.ofNullable(buildExternalListenerAnnotations(managedKafka)),
+                    Optional.of(new TLSConfigBuilder().withTermination("passthrough").build()),
+                    "kafka-bootstrap");
         }
 
         super.createOrUpdate(managedKafka);

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -207,6 +207,10 @@ public class KafkaCluster extends AbstractKafkaCluster {
 
         createOrUpdateIfNecessary(currentCruiseControlLoggingConfigMap, cruiseControlLoggingConfigMap);
 
+        if (ingressControllerManagerInstance.isResolvable()) {
+            ingressControllerManagerInstance.get().ensureBlueprintRouteMatching(Optional.ofNullable(buildExternalListenerAnnotations(managedKafka)),Optional.of("passthrough"), "kafka-bootstrap");
+        }
+
         super.createOrUpdate(managedKafka);
     }
 
@@ -1134,7 +1138,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         Map<String, String> labels = OperandUtils.getDefaultLabels();
         //this.strimziManager.changeStrimziVersion(managedKafka, this, labels);
         Optional.ofNullable(managedKafka.getMetadata().getLabels()).ifPresent(labels::putAll);
-        labels.put("ingressType", "sharded");
+        labels.put(OperandUtils.INGRESS_TYPE, OperandUtils.SHARDED);
         labels.put(this.strimziManager.getVersionLabel(), this.strimziManager.currentStrimziVersion(managedKafka));
 
         if (ingressControllerManagerInstance.isResolvable()) {
@@ -1256,6 +1260,10 @@ public class KafkaCluster extends AbstractKafkaCluster {
             return KafkaInstance.combineReadiness(readiness);
         }
         return super.getReadiness(managedKafka);
+    }
+
+    protected Map<String, String> buildExternalListenerAnnotations(ManagedKafka managedKafka) {
+        return Map.of(OperandUtils.OPENSHIFT_INGRESS_BALANCE, OperandUtils.OPENSHIFT_INGRESS_BALANCE_LEASTCONN);
     }
 
 }

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -225,7 +225,11 @@ spec:
             - name: QUARKUS_PROFILE
               value: prod
             - name: INGRESSCONTROLLER_AZ_REPLICA_COUNT
-              value: "1"              
+              value: "1"
+            - name: INGRESSCONTROLLER_BLUEPRINT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - containerPort: 8080
               name: http

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -41,13 +41,14 @@ ingresscontroller.max-ingress-connections=108000
 ingresscontroller.peak-connection-percentage=100
 
 # Enables haproxy option contstats in the kas ingress so that stats are reported live rather than at connection close (RFE-3007 provide a proper mechanism to enable this option).
-ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=${ingresscontroller.router-verbosity} --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers}
+ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=${ingresscontroller.router-verbosity} --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers} --blueprint-route-namespace=${ingresscontroller.blueprint-namespace}
 # Disconnect established connections after a haproxy reconfiguration (NE-879 should eliminate the need for this)
 ingresscontroller.hard-stop-after=5s
 # Coalesce up-to reloadInterval worth of haproxy updates.  This prevents a flurry of haproxy restarts (1 per OpenShift Route) as each kafka
 # instance is created (NE-879 should eliminate the need for this).
 ingresscontroller.reload-interval-seconds=60
 ingresscontroller.router-verbosity=2
+ingresscontroller.blueprint-namespace=kas-route-blueprints
 
 # HA proxy dynamic config manager
 ingresscontroller.dynamic-config-manager=true

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -41,12 +41,19 @@ ingresscontroller.max-ingress-connections=108000
 ingresscontroller.peak-connection-percentage=100
 
 # Enables haproxy option contstats in the kas ingress so that stats are reported live rather than at connection close (RFE-3007 provide a proper mechanism to enable this option).
-ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=2 --template /tmp/haproxy-config.template
+ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=2 --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers}
 # Disconnect established connections after a haproxy reconfiguration (NE-879 should eliminate the need for this)
 ingresscontroller.hard-stop-after=5s
 # Coalesce up-to reloadInterval worth of haproxy updates.  This prevents a flurry of haproxy restarts (1 per OpenShift Route) as each kafka
 # instance is created (NE-879 should eliminate the need for this).
 ingresscontroller.reload-interval-seconds=60
+
+# HA proxy dynamic config manager
+ingresscontroller.dynamic-config-manager=true
+# the following three variables are meaningful when the dynamic-config-manager=true
+ingresscontroller.commit-interval=9223372036854775807ns
+ingresscontroller.blueprint-route-pool-size=500
+ingresscontroller.max-dynamic-servers=5
 
 # external configuration injection through configmap
 quarkus.kubernetes-config.enabled=true

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -41,12 +41,13 @@ ingresscontroller.max-ingress-connections=108000
 ingresscontroller.peak-connection-percentage=100
 
 # Enables haproxy option contstats in the kas ingress so that stats are reported live rather than at connection close (RFE-3007 provide a proper mechanism to enable this option).
-ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=2 --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers}
+ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=${ingresscontroller.router-verbosity} --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers}
 # Disconnect established connections after a haproxy reconfiguration (NE-879 should eliminate the need for this)
 ingresscontroller.hard-stop-after=5s
 # Coalesce up-to reloadInterval worth of haproxy updates.  This prevents a flurry of haproxy restarts (1 per OpenShift Route) as each kafka
 # instance is created (NE-879 should eliminate the need for this).
 ingresscontroller.reload-interval-seconds=60
+ingresscontroller.router-verbosity=2
 
 # HA proxy dynamic config manager
 ingresscontroller.dynamic-config-manager=true

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -53,7 +53,9 @@ ingresscontroller.dynamic-config-manager=true
 # the following three variables are meaningful when the dynamic-config-manager=true
 ingresscontroller.commit-interval=9223372036854775807ns
 ingresscontroller.blueprint-route-pool-size=500
-ingresscontroller.max-dynamic-servers=5
+# The worst case is the bootstrap route, For 2SU, this needs to be 6.  When we start supporting 3SU, we might want
+# to switch to using "router.openshift.io/pool-size" on the bootstrap blueprint.
+ingresscontroller.max-dynamic-servers=6
 
 # Disconnect established connections after a haproxy reconfiguration event that *requires a restart*.
 ingresscontroller.hard-stop-after=5s

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -40,15 +40,12 @@ ingresscontroller.max-ingress-connections=108000
 # percentage of peak connections you actually need to meet
 ingresscontroller.peak-connection-percentage=100
 
-# Enables haproxy option contstats in the kas ingress so that stats are reported live rather than at connection close (RFE-3007 provide a proper mechanism to enable this option).
-ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=${ingresscontroller.router-verbosity} --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers} --blueprint-route-namespace=${ingresscontroller.blueprint-namespace}
-# Disconnect established connections after a haproxy reconfiguration (NE-879 should eliminate the need for this)
-ingresscontroller.hard-stop-after=5s
-# Coalesce up-to reloadInterval worth of haproxy updates.  This prevents a flurry of haproxy restarts (1 per OpenShift Route) as each kafka
-# instance is created (NE-879 should eliminate the need for this).
-ingresscontroller.reload-interval-seconds=60
 ingresscontroller.router-verbosity=2
-ingresscontroller.blueprint-namespace=kas-route-blueprints
+# note that this variable is overridden using the downward API in the deployment.
+ingresscontroller.blueprint-namespace=kas-fleetshard-operator
+
+# customizes the router operators command line to enable specific options that can't currently be controller from the CR.
+ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=${ingresscontroller.router-verbosity} --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers} --blueprint-route-namespace=${ingresscontroller.blueprint-namespace}
 
 # HA proxy dynamic config manager
 ingresscontroller.dynamic-config-manager=true
@@ -56,6 +53,12 @@ ingresscontroller.dynamic-config-manager=true
 ingresscontroller.commit-interval=9223372036854775807ns
 ingresscontroller.blueprint-route-pool-size=500
 ingresscontroller.max-dynamic-servers=5
+
+# Disconnect established connections after a haproxy reconfiguration event that *requires a restart*.
+ingresscontroller.hard-stop-after=5s
+# Coalesce up-to reload-interval-seconds worth of haproxy reconfiguration events before restarting.
+ingresscontroller.reload-interval-seconds=60
+
 
 # external configuration injection through configmap
 quarkus.kubernetes-config.enabled=true

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -43,9 +43,10 @@ ingresscontroller.peak-connection-percentage=100
 ingresscontroller.router-verbosity=2
 # note that this variable is overridden using the downward API in the deployment.
 ingresscontroller.blueprint-namespace=kas-fleetshard-operator
+ingresscontroller.blueprint-selector=bf2.org/blueprint=true
 
 # customizes the router operators command line to enable specific options that can't currently be controller from the CR.
-ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=${ingresscontroller.router-verbosity} --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers} --blueprint-route-namespace=${ingresscontroller.blueprint-namespace}
+ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^defaults$/ {print \"  option contstats\"}' < $TEMPLATE_FILE > /tmp/haproxy-config.template; exec /usr/bin/openshift-router --v=${ingresscontroller.router-verbosity} --template /tmp/haproxy-config.template --commit-interval=${ingresscontroller.commit-interval} --blueprint-route-pool-size=${ingresscontroller.blueprint-route-pool-size} --max-dynamic-servers=${ingresscontroller.max-dynamic-servers} --blueprint-route-namespace=${ingresscontroller.blueprint-namespace} --blueprint-route-labels=${ingresscontroller.blueprint-selector}
 
 # HA proxy dynamic config manager
 ingresscontroller.dynamic-config-manager=true


### PR DESCRIPTION
Enables the (unsupported) dynamic config manager option on openshift-ingress.  This is done as otherwise, haproxy reconfigurations (which occur every time new kafka instance is provisioned or deprovisioned) cause all kafka connections to all instances to be dropped.  This is too disruptive for applications.

Work based on ideas from @shawkins and @showuon .