### PR TITLE
MGDSTRM-10557: Expose strimzi oauth metrics prometheus in order to assist investigating a slow authentication issue

### DIFF
--- a/operator/src/main/resources/kafka-metrics.yaml
+++ b/operator/src/main/resources/kafka-metrics.yaml
@@ -305,3 +305,64 @@ data:
         pattern: >-
           kafka.server<type=KafkaServer, name=BrokerState><>Value: (\d+)
         type: GAUGE
+      # OAuth Metrics - from https://raw.githubusercontent.com/strimzi/strimzi-kafka-oauth/main/testsuite/docker/kafka/config/metrics-config.yml
+      - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(count|totalTimeMs):"
+        name: "strimzi_oauth_$1_$12"
+        type: COUNTER
+        labels:
+          context: "$2"
+          kind: "$3"
+          host: "$4"
+          path: "$5"
+          "$6": "$7"
+          "$8": "$9"
+          "$10": "$11"
+      - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+), (.+)=(.+)><>(count|totalTimeMs):"
+        name: "strimzi_oauth_$1_$10"
+        type: COUNTER
+        labels:
+          context: "$2"
+          kind: "$3"
+          host: "$4"
+          path: "$5"
+          "$6": "$7"
+          "$8": "$9"
+      - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+)><>(count|totalTimeMs):"
+        name: "strimzi_oauth_$1_$8"
+        type: COUNTER
+        labels:
+          context: "$2"
+          kind: "$3"
+          host: "$4"
+          path: "$5"
+          "$6": "$7"
+      - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(.+):"
+        name: "strimzi_oauth_$1_$12"
+        type: GAUGE
+        labels:
+          context: "$2"
+          kind: "$3"
+          host: "$4"
+          path: "$5"
+          "$6": "$7"
+          "$8": "$9"
+          "$10": "$11"
+      - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+), (.+)=(.+)><>(.+):"
+        name: "strimzi_oauth_$1_$10"
+        type: GAUGE
+        labels:
+          context: "$2"
+          kind: "$3"
+          host: "$4"
+          path: "$5"
+          "$6": "$7"
+          "$8": "$9"
+      - pattern: "strimzi.oauth<type=(.+), context=(.+), kind=(.+), host=\"(.+)\", path=\"(.+)\", (.+)=(.+)><>(.+):"
+        name: "strimzi_oauth_$1_$8"
+        type: GAUGE
+        labels:
+          context: "$2"
+          kind: "$3"
+          host: "$4"
+          path: "$5"
+          "$6": "$7"

--- a/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
+++ b/operator/src/test/java/org/bf2/operator/operands/KafkaClusterTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
@@ -445,6 +446,7 @@ class KafkaClusterTest {
 
         OperandOverrideManager.Kafka kafkaOverride = new OperandOverrideManager.Kafka();
         kafkaOverride.setBrokerConfig(brokerConfig);
+        kafkaOverride.setEnv(List.of(new EnvVar("FOO", "BAR", null)));
         kafkaOverride.setListeners(Map.of("external", externalListenerOverride, "oauth", oauthListenerOverride));
 
         when(overrideManager.getKafkaOverride(strimzi)).thenReturn(kafkaOverride);

--- a/operator/src/test/resources/expected/custom-config-strimzi.yml
+++ b/operator/src/test/resources/expected/custom-config-strimzi.yml
@@ -234,6 +234,10 @@ spec:
           name: "test-mk-kafka-logging"
           optional: false
     template:
+      kafkaContainer:
+        env:
+          - name: FOO
+            value: BAR
       pod:
         tolerations:
         - effect: "NoExecute"


### PR DESCRIPTION
I also needed to apply the override mechanism to the kafka container in order to set kafka container environment variables, so I can actually [turn on strimzi oauth metrics](https://github.com/strimzi/strimzi-kafka-oauth/blob/main/README.md#configuring-the-metrics). The work for this part is a separate commit.

```
 env:
      - name: OAUTH_ENABLE_METRICS
        value: "true"
```

Here are screenshots showing the new metrics, demonstrating that the end to end is working.

<img width="2542" alt="Screenshot 2023-04-18 at 12 02 29" src="https://user-images.githubusercontent.com/18440250/232758864-5ac470c2-7b87-4cfc-bfad-e429dde67795.png">


<img width="2542" alt="Screenshot 2023-04-18 at 12 09 23" src="https://user-images.githubusercontent.com/18440250/232759732-3f4a45cd-68e1-47f8-b056-df5c7e540b35.png">


