### PR TITLE
MGDSTRM-10094 making KafkaCluster.fromKafka not modify the ManagedKafka

### DIFF
--- a/common/src/main/java/org/bf2/common/OperandUtils.java
+++ b/common/src/main/java/org/bf2/common/OperandUtils.java
@@ -7,6 +7,7 @@ import io.fabric8.kubernetes.api.model.LabelSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeAffinity;
 import io.fabric8.kubernetes.api.model.NodeAffinityBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PodAffinity;
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class OperandUtils {
 
@@ -220,4 +222,9 @@ public class OperandUtils {
         }
         return map.getOrDefault(key, defaultValue);
     }
+
+    public static Optional<String> getAnnotation(HasMetadata hasMeta, String key) {
+        return Optional.ofNullable(hasMeta).map(HasMetadata::getMetadata).map(ObjectMeta::getAnnotations).map(a -> a.get(key));
+    }
+
 }

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -719,15 +719,15 @@ class KafkaClusterTest {
         KafkaBuilder kafka = new KafkaBuilder(this.kafkaCluster.kafkaFrom(mk, null));
 
         if (kafkaUpgradeStart != null) {
-            mk.getMetadata().getAnnotations().put(
+            kafka.editMetadata().addToAnnotations(
                     ManagedKafkaKeys.Annotations.KAFKA_UPGRADE_START_TIMESTAMP,
-                    Instant.ofEpochMilli(kafkaUpgradeStart).toString());
+                    Instant.ofEpochMilli(kafkaUpgradeStart).toString()).endMetadata();
         }
 
         if (kafkaUpgradeEnd != null) {
-            mk.getMetadata().getAnnotations().put(
+            kafka.editMetadata().addToAnnotations(
                     ManagedKafkaKeys.Annotations.KAFKA_UPGRADE_END_TIMESTAMP,
-                    Instant.ofEpochMilli(kafkaUpgradeEnd).toString());
+                    Instant.ofEpochMilli(kafkaUpgradeEnd).toString()).endMetadata();
         }
 
         if (suspendedValue != null) {


### PR DESCRIPTION
This moves the upgrade annotations from the managedkafka to kafka.  After this version is rolled out, we'll be able to remove the logic in the controller that is checking for moving the annotations and remove the annotations from the list of ones that are managed by the operator.