### PR TITLE
bug fix: create blueprints for suspended routes too

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -333,7 +333,11 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                 routeAnnotations.putAll(rateLimitAnnotations);
                 r.getMetadata().setAnnotations(routeAnnotations);
                 OperandUtils.createOrUpdate(kubernetesClient.resources(Route.class), r);
+                ensureBlueprintRouteForSuspendedRoute(r);
             });
+    }
+
+    protected void ensureBlueprintRouteForSuspendedRoute(Route r) {
     }
 
     protected List<GenericKafkaListener> buildListeners(ManagedKafka managedKafka, int replicas) {

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.TopologySpreadConstraint;
 import io.fabric8.kubernetes.api.model.TopologySpreadConstraintBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.TLSConfigBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.quarkus.arc.DefaultBean;
@@ -1267,6 +1268,13 @@ public class KafkaCluster extends AbstractKafkaCluster {
 
     protected Map<String, String> buildExternalListenerAnnotations(ManagedKafka managedKafka) {
         return Map.of(OperandUtils.OPENSHIFT_INGRESS_BALANCE, OperandUtils.OPENSHIFT_INGRESS_BALANCE_LEASTCONN);
+    }
+
+    @Override
+    protected void ensureBlueprintRouteForSuspendedRoute(Route r) {
+        if (ingressControllerManagerInstance.isResolvable()) {
+            ingressControllerManagerInstance.get().ensureBlueprintRouteMatching(r, "kafka-suspension");
+        }
     }
 
 }

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -52,7 +52,7 @@ ingresscontroller.ingress-container-command=/usr/bin/bash,-c,awk '{print $0} /^d
 ingresscontroller.dynamic-config-manager=true
 # the following three variables are meaningful when the dynamic-config-manager=true
 ingresscontroller.commit-interval=9223372036854775807ns
-ingresscontroller.blueprint-route-pool-size=500
+ingresscontroller.blueprint-route-pool-size=300
 # The worst case is the bootstrap route, For 2SU, this needs to be 6.  When we start supporting 3SU, we might want
 # to switch to using "router.openshift.io/pool-size" on the bootstrap blueprint.
 ingresscontroller.max-dynamic-servers=6


### PR DESCRIPTION
#850 was incomplete as we failed to consider suspended routes, so instance suspension was still leading to a haproxy restart.  This creates blueprints for those routes too.