### PR TITLE
Approve Strimzi installation immediately when CSV not present

### DIFF
--- a/operator/src/main/java/org/bf2/operator/managers/StrimziBundleManager.java
+++ b/operator/src/main/java/org/bf2/operator/managers/StrimziBundleManager.java
@@ -202,7 +202,7 @@ public class StrimziBundleManager {
 
         final String subNamespace = subscription.getMetadata().getNamespace();
         final String subName = subscription.getMetadata().getName();
-        boolean approveImmediately;
+        boolean approveImmediately = false;
 
         if (subscription.getStatus().getInstalledCSV() == null) {
             log.infof("Subscription %s/%s has no linked CSV; InstallPlan will be approved immediately", subNamespace, subName);
@@ -210,8 +210,6 @@ public class StrimziBundleManager {
         } else if (!this.isKafkaCrdsInstalled()) {
             log.infof("Subscription %s/%s has missing Strimzi CRDs; InstallPlan will be approved immediately", subNamespace, subName);
             approveImmediately = true;
-        } else {
-            approveImmediately = false;
         }
 
         // CSV or CRDs are not installed, nothing we can do more ... just approving installation

--- a/operator/src/test/java/org/bf2/operator/managers/StrimziBundleManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/StrimziBundleManagerTest.java
@@ -85,6 +85,17 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
+    public void testInstallationWithCRDsPresent() {
+        Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
+                "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
+        this.createKafkaCRDs();
+        subscription.getStatus().setInstalledCSV(null);
+        this.strimziBundleManager.handleSubscription(subscription);
+        // check that InstallPlan was approved
+        this.checkInstallPlan(subscription, true);
+    }
+
+    @Test
     public void testInstallationWithEmptyStrimzi() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual", null);
         this.strimziBundleManager.handleSubscription(subscription);
@@ -376,6 +387,7 @@ public class StrimziBundleManagerTest {
                 .withNewStatus()
                     .withConditions(new SubscriptionConditionBuilder().withType("InstallPlanPending").withReason("RequiresApproval").build())
                     .withInstallPlanRef(new ObjectReferenceBuilder().withNamespace(namespace).withName(installPlan).build())
+                    .withInstalledCSV(bundleName + ".v0.0.1")
                 .endStatus()
                 .build();
 

--- a/operator/src/test/java/org/bf2/operator/managers/StrimziBundleManagerTest.java
+++ b/operator/src/test/java/org/bf2/operator/managers/StrimziBundleManagerTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 @QuarkusTestResource(KubernetesServerTestResource.class)
 @QuarkusTest
-public class StrimziBundleManagerTest {
+class StrimziBundleManagerTest {
 
     @Inject
     StrimziBundleManager strimziBundleManager;
@@ -59,7 +59,7 @@ public class StrimziBundleManagerTest {
     MixedOperation<PackageManifest, PackageManifestList, Resource<PackageManifest>> packageManifestClient;
 
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         this.packageManifestClient = this.openShiftClient.operatorHub().packageManifests();
 
         // cleaning OpenShift cluster
@@ -71,12 +71,12 @@ public class StrimziBundleManagerTest {
     }
 
     @AfterEach
-    public void afterEach() {
+    void afterEach() {
         strimziManager.clearStrimziPendingInstallationVersions();
     }
 
     @Test
-    public void testFirstInstallation() {
+    void testFirstInstallation() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
         this.strimziBundleManager.handleSubscription(subscription);
@@ -85,7 +85,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testInstallationWithCRDsPresent() {
+    void testInstallationWithCRDsPresent() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
         this.createKafkaCRDs();
@@ -96,7 +96,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testInstallationWithEmptyStrimzi() {
+    void testInstallationWithEmptyStrimzi() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual", null);
         this.strimziBundleManager.handleSubscription(subscription);
         // check that InstallPlan was not approved due to empty Strimzi versions
@@ -104,7 +104,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testInstallationWithAutomaticApproval() {
+    void testInstallationWithAutomaticApproval() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Automatic",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
         this.strimziBundleManager.handleSubscription(subscription);
@@ -113,7 +113,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testUpdateInstallation() {
+    void testUpdateInstallation() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
         this.strimziBundleManager.handleSubscription(subscription);
@@ -130,7 +130,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testDelayUpdateInstallation() throws InterruptedException {
+    void testDelayUpdateInstallation() throws InterruptedException {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
 
@@ -162,7 +162,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testNotApprovedInstallation() {
+    void testNotApprovedInstallation() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
         this.strimziBundleManager.handleSubscription(subscription);
@@ -180,7 +180,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testApprovedInstallationAfterKafkaUpdate() {
+    void testApprovedInstallationAfterKafkaUpdate() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
         this.strimziBundleManager.handleSubscription(subscription);
@@ -207,7 +207,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testPackageManifestWithoutStatus() {
+    void testPackageManifestWithoutStatus() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
 
@@ -221,7 +221,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testPackageManifestWithoutChannels() {
+    void testPackageManifestWithoutChannels() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
 
@@ -235,7 +235,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testPackageManifestWithoutCurrentCSVDesc() {
+    void testPackageManifestWithoutCurrentCSVDesc() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
 
@@ -253,7 +253,7 @@ public class StrimziBundleManagerTest {
     }
 
     @Test
-    public void testPackageManifestWithoutCurrentCSVDescAnnotations() {
+    void testPackageManifestWithoutCurrentCSVDescAnnotations() {
         Subscription subscription = this.installOrUpdateBundle("kas-strimzi-operator", "kas-strimzi-bundle", "Manual",
                 "strimzi-cluster-operator.v1", "strimzi-cluster-operator.v2");
 


### PR DESCRIPTION
In addition to the case when the CRDs are not present, also approve Strimzi installation immediately when the subscription does not have a linked CSV yet. This likely only applies to test environments where the operator is installed/removed repeatedly and the CRDs are kept in the cluster.