### PR TITLE
[MGDSTRM-10669] Allow access via 9096 for any Kafka pod in namespace

### DIFF
--- a/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
+++ b/operator/src/main/java/org/bf2/operator/operands/AbstractKafkaCluster.java
@@ -2,7 +2,6 @@ package org.bf2.operator.operands;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.networking.v1.IPBlockBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.NetworkPolicyPeerBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.Route;
@@ -417,17 +416,18 @@ public abstract class AbstractKafkaCluster implements Operand<ManagedKafka> {
                                 .withAuth(oauthAuthenticationListener)
                                 .withNetworkPolicyPeers(new NetworkPolicyPeerBuilder()
                                         .withNewPodSelector()
-                                        .addToMatchLabels("app", AbstractAdminServer.adminServerName(managedKafka))
-                                        .endPodSelector().build())
+                                            .addToMatchLabels("app", AbstractAdminServer.adminServerName(managedKafka))
+                                        .endPodSelector()
+                                        .build())
                                 .build(),
                         new GenericKafkaListenerBuilder()
                                 .withName("sre")
                                 .withPort(9096)
                                 .withType(KafkaListenerType.INTERNAL)
                                 .withNetworkPolicyPeers(new NetworkPolicyPeerBuilder()
-                                        .withIpBlock(new IPBlockBuilder()
-                                                .withCidr("0.0.0.0/32")
-                                                .build())
+                                        .withNewPodSelector()
+                                            .addToMatchLabels("strimzi.io/name", managedKafka.getMetadata().getName() + "-kafka")
+                                        .endPodSelector()
                                         .build())
                                 .withTls(false)
                                 .build()

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -96,8 +96,9 @@ spec:
       type: "internal"
       tls: false
       networkPolicyPeers:
-        - ipBlock:
-            cidr: "0.0.0.0/32"
+      - podSelector:
+          matchLabels:
+            strimzi.io/name: test-mk-kafka
     config:
       min.insync.replicas: 2
       create.topic.policy.class.name: "io.bf2.kafka.topic.ManagedKafkaCreateTopicPolicy"

--- a/operator/src/test/resources/expected/developer-strimzi.yml
+++ b/operator/src/test/resources/expected/developer-strimzi.yml
@@ -87,8 +87,9 @@ spec:
       type: "internal"
       tls: false
       networkPolicyPeers:
-      - ipBlock:
-          cidr: "0.0.0.0/32"
+      - podSelector:
+          matchLabels:
+            strimzi.io/name: test-mk-kafka
     config:
       auto.create.topics.enable: "false"
       min.insync.replicas: 1

--- a/operator/src/test/resources/expected/strimzi.yml
+++ b/operator/src/test/resources/expected/strimzi.yml
@@ -90,8 +90,9 @@ spec:
       type: "internal"
       tls: false
       networkPolicyPeers:
-        - ipBlock:
-            cidr: "0.0.0.0/32"
+      - podSelector:
+          matchLabels:
+            strimzi.io/name: test-mk-kafka
     config:
       auto.create.topics.enable: "false"
       min.insync.replicas: 2

--- a/operator/src/test/resources/expected/strimzi_su2.yml
+++ b/operator/src/test/resources/expected/strimzi_su2.yml
@@ -96,8 +96,9 @@ spec:
         type: "internal"
         tls: false
         networkPolicyPeers:
-          - ipBlock:
-              cidr: "0.0.0.0/32"
+        - podSelector:
+            matchLabels:
+              strimzi.io/name: test-mk-kafka
     config:
       auto.create.topics.enable: "false"
       min.insync.replicas: 2


### PR DESCRIPTION
Test OLM index image with this change: `quay.io/medgar/kas-fleetshard-operator-index:1.0.17-1`