### PR TITLE
MGDSTRM-10828 updating github actions

### DIFF
--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v3
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,18 +19,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 11
-    - name: Cache m2 repo
-      uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Build and run Unit tests
       run: mvn install --file pom.xml --no-transfer-progress -Dno-format
     - name: Save Build Context
@@ -38,7 +33,7 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Attach Build Output
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: target
         path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,21 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
         java-version: 11
-        distribution: temurin
-
-    - name: Cache m2 repo
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        distribution: 'temurin'
+        cache: 'maven'
 
     - name: Deploy Artifacts
       run: mvn deploy -Pquickly --no-transfer-progress -Dno-format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{secrets.BF2ROBOT_TOKEN}}
 
@@ -29,10 +29,10 @@ jobs:
           local-file: true
 
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Perform Maven Release
         run: |

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -19,20 +19,14 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.1
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
-
-      - name: Cache m2 repo
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.4.2
@@ -50,7 +44,7 @@ jobs:
           mvn verify -P systemtest -pl systemtest -Dgroups=smoke -am --no-transfer-progress
 
       - name: Archive results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: artifacts

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -78,10 +78,12 @@ jobs:
           git checkout -B $BASE_BRANCH upstream/$BASE_BRANCH
           git checkout ${{ github.event.workflow_run.head_sha }}
           git clean -ffdx --exclude=target/ && git reset --hard HEAD
-      - name: Setup JDK
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
@@ -89,13 +91,6 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
 
       ## (PRs Only) Run Sonar analysis against the results of the build job, providing PR information
       - name: SonarCloud Analysis (PR Only)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,23 +10,17 @@ jobs:
     steps:
       - name: Cancel Previous Runs
         if: github.event_name == 'pull_request'
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.11.0
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
-
-      - name: Cache m2 repo
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.4.2
@@ -44,7 +38,7 @@ jobs:
           mvn verify -P systemtest -pl systemtest -am --no-transfer-progress
 
       - name: Archive results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: artifacts


### PR DESCRIPTION
Updating various action versions.  Moving caching to the setup-java action.  Having everything use temurin - previously zulu (the default), adopt, and temurin were referenced.  Not sure if we have a hard preference here.