### PR TITLE
MGDSTRM-10459 changing the reloadInterval tuning option to a string

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/IngressControllerManager.java
@@ -636,7 +636,7 @@ public class IngressControllerManager {
         GenericKubernetesResource spec = Serialization.jsonMapper().convertValue(builder.buildSpec(), GenericKubernetesResource.class);
 
         if (ingressReloadIntervalSeconds > 0) {
-            setSpecProperty(spec, TUNING_OPTIONS, RELOAD_INTERVAL, ingressReloadIntervalSeconds);
+            setSpecProperty(spec, TUNING_OPTIONS, RELOAD_INTERVAL, ingressReloadIntervalSeconds + "s");
             setSpecProperty(spec, UNSUPPORTED_CONFIG_OVERRIDES, RELOAD_INTERVAL, ingressReloadIntervalSeconds);
         } else {
             removeSpecProperty(spec, RELOAD_INTERVAL);

--- a/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/IngressControllerManagerTest.java
@@ -463,7 +463,7 @@ class IngressControllerManagerTest {
 
         assertEquals("5s", ingressController.getMetadata().getAnnotations().get(IngressControllerManager.HARD_STOP_AFTER_ANNOTATION));
         assertEquals(60, ((Config) ingressController.getSpec().getUnsupportedConfigOverrides()).getAdditionalProperties().get("reloadInterval"));
-        assertEquals(60, ingressController.getSpec().getTuningOptions().getAdditionalProperties().get("reloadInterval"));
+        assertEquals("60s", ingressController.getSpec().getTuningOptions().getAdditionalProperties().get("reloadInterval"));
         assertEquals(108000, ((Config) ingressController.getSpec().getUnsupportedConfigOverrides()).getAdditionalProperties().get("maxConnections"));
         assertEquals(108000, ingressController.getSpec().getTuningOptions().getAdditionalProperties().get("maxConnections"));
     }


### PR DESCRIPTION
We need to leave the unsupport option as an int, but change the tuning option to a string.