### PR TITLE
MGDSTRM-10104: configure kafka with smaller sasl.server.max.receive.size

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaCluster.java
@@ -736,6 +736,7 @@ public class KafkaCluster extends AbstractKafkaCluster {
         config.put("inter.broker.protocol.version", this.kafkaManager.currentKafkaIbpVersion(managedKafka));
         config.put("ssl.enabled.protocols", "TLSv1.3,TLSv1.2");
         config.put("ssl.protocol", "TLS");
+        config.put("sasl.server.max.receive.size", kafkaConfigs.getSaslServerMaxReceiveSize());
         config.put("kas.policy.create-topic.partition-limit-enforced",
                 kafkaConfigs.isPartitionLimitEnforced());
 

--- a/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
+++ b/operator/src/main/java/org/bf2/operator/operands/KafkaInstanceConfiguration.java
@@ -205,6 +205,8 @@ public class KafkaInstanceConfiguration {
         private int quotaCallbackQuotaPolicyCheckInterval;
         @JsonProperty("quota-callback-quota-kafka-clientid-prefix")
         private String quotaCallbackQuotaKafkaClientidPrefix;
+        @JsonProperty("sasl-server-max-receive-size")
+        private int saslServerMaxReceiveSize;
 
         public String getStorageClass() {
             return storageClass;
@@ -419,6 +421,14 @@ public class KafkaInstanceConfiguration {
 
         public void setQuotaCallbackQuotaKafkaClientidPrefix(String quotaCallbackQuotaKafkaClientidPrefix) {
             this.quotaCallbackQuotaKafkaClientidPrefix = quotaCallbackQuotaKafkaClientidPrefix;
+        }
+
+        public int getSaslServerMaxReceiveSize() {
+            return saslServerMaxReceiveSize;
+        }
+
+        public void setSaslServerMaxReceiveSize(int saslServerMaxReceiveSize) {
+            this.saslServerMaxReceiveSize = saslServerMaxReceiveSize;
         }
     }
 

--- a/operator/src/main/resources/instances/managedkafka.properties
+++ b/operator/src/main/resources/instances/managedkafka.properties
@@ -10,6 +10,7 @@ kafka.message-max-bytes=1048588
 kafka.connection-attempts-per-sec=100
 kafka.quota-callback-usage-metrics-topic=__redhat_strimzi_volumeUsageMetrics
 kafka.quota-callback-quota-kafka-clientid-prefix=__redhat_strimzi
+kafka.sasl-server-max-receive-size=16384
 
 kafka.quota-callback-quota-policy-check-interval=15
 

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -123,6 +123,7 @@ spec:
       inter.broker.protocol.version: "2.6"
       client.quota.callback.static.produce: "349525"
       ssl.protocol: "TLS"
+      sasl.server.max.receive.size: 16384
       client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
       ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
       client.quota.callback.static.storage.hard: "10737418240"

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -115,6 +115,7 @@ spec:
       inter.broker.protocol.version: "2.6"
       client.quota.callback.static.produce: "2097152"
       ssl.protocol: "TLS"
+      sasl.server.max.receive.size: 16384
       client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
       ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
       client.quota.callback.static.storage.hard: "64424509440"

--- a/operator/src/test/resources/expected/scaling-one.yml
+++ b/operator/src/test/resources/expected/scaling-one.yml
@@ -22,6 +22,7 @@ client.quota.callback.static.storage.soft: "64424509440"
 inter.broker.protocol.version: "2.6"
 client.quota.callback.static.produce: "2097152"
 ssl.protocol: "TLS"
+sasl.server.max.receive.size: 16384
 client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
 ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
 client.quota.callback.static.storage.hard: "64424509440"

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -117,6 +117,7 @@ spec:
       inter.broker.protocol.version: "2.6"
       client.quota.callback.static.produce: "699050"
       ssl.protocol: "TLS"
+      sasl.server.max.receive.size: 16384
       client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
       ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
       client.quota.callback.static.storage.hard: "21474836480"

--- a/operator/src/test/resources/expected/strimzi_su2.yml
+++ b/operator/src/test/resources/expected/strimzi_su2.yml
@@ -123,6 +123,7 @@ spec:
       inter.broker.protocol.version: "2.6"
       client.quota.callback.static.produce: "17476266"
       ssl.protocol: "TLS"
+      sasl.server.max.receive.size: 16384
       client.quota.callback.class: "io.strimzi.kafka.quotas.StaticQuotaCallback"
       ssl.enabled.protocols: "TLSv1.3,TLSv1.2"
       client.quota.callback.static.storage.hard: "366503875925"


### PR DESCRIPTION
This is a DoS defence.  This change bakes the configuration into fleetshard, allowing the override to be removed from the overrides.