### PR TITLE
[MGDSTRM-9807] Separate image-jib to active-by-default profile

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -30,6 +30,12 @@
         <dependency>
             <groupId>io.quarkiverse.operatorsdk</groupId>
             <artifactId>quarkus-operator-sdk</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.operatorsdk</groupId>
@@ -148,6 +154,22 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>image-jib</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>quarkus.container-image.build</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>native</id>
             <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -522,7 +522,7 @@
                     <plugin>
                         <artifactId>maven-release-plugin</artifactId>
                         <configuration>
-                            <releaseProfiles>release-perform,quickly</releaseProfiles>
+                            <releaseProfiles>release-perform,image-jib,quickly</releaseProfiles>
                             <arguments>${release.properties}</arguments>
                         </configuration>
                     </plugin>

--- a/sync/pom.xml
+++ b/sync/pom.xml
@@ -20,10 +20,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-container-image-jib</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-kubernetes</artifactId>
         </dependency>
         <dependency>
@@ -129,6 +125,22 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>image-jib</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>quarkus.container-image.build</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>native</id>
             <activation>


### PR DESCRIPTION
This seems to be the configuration that will allow us to skip the JIB processing when needed.