### PR TITLE
[MGDSTRM-10349] Publish kas-fleetshard artifacts to GitHub packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - test-pkg-deploy
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+# This workflow will build a Java project with Maven
+
+name: Publish Artifacts
+
+on:
+  release:
+    types:
+      - created
+  push:
+    branches:
+      - main
+      - test-pkg-deploy
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: temurin
+
+    - name: Cache m2 repo
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Deploy Artifacts
+      run: mvn deploy -Pquickly --no-transfer-progress -Dno-format
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bf2</groupId>
         <artifactId>kas-fleetshard</artifactId>
-        <version>0.32.2-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
     </parent>
     <artifactId>kas-fleetshard-api</artifactId>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bf2</groupId>
         <artifactId>kas-fleetshard</artifactId>
-        <version>0.32.2-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
     </parent>
     <artifactId>kas-fleetshard-common</artifactId>
 

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bf2</groupId>
         <artifactId>kas-fleetshard</artifactId>
-        <version>0.32.2-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
     </parent>
     <artifactId>kas-fleetshard-operator</artifactId>
     <properties>

--- a/perf/pom.xml
+++ b/perf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>kas-fleetshard</artifactId>
         <groupId>org.bf2</groupId>
-        <version>0.32.2-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
     </parent>
     <artifactId>kas-fleetshard-perf</artifactId>
 
@@ -70,24 +70,24 @@
         <dependency>
             <groupId>org.bf2</groupId>
             <artifactId>kas-fleetshard-operator</artifactId>
-            <version>0.32.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bf2</groupId>
-            <artifactId>test</artifactId>
-            <version>0.32.2-SNAPSHOT</version>
+            <artifactId>kas-fleetshard-test</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bf2</groupId>
-            <artifactId>systemtest</artifactId>
-            <version>0.32.2-SNAPSHOT</version>
+            <artifactId>kas-fleetshard-systemtest</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bf2</groupId>
-            <artifactId>systemtest</artifactId>
+            <artifactId>kas-fleetshard-systemtest</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
-            <version>0.32.2-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <groupId>org.bf2</groupId>
     <artifactId>kas-fleetshard</artifactId>
     <packaging>pom</packaging>
-    <version>0.32.2-SNAPSHOT</version>
+    <version>0.33.0-SNAPSHOT</version>
 
     <properties>
         <!-- things we don't need from basepom -->
@@ -262,6 +262,19 @@
             </releases>
         </repository>
     </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard</url>
+        </repository>
+        <snapshotRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <build>
         <plugins>

--- a/sync/pom.xml
+++ b/sync/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.bf2</groupId>
         <artifactId>kas-fleetshard</artifactId>
-        <version>0.32.2-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
     </parent>
     <artifactId>kas-fleetshard-sync</artifactId>
 

--- a/systemtest/pom.xml
+++ b/systemtest/pom.xml
@@ -5,9 +5,9 @@
     <parent>
         <artifactId>kas-fleetshard</artifactId>
         <groupId>org.bf2</groupId>
-        <version>0.32.2-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
     </parent>
-    <artifactId>systemtest</artifactId>
+    <artifactId>kas-fleetshard-systemtest</artifactId>
 
     <properties>
         <it.skip>true</it.skip>
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>org.bf2</groupId>
-            <artifactId>test</artifactId>
+            <artifactId>kas-fleetshard-test</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <artifactId>kas-fleetshard</artifactId>
         <groupId>org.bf2</groupId>
-        <version>0.32.2-SNAPSHOT</version>
+        <version>0.33.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>test</artifactId>
-    
+    <artifactId>kas-fleetshard-test</artifactId>
+
     <properties>
         <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
         <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>


### PR DESCRIPTION
- Add workflow to publish artifacts on pushes to `main` (snapshot versions) and for each release (regular/non-snapshot versions)
- Add `kas-fleetshard-` prefix to the `systemtest` and `test` artifact ids to avoid potential conflicts elsewhere in bf2
- Update version to 0.33.0-SNAPSHOT to reflect the plan for `main`

The packages were published [1] from the first commit by having the PR's source branch named in the action YAML. The second commit removes the branch going forward.

[1] https://github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard/actions/runs/4008001312